### PR TITLE
Revert "Save attachments from phases"

### DIFF
--- a/openhtf/exe/phase_data.py
+++ b/openhtf/exe/phase_data.py
@@ -151,7 +151,6 @@ class PhaseData(object):  # pylint: disable=too-many-instance-attributes
       test_state.running_phase.measurements = validated_measurements
       test_state.running_phase.end_time_millis = util.TimeMillis()
       test_state.running_phase.result = result_wrapper.result
-      test_state.running_phase.attachments.update(self.attachments)
       self.test_record.phases.append(test_state.running_phase)
 
       # Clear these between uses for the frontend API.


### PR DESCRIPTION
Reverts google/openhtf#62, which introduced issue #69. We should really add an end-to-end test in our test suite, but in lieu of that, running the hello_world test and at least eyeballing the JSON test record it outputs is out best practice for at least making sure the framework runs with our changes.