### PR TITLE
Use tox to test multiple environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ addons:
       - swig
       - libusb-1.0-0-dev
 cache:
-  - pip
-  - apt
-script: python setup.py test
+  pip: true
+  apt: true
+  directories:
+    - .tox
+    - $HOME/.cache/pip
+env:
+  - TOXENV=py27
+install:
+  - pip install tox
+script: tox

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,11 @@ requires = [  # pylint: disable=invalid-name
     'Werkzeug==0.10.4',
 ]
 
+tests_require = [
+    'mock',
+    'pytest',
+]
+
 
 class PyTestCommand(test):
   # Derived from
@@ -99,5 +104,5 @@ setup(
         'test': PyTestCommand,
     },
     install_requires=requires,
-    tests_require=['pytest'],
+    tests_require=tests_require,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py34
+
+[testenv]
+commands = python setup.py test


### PR DESCRIPTION
Initially, just enables python 2.7 and 3.4. However, Python 3 support is broken for a few reasons, so this just lets us start working towards that goal.