### PR TITLE
Update mutablerecords to 0.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ cache:
   directories:
     - .tox
     - $HOME/.cache/pip
+before_cache:
+  - rm -r .tox/dist/
 env:
   - TOXENV=py27
 install:

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requires = [  # pylint: disable=invalid-name
     'libusb1==1.3.0',
     'M2Crypto==0.22.3',
     'MarkupSafe==0.23',
-    'mutablerecords==0.2.4',
+    'mutablerecords==0.2.6',
     'pyaml==15.3.1',
     'python-gflags==2.0',
     'PyYAML==3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,7 @@ envlist = py27,py34
 
 [testenv]
 commands = python setup.py test
+# usedevelop causes tox to skip using .tox/dist/openhtf*.zip
+# Instead, it does 'python setup.py develop' which only adds openhtf/ to the
+# path.
+usedevelop = True


### PR DESCRIPTION
I had fixed something in mutablerecords but forgot to update the version here. 0.2.6 fixes `setattr` going through `__setattr__` by using `object.__setattr__` directly, so the infinite recursion in `measurements.Collection` won't happen anymore.