### PR TITLE
Move tests_require into tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,6 @@ requires = [  # pylint: disable=invalid-name
     'Werkzeug==0.10.4',
 ]
 
-tests_require = [
-    'mock',
-    'pytest',
-]
-
 
 class PyTestCommand(test):
   # Derived from
@@ -103,5 +98,4 @@ setup(
         'test': PyTestCommand,
     },
     install_requires=requires,
-    tests_require=tests_require,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist = py27,py34
 
 [testenv]
+deps =
+    pytest
+    mock
 commands = python setup.py test
 # usedevelop causes tox to skip using .tox/dist/openhtf*.zip
 # Instead, it does 'python setup.py develop' which only adds openhtf/ to the


### PR DESCRIPTION
tests_require wasn't working and was causing problems. This may fix the cache problem, but I can't tell because tests_require and the caching were conflicting. I'll check the deps caching after this gets in