### PR TITLE
Add coveralls/coverage support to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,7 @@ before_cache:
 env:
   - TOXENV=py27
 install:
-  - pip install tox
+  - pip install tox coveralls
 script: tox
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 **DISCLAIMER:** This is not an official Google product.
 
-# OpenHTF  [![Build Status](https://travis-ci.org/google/openhtf.svg?branch=master)](https://travis-ci.org/google/openhtf)
+# OpenHTF
+[![Build Status](https://travis-ci.org/google/openhtf.svg?branch=master)](https://travis-ci.org/google/openhtf)
+[![Coverage Status](https://coveralls.io/repos/google/openhtf/badge.svg?branch=master&service=github)](https://coveralls.io/github/google/openhtf?branch=master)
+
 The open-source hardware testing framework.
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ requires = [  # pylint: disable=invalid-name
     'Werkzeug==0.10.4',
 ]
 
-
 class PyTestCommand(test):
   # Derived from
   # https://github.com/chainreactionmfg/cara/blob/master/setup.py

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,8 @@
 envlist = py27,py34
 
 [testenv]
-deps =
-    pytest
-    mock
-commands = python setup.py test
+deps = -r{toxinidir}/test_reqs.txt
+commands = python setup.py test --pytest-cov=term-missing
 # usedevelop causes tox to skip using .tox/dist/openhtf*.zip
 # Instead, it does 'python setup.py develop' which only adds openhtf/ to the
 # path.


### PR DESCRIPTION
You can see the results here: https://coveralls.io/github/fahhem/openhtf

A repo owner (jethier) has to 'sign up' or enable coveralls for the google/openhtf repo, then starting with this one, every PR will get a 'badge' from coveralls with the coverage change.