### PR TITLE
Allow reuse of phases with different options, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,12 @@ cache:
   pip: true
   apt: true
   directories:
-    - .tox
     - $HOME/.cache/pip
-before_cache:
-  - rm -r .tox/dist/
 env:
   - TOXENV=py27
 install:
   - pip install tox coveralls
+  - pip install -e .
 script: tox
 after_success:
   - coveralls

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -159,7 +159,7 @@ def requires(update_kwargs=True, **plugs):
       DuplicatePlugError:  If a plug name is declared twice for the
           same function.
     """
-    wrapper = openhtf.TestPhaseInfo.WrapOrReturn(func)
+    wrapper = openhtf.TestPhaseInfo.WrapOrCopy(func)
     duplicates = frozenset(wrapper.plugs) & frozenset(plugs)
     if duplicates:
       raise DuplicatePlugError(

--- a/openhtf/util/measurements.py
+++ b/openhtf/util/measurements.py
@@ -364,7 +364,7 @@ def measures(*measurements):
   # 'descriptors' is guaranteed to be a list of Measurements here.
   def decorate(wrapped_phase):
     """Phase decorator to be returned."""
-    phase = openhtf.TestPhaseInfo.WrapOrReturn(wrapped_phase)
+    phase = openhtf.TestPhaseInfo.WrapOrCopy(wrapped_phase)
     phase.measurements.extend(measurements)
     return phase
   return decorate

--- a/openhtf/util/monitors.py
+++ b/openhtf/util/monitors.py
@@ -83,7 +83,7 @@ class _MonitorThread(threads.KillableThread):
 
 
 def monitors(measurement_name, monitor_func, units=None, poll_interval_ms=1000):
-  monitor = openhtf.TestPhaseInfo.WrapOrReturn(monitor_func)
+  monitor = openhtf.TestPhaseInfo.WrapOrCopy(monitor_func)
   def Wrapper(phase_func):
     @functools.wraps(phase_func)
     def MonitoredPhaseFunc(phase_data, *args, **kwargs):
@@ -95,7 +95,7 @@ def monitors(measurement_name, monitor_func, units=None, poll_interval_ms=1000):
         return phase_func(phase_data, *args, **kwargs)
       finally:
         monitor_thread.Kill()
-    phase = openhtf.TestPhaseInfo.WrapOrReturn(phase_func)
+    phase = openhtf.TestPhaseInfo.WrapOrCopy(phase_func)
 
     # Re-key this dict so we don't have to worry about collisions with
     # plug.requires() decorators on the phase function.  Since we aren't

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ install_requires = [  # pylint: disable=invalid-name
     'libusb1==1.3.0',
     'M2Crypto==0.22.3',
     'MarkupSafe==0.23',
-    'mutablerecords==0.2.6',
+    'mutablerecords==0.2.7',
     'oauth2client==1.5.2',
     'protobuf==2.6.1',
     'pyaml==15.3.1',

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,3 +1,6 @@
 pytest
 pytest-cov
 mock
+
+# We also want everything as specified by setup.py
+-e .


### PR DESCRIPTION
Changes WrapOrReturn to WrapOrCopy and only replaces attributes of TestPhaseOptions that aren't the default.