### PR TITLE
Convert gflags usage to argparse

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -107,7 +107,7 @@ class Test(object):
 
   def Execute(self, loop=None,
               test_start=triggers.AutoStart, test_stop=triggers.AutoStop,
-              http_port=8888):
+              http_port=http_api.DEFAULT_HTTP_PORT):
     """Starts the framework and executes the given test.
     Args:
       test_start: Trigger for starting the test, defaults to AutoStart with a
@@ -124,7 +124,7 @@ class Test(object):
 
     _LOG.info('Executing test: %s', self.code_info.name)
     executor = exe.TestExecutor(self, test_start, test_stop)
-    http_server = http_api.Server(executor, http_port=http_port)
+    http_server = http_api.Server(executor, http_port)
     StopOnSigInt([http_server.Stop, executor.Stop])
     http_server.Start()
     executor.Start()

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -15,6 +15,7 @@
 
 """The main OpenHTF entry point."""
 
+import argparse
 import collections
 import copy
 import inspect
@@ -25,7 +26,6 @@ import signal
 import socket
 import sys
 
-import gflags
 import mutablerecords
 
 from enum import Enum
@@ -34,9 +34,11 @@ from openhtf import conf
 from openhtf import exe
 from openhtf import plugs
 from openhtf import util
+from openhtf.exe import phase_executor
 from openhtf.exe import triggers
 from openhtf.io import http_api
 from openhtf.io import test_record
+from openhtf.io import user_input
 from openhtf.util import functions
 from openhtf.util import logs
 from openhtf.util import measurements
@@ -49,7 +51,6 @@ from openhtf.util import measurements
 conf.Declare('station_id', 'The name of this test station',
              default_value=socket.gethostname())
 
-FLAGS = gflags.FLAGS
 __version__ = util.get_version()
 _LOG = logging.getLogger(__name__)
 
@@ -105,7 +106,8 @@ class Test(object):
     return self._test_info.metadata
 
   def Execute(self, loop=None,
-              test_start=triggers.AutoStart, test_stop=triggers.AutoStop):
+              test_start=triggers.AutoStart, test_stop=triggers.AutoStop,
+              http_port=8888):
     """Starts the framework and executes the given test.
     Args:
       test_start: Trigger for starting the test, defaults to AutoStart with a
@@ -122,12 +124,12 @@ class Test(object):
 
     _LOG.info('Executing test: %s', self.code_info.name)
     executor = exe.TestExecutor(self, test_start, test_stop)
-    server = http_api.Server(executor)
-    StopOnSigInt([server.Stop, executor.Stop])
-    server.Start()
+    http_server = http_api.Server(executor, http_port=http_port)
+    StopOnSigInt([http_server.Stop, executor.Stop])
+    http_server.Start()
     executor.Start()
     executor.Wait()
-    server.Stop()
+    http_server.Stop()
 
 
 class TestData(collections.namedtuple(
@@ -162,15 +164,18 @@ class TestData(collections.namedtuple(
     return plug_type_map
 
 
+def CreateArgParser():
+  """Creates an argparse.ArgumentParser for parsing command line flags."""
+  parser = argparse.ArgumentParser('OpenHTF-based testing', parents=[
+      conf.ARG_PARSER, user_input.ARG_PARSER, phase_executor.ARG_PARSER,
+      logs.ARG_PARSER])
+  return parser
+
+
 @functions.RunOnce
 def SetupFramework():
   """Sets up various bits of the framework. Only needs to be called once."""
-  try:
-    sys.argv = FLAGS(sys.argv)  # parse flags
-  except gflags.FlagsError, e:  # pylint: disable=invalid-name
-    print '%s\nUsage: %s ARGS\n%s' % (e, sys.argv[0], FLAGS)
-    sys.exit(1)
-
+  CreateArgParser().parse_args()
   logs.setup_logger()
 
 

--- a/openhtf/conf.py
+++ b/openhtf/conf.py
@@ -121,6 +121,7 @@ Loaded configuration values may be purged via the Reset() method, but this
 should only be used for testing purposes.
 """
 
+import argparse
 import functools
 import inspect
 import logging
@@ -128,22 +129,23 @@ import sys
 import threading
 import yaml
 
-import gflags
 import mutablerecords
 
+from openhtf.util import argv
 from openhtf.util import threads
 
 # If provided, --config-file will cause the given file to be Load()ed when the
 # conf module is initially imported.
-gflags.DEFINE_string('config-file', None,
-                     'File from which to load configuration values.')
+ARG_PARSER = argv.ModuleParser()
+ARG_PARSER.add_argument(
+    '--config-file', type=argparse.FileType('r'),
+    help='File from which to load configuration values.')
 
-gflags.DEFINE_multistring(
-    'config-value', [], 'Allows specifying a configuration key=value '
-    'on the command line.  The format should be --config-value=key=value. '
-    'This value will override any loaded value, and will be a string.')
-
-FLAGS = gflags.FLAGS
+ARG_PARSER.add_argument(
+    '--config-value', action='append', default=[],
+    help='Allows specifying a configuration key=value on the command line. '
+    'The format should be --config-value=key=value. This value will override '
+    'any loaded value, and will be a string.')
 
 
 class Configuration(object):  # pylint: disable=too-many-instance-attributes
@@ -181,10 +183,10 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
       self.has_default = 'default_value' in kwargs
   # pylint: enable=invalid-name,bad-super-call,too-few-public-methods
 
-  __slots__ = ('_flags', '_logger', '_lock', '_functools', '_modules',
-               '_declarations', '_flag_values', '_loaded_values')
+  __slots__ = ('_logger', '_lock', '_modules', '_declarations',
+               '_flag_values', '_flags', '_loaded_values', 'ARG_PARSER')
 
-  def __init__(self, flags, logger, lock, _functools, **kwargs):
+  def __init__(self, logger, lock, parser, **kwargs):
     """Initializes the configuration state.
 
     We have to pull everything we need from global scope into here because we
@@ -194,73 +196,24 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     Args:
       logger: Logger to use for logging messages within this class.
       lock: Threading.Lock to use for locking access to config values.
-      _functools: Reference to the functools module so we can use it internally
-          for decorating methods.
       **kwargs: Modules we need to access within this class.
     """
-    self._flags = flags
     self._logger = logger
     self._lock = lock
-    self._functools = _functools
     self._modules = kwargs
     self._declarations = {}
+    self.ARG_PARSER = parser
 
     # Parse just the flags we care about, since this happens at import time.
-    sys.argv = self._ParseSingleFlag(sys.argv, 'config-file')
-    sys.argv = self._ParseSingleFlag(sys.argv, 'config-value')
+    self._flags, _ = parser.parse_known_args()
 
     # Populate flag_values from flags now.
     self._flag_values = {}
-    for keyval in flags['config-value'].value:
+    for keyval in self._flags.config_value:
       self._flag_values.setdefault(*keyval.split('=', 1))
 
     # Initialize self._loaded_values and load from --config-file if it's set.
     self.Reset()
-
-  def _ParseSingleFlag(self, argv, flag_name):
-    """Parse a single gflag from argv.
-
-    This duplicates some of the parsing done in gflags, but we do it here so we
-    can access certain flags at module import time, without forcing the user to
-    have to parse all commandline flags beforehand.  We also don't want to parse
-    all commandline flags as a side effect of loading this module, so we do this
-    bit of hackery to parse just the ones we care about.
-
-    Args:
-      argv: sys.argv to parse, new argv will be returned, like gflags.FLAGS().
-      flag_name: flag name to parse for, will raise if it's not registered.
-    """
-    if len(argv) < 2:
-      return argv
-
-    flag = self._flags.FlagDict()[flag_name]
-    indices_to_delete = set()
-    for idx, arg in enumerate(argv[1:], start=1):
-      if arg.startswith('-'):
-        arg = arg.lstrip('-')
-        if '=' in arg:
-          # '--config-file=foo.json' syntax, split on the first '='.
-          name, value = arg.split('=', 1)
-        elif idx + 1 >= len(argv):
-          # If no value is given, skip this token.  gflags actually raises in
-          # this case, but we'll just ignore it and let gflags do the raising
-          # when the arguments are parsed for real.
-          continue
-        else:
-          # '--config-file foo.json' syntax, grab the entire next arg.
-          name, value = arg, argv[idx + 1]
-        # If this flag matches the name we want, set the value.
-        if name == flag_name:
-          flag.Parse(value)
-          indices_to_delete.add(idx)
-          if '=' not in arg:
-            indices_to_delete.add(idx + 1)
-
-    # If we found at least one value, mark the flag as not using default.
-    flag.using_default_value = False
-
-    # Return a copy of argv, minus any args we parsed.
-    return [v for i, v in enumerate(argv) if i not in indices_to_delete]
 
   @staticmethod
   def _IsValidKey(key):
@@ -354,9 +307,8 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     """
     # Populate loaded_values with values from --config-file, if it was given.
     self._loaded_values = {}
-    if self._flags['config-file'].value:
-      self.LoadFromFile(self._flags['config-file'].value,
-                        _allow_undeclared=True)
+    if self._flags.config_file is not None:
+      self.LoadFromFile(self._flags.config_file, _allow_undeclared=True)
 
   def LoadFromFile(self, filename, _override=True, _allow_undeclared=False):
     """Loads the configuration from a file.
@@ -483,13 +435,14 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     keyword_arg_index = -1 * len(argspec.defaults or [])
     arg_names = argspec.args[:keyword_arg_index or None]
     kwarg_names = argspec.args[len(arg_names):]
+    functools = self._modules['functools']
 
     # Create the actual method wrapper, all we do is update kwargs.  Note we
     # don't pass any *args through because there can't be any - we've filled
     # them all in with values from the configuration.  Any positional args that
     # are missing from the configuration *must* be explicitly specified as
     # kwargs.
-    @self._functools.wraps(method)
+    @functools.wraps(method)
     def method_wrapper(**kwargs):
       """Wrapper that pulls values from openhtf.conf."""
       # Check for keyword args with names that are in the config so we can warn.
@@ -513,7 +466,7 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     # We have to check for a 'self' parameter explicitly because Python doesn't
     # pass it as a keyword arg, it passes it as the first positional arg.
     if argspec.args[0] == 'self':
-      @self._functools.wraps(method)
+      @functools.wraps(method)
       def SelfWrapper(self, **kwargs):  # pylint: disable=invalid-name
         """Wrapper that pulls values from openhtf.conf."""
         kwargs['self'] = self
@@ -524,5 +477,5 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
 # Swap out the module for a singleton instance of Configuration so we can
 # provide __getattr__ and __getitem__ functionality at the module level.
 sys.modules[__name__] = Configuration(
-    FLAGS, logging.getLogger(__name__), threading.RLock(), functools,
-    inspect=inspect, yaml=yaml)
+    logging.getLogger(__name__), threading.RLock(), ARG_PARSER,
+    functools=functools, inspect=inspect, yaml=yaml)

--- a/openhtf/exe/phase_executor.py
+++ b/openhtf/exe/phase_executor.py
@@ -36,17 +36,19 @@ import collections
 import inspect
 import logging
 
-import gflags
-
 import openhtf
 from openhtf.exe import phase_data
 from openhtf.io import test_record
+from openhtf.util import argv
 from openhtf.util import threads
 
+DEFAULT_PHASE_TIMEOUT_S = 3 * 60
 
-FLAGS = gflags.FLAGS
-gflags.DEFINE_integer('phase_default_timeout_ms', 3 * 60 * 1000,
-                      'Test phase timeout in ms', lower_bound=0)
+ARG_PARSER = argv.ModuleParser()
+ARG_PARSER.add_argument(
+    '--phase_default_timeout_s', default=DEFAULT_PHASE_TIMEOUT_S,
+    action=argv.StoreInModule, target='%s.DEFAULT_PHASE_TIMEOUT_S' % __name__,
+    help='Test phase timeout in seconds')
 
 _LOG = logging.getLogger(__name__)
 
@@ -129,7 +131,7 @@ class PhaseExecutorThread(threads.KillableThread):
     if self._phase.options.timeout_s is not None:
       self.join(self._phase.options.timeout_s)
     else:
-      self.join(FLAGS.phase_default_timeout_ms / 1000.0)
+      self.join(DEFAULT_PHASE_TIMEOUT_S)
 
     # We got a return value or an exception and handled it.
     if isinstance(self._phase_outcome, PhaseOutcome):

--- a/openhtf/exe/test_state.py
+++ b/openhtf/exe/test_state.py
@@ -53,6 +53,7 @@ class TestState(object):
     test: openhtf.Test instance describing the test to run.
     plug_map: dict mapping plug name to instances.
     dut_id: DUT identifier, if it's known, otherwise None.
+    station_id: Station identifier.
   """
   State = Enum('State', ['CREATED', 'RUNNING', 'COMPLETED'])
 

--- a/openhtf/io/http_api.py
+++ b/openhtf/io/http_api.py
@@ -34,6 +34,7 @@ _LOG = logging.getLogger(__name__)
 
 PING_STRING = 'OPENHTF_PING'
 PING_RESPONSE_KEY = 'OPENHTF_PING_RESPONSE'
+DEFAULT_HTTP_PORT = 8888
 
 
 class Server(object):
@@ -52,7 +53,7 @@ class Server(object):
   KILL_TIMEOUT_S = 1  # Seconds to wait between service kill attempts.
 
 
-  def __init__(self, executor, http_port=8888, multicast_info=None):
+  def __init__(self, executor, http_port, multicast_info=None):
     super(Server, self).__init__()
 
     def multicast_response(message):

--- a/openhtf/io/user_input.py
+++ b/openhtf/io/user_input.py
@@ -21,7 +21,6 @@ frontends alike. Any other part of the framework that needs to access shared
 prompt state should use the openhtf.prompts pseudomodule.
 """
 
-
 import collections
 import functools
 import logging
@@ -31,17 +30,20 @@ import sys
 import threading
 import uuid
 
-import gflags
+from openhtf.util import argv
+
 
 if platform.system() != 'Windows':
   import termios
 
 _LOG = logging.getLogger(__name__)
 
-FLAGS = gflags.FLAGS
-gflags.DEFINE_integer('prompt_timeout_s',
-                       None,
-                      'User prompt timeout in seconds.')
+ARG_PARSER = argv.ModuleParser()
+ARG_PARSER.add_argument(
+    '--prompt_timeout_s', type=int, action=argv.StoreInModule,
+    target='%s.DEFAULT_TIMEOUT_S' % __name__,
+    help='User prompt timeout in seconds.')
+DEFAULT_TIMEOUT_S = None
 
 
 class PromptInputError(Exception):
@@ -69,8 +71,7 @@ class PromptManager(object):
     self._response = None
     self._cond = threading.Condition()
 
-  def DisplayPrompt(self, message, text_input=False,
-                    timeout_s=None):
+  def DisplayPrompt(self, message, text_input=False, timeout_s=None):
     """Prompt for a user response by showing the message.
 
     Args:
@@ -79,6 +80,7 @@ class PromptManager(object):
     Returns:
       The string input by the user.
     """
+    timeout_s = timeout_s or DEFAULT_TIMEOUT_S
     with self._cond:
       if self.prompt is not None:
         self.prompt = None
@@ -94,7 +96,7 @@ class PromptManager(object):
       console_prompt = ConsolePrompt(
           message, functools.partial(self.Respond, self.prompt.id))
       console_prompt.start()
-      self._cond.wait(timeout_s or FLAGS.prompt_timeout_s)
+      self._cond.wait(timeout_s)
       console_prompt.Stop()
       self.prompt = None
       if self._response is None:

--- a/openhtf/util/argv.py
+++ b/openhtf/util/argv.py
@@ -1,0 +1,23 @@
+"""Utilities for handling command line arguments."""
+
+import argparse
+
+
+def ModuleParser():
+    return argparse.ArgumentParser(add_help=False)
+
+
+class StoreInModule(argparse.Action):
+
+    def __init__(self, *args, **kwargs):
+        self._tgt_mod, self._tgt_attr = kwargs.pop('target').rsplit('.', 1)
+        proxy_cls = kwargs.pop('proxy', None)
+        if proxy_cls is not None:
+            self._proxy = proxy_cls(*args, **kwargs)
+        super(StoreInModule, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if hasattr(self, '_proxy'):
+            values = self._proxy(parser, namespace, values)
+        setattr(__import__(self._tgt_mod), self._tgt_attr, values)
+

--- a/openhtf/util/functions.py
+++ b/openhtf/util/functions.py
@@ -21,14 +21,16 @@ def RunOnce(func):
   """Decorate a function to only allow it to be called once."""
   @functools.wraps(func)
   def _Wrapper(*args, **kwargs):
-    if not _Wrapper.has_run:
-      _Wrapper.has_run = True
+    if not _Wrapper.HasRun():
+      _Wrapper.MarkAsRun()
       return func(*args, **kwargs)
 
     # All subsequent calls go here.
     return None
 
   _Wrapper.has_run = False
+  _Wrapper.HasRun = lambda: _Wrapper.has_run
+  _Wrapper.MarkAsRun = lambda: setattr(_Wrapper, 'has_run', True)
   return _Wrapper
 
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ INSTALL_REQUIRES = [
     'protobuf==2.6.1',
     'pyaml==15.3.1',
     'pyOpenSSL==0.15.1',
-    'python-gflags==2.0',
     'PyYAML==3.11',
     'singledispatch==3.4.0.3',
     'tornado==4.3',
@@ -173,6 +172,7 @@ setup(
         'usb_plugs': [
             'libusb1==1.3.0',
             'M2Crypto==0.22.3',
+            'python-gflags==2.0',
         ],
     },
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ class PyTestCommand(test):
                          for output in self.pytest_cov.split(','))
       cov = ' --cov openhtf ' + outputs
 
+    sys.argv = [sys.argv[0]]
     sys.exit(pytest.main(self.pytest_args + cov))
 
 

--- a/test/conf_test.py
+++ b/test/conf_test.py
@@ -14,18 +14,17 @@
 
 import sys
 
+_old_argv = list(sys.argv)
 sys.argv.extend([
     '--config-value=flag_key=flag_value',
     '--config-value', 'other_flag=other_value',
-# You can specify arbitrary keys, but they'll get ignored if they aren't
-# actually declared anywhere (included here to make sure of that).
+    # You can specify arbitrary keys, but they'll get ignored if they aren't
+    # actually declared anywhere (included here to make sure of that).
     '--config_value=undeclared_flag=who_cares',
 ])
 
 import os.path
 import unittest
-
-import gflags
 
 from openhtf import conf
 
@@ -39,6 +38,10 @@ conf.Declare('string_default', default_value='default')
 conf.Declare('no_default')
 
 
+def tearDownModule():
+    sys.argv = _old_argv
+
+
 class TestConf(unittest.TestCase):
 
   YAML_FILENAME = os.path.join(os.path.dirname(__file__), 'test_config.yaml')
@@ -46,11 +49,11 @@ class TestConf(unittest.TestCase):
   NOT_A_DICT = os.path.join(os.path.dirname(__file__), 'bad_config.yaml')
 
   def tearDown(self):
-    gflags.FLAGS.Reset()
+    conf._flags.config_file = None
     conf.Reset()
 
   def testYamlConfig(self):
-    setattr(gflags.FLAGS, 'config-file', self.YAML_FILENAME)
+    conf._flags.config_file = self.YAML_FILENAME
     conf.Reset()
     self.assertEquals('yaml_test_value', conf.yaml_test_key)
 
@@ -117,13 +120,13 @@ class TestConf(unittest.TestCase):
       conf.Declare('Invalid')
 
   def testBadConfigFile(self):
-    setattr(gflags.FLAGS, 'config-file', self.NOT_A_DICT)
+    conf._flags.config_file = self.NOT_A_DICT
     with self.assertRaises(conf.ConfigurationInvalidError):
       conf.Reset()
-    setattr(gflags.FLAGS, 'config-file', self.BAD_FORMAT)
+    conf._flags.config_file = self.BAD_FORMAT
     with self.assertRaises(conf.ConfigurationInvalidError):
       conf.Reset()
-    setattr(gflags.FLAGS, 'config-file', 'notfound')
+    conf._flags.config_file = 'notfound'
     with self.assertRaises(conf.ConfigurationInvalidError):
       conf.Reset()
 


### PR DESCRIPTION
I got stuck at how best to pass the arguments to the relevant code. `user_input.PromptManager`'s use was already ambiguous, but then `test_record.CodeInfo` wanted something in a `classmethod` and I hit a wall. There are many ways to do this, but it's either too late to think of a good one or there just isn't a good option.

Another option for `CodeInfo` may be to forgo the optimization of not capturing the source at all and create a source-wipe step that only happens later, but that brings its own `user_input.PromptManager`-like problems.

What do you think?

There is significant win in the `conf` module that even if we want to keep `gflags` in general, I'd switch `conf` to `argparse` at least because that's 45 lines of command-line parsing that we don't want to maintain when it's done just as well elsewhere.