### PR TITLE
Remove capture_test_source flag

### DIFF
--- a/openhtf/io/test_record.py
+++ b/openhtf/io/test_record.py
@@ -20,18 +20,11 @@ import collections
 import inspect
 import os
 
-import gflags
 import mutablerecords
 
 from enum import Enum
 
 from openhtf import util
-
-gflags.DEFINE_bool(
-    'capture_test_source', True,
-    'If True, inspect test source and save it in the output.')
-
-FLAGS = gflags.FLAGS
 
 
 class InvalidMeasurementDimensions(Exception):
@@ -97,10 +90,10 @@ class CodeInfo(mutablerecords.Record(
     #  2+: The function calling 'you' (likely in the framework).
     frame, filename = inspect.stack(context=0)[levels_up][:2]
     module = inspect.getmodule(frame)
-    source = inspect.getsource(frame) if FLAGS.capture_test_source else ''
+    source = inspect.getsource(frame)
     return cls(os.path.basename(filename), inspect.getdoc(module), source)
 
   @classmethod
   def ForFunction(cls, func):
-    source = inspect.getsource(func) if FLAGS.capture_test_source else ''
+    source = inspect.getsource(func)
     return cls(func.__name__, inspect.getdoc(func), source)


### PR DESCRIPTION
After using it internally, I realized this flag can't work the way it's used right now. By definition, the phases are defined before the test is created or executed, but we parse flags right before we `Execute` a test. Which means that the `capture_test_source` flag was misleading: it was always used before its value was known.


I'm trying to come up with a way to use `argparse` instead of `gflags` in another PR, and while thinking about that, the only tenable solution seems to have a flag cause the source to get removed from the `Test` when you create the test. It could be something like one of these:
```py
test = openhtf.Test(PhaseOne, PhaseTwo, strip_sources=True)
```
```py
test = openhtf.Test(PhaseOne, PhaseTwo)
test.StripSources()
```
```py
test = openhtf.Test(PhaseOne, PhaseTwo).StripSources()
```