### PR TITLE
Refactor multicast discovery mechanism.

### DIFF
--- a/openhtf/exe/triggers.py
+++ b/openhtf/exe/triggers.py
@@ -53,7 +53,7 @@ def AutoStop(dummy_dut_id):  # pylint: disable=invalid-name
 
 
 def PromptForTestStart(message='Provide a DUT ID in order to start the test.',
-                       text_input=False, timeout_s=60*60*24):
+                       text_input=True, timeout_s=60*60*24):
   """Make a test start trigger based on prompting the user for input."""
   def trigger():  # pylint: disable=missing-docstring
     prompt_manager = user_input.get_prompt_manager()
@@ -63,7 +63,7 @@ def PromptForTestStart(message='Provide a DUT ID in order to start the test.',
 
 
 def PromptForTestStop(message='Hit ENTER to complete the test.',
-                      text_input=False, timeout_s=60*60*24):
+                      text_input=True, timeout_s=60*60*24):
   """Make a test stop trigger based on prompting the user for a response."""
   def trigger(dummy_dut_id):  # pylint: disable=missing-docstring
     prompt_manager = user_input.get_prompt_manager()

--- a/openhtf/exe/triggers.py
+++ b/openhtf/exe/triggers.py
@@ -63,7 +63,7 @@ def PromptForTestStart(message='Provide a DUT ID in order to start the test.',
 
 
 def PromptForTestStop(message='Hit ENTER to complete the test.',
-                      text_input=True, timeout_s=60*60*24):
+                      text_input=False, timeout_s=60*60*24):
   """Make a test stop trigger based on prompting the user for a response."""
   def trigger(dummy_dut_id):  # pylint: disable=missing-docstring
     prompt_manager = user_input.get_prompt_manager()

--- a/openhtf/io/frontend/__main__.py
+++ b/openhtf/io/frontend/__main__.py
@@ -113,7 +113,7 @@ class StationStore(threading.Thread):
       if response.status_code == 200:
         result = json.loads(response.text)
     except requests.RequestException as e:
-      _LOG.warning('Failed to query station %s:%s -- %s' % (host, port, e))
+      _LOG.debug('Failed to query station %s:%s -- %s', host, port, e)
       result = None
     return result
 
@@ -129,8 +129,8 @@ class StationStore(threading.Thread):
     """
     try:
       requests.post('http://%s:%s' % (host, port), data=message)
-    except requests.RequestException:
-      _LOG.warning('Unable to post to %s:%s.' % (host, port))
+    except requests.RequestException as e:
+      _LOG.warning('Unable to post to %s:%s. -- %s', host, port, e)
 
   def _Discover(self):
     """Use multicast to discover stations on the local network."""

--- a/openhtf/io/frontend/templates/prompt.html
+++ b/openhtf/io/frontend/templates/prompt.html
@@ -1,13 +1,11 @@
 {% if state is not None and state['framework']['prompt'] is not None %}
 {% if 'id' in state['framework']['prompt'] %}
   {{ state['framework']['prompt']['message'] }}
-  {% if state['framework']['prompt']['text_input'] %}
     <input type="text"
            id="prompt_field"
            onkeydown="javascript:enter_check('{{ state['framework']['prompt']['id'] }}');">
     <span class="ok">
       <a href="javascript:submit('{{ state['framework']['prompt']['id'] }}');">ENTER</a>
     </span>
-  {% end %}
 {% end %}
 {% end %}

--- a/openhtf/io/frontend/templates/test.html
+++ b/openhtf/io/frontend/templates/test.html
@@ -25,7 +25,9 @@
 {% if state['framework']['status'] == 'EXECUTING' %}
 <div class="current_phase">
   <h3>Current Phase: {{ state['test']['running_phase_record']['name'] }}</h3>
-<p>{{ state['test']['running_phase_record']['docstring'] }}</p>
+  {% if 'docstring' in state['test']['running_phase_record'] %}
+    <p>{{ state['test']['running_phase_record']['docstring'] }}</p>
+  {% end %}
 <h4>Measurements</h4>
 <table border=1>
 {% for m in state['test']['running_phase_record']['measurements'] %}

--- a/openhtf/io/http_api.py
+++ b/openhtf/io/http_api.py
@@ -30,6 +30,7 @@ from openhtf.io import user_input
 from openhtf.util import data
 from openhtf.util import multicast
 
+
 _LOG = logging.getLogger(__name__)
 
 PING_STRING = 'OPENHTF_PING'

--- a/openhtf/io/http_api.py
+++ b/openhtf/io/http_api.py
@@ -41,9 +41,8 @@ class Server(object):
   """Frontend API server for openhtf.
 
   Starts up two services as separate threads. An HTTP server that serves
-  detailed information about this intance of openhtf, and a service discovery
-  listener that helps frontends find and connect to the HTTP server.
-
+  detailed information about this intance of openhtf, and a multicast station
+  discovery service that helps frontends find and connect to the HTTP server.
   Args:
     executor: An openhtf.exe.TestExecutor object.
     discovery_info: A dict to specify options for service discovery.

--- a/openhtf/io/http_api.py
+++ b/openhtf/io/http_api.py
@@ -114,6 +114,7 @@ class HTTPServer(threading.Thread):
       user_input.get_prompt_manager().Respond(
           uuid.UUID((request['id'])), request['response'])
 
+
   def Stop(self):
     """Stop the HTTP server."""
     if self._server:

--- a/openhtf/io/http_api.py
+++ b/openhtf/io/http_api.py
@@ -114,6 +114,9 @@ class HTTPServer(threading.Thread):
       request = json.loads(raw)
       user_input.get_prompt_manager().Respond(
           uuid.UUID((request['id'])), request['response'])
+      self.send_response(200)
+      self.end_headers()
+      self.wfile.write('OK')
 
 
   def Stop(self):

--- a/openhtf/io/http_api.py
+++ b/openhtf/io/http_api.py
@@ -103,14 +103,16 @@ class HTTPServer(threading.Thread):
       """
       result = {'test': data.ConvertToBaseTypes(self.executor.GetState()),
                 'framework': data.ConvertToBaseTypes(self.executor)}
+      self.send_response(200)
+      self.end_headers()
       self.wfile.write(json.dumps(result))
 
     def do_POST(self):  # pylint: disable=invalid-name
       """Parse a prompt response and send it to the PromptManager."""
       raw = self.rfile.read()
-      data = json.loads(raw)
+      request = json.loads(raw)
       user_input.get_prompt_manager().Respond(
-          uuid.UUID((data['id'])), data['response'])
+          uuid.UUID((request['id'])), request['response'])
 
   def Stop(self):
     """Stop the HTTP server."""

--- a/openhtf/io/user_input.py
+++ b/openhtf/io/user_input.py
@@ -115,6 +115,8 @@ class PromptManager(object):
       if self.prompt is not None and prompt_id == self.prompt.id:
         self._response = response
         self._cond.notifyAll()
+        return True  # The response was used.
+      return False  # The response was not used.
 
 
 # Module-level instance to achieve shared prompt state.

--- a/openhtf/util/multicast.py
+++ b/openhtf/util/multicast.py
@@ -104,15 +104,15 @@ class MulticastListener(threading.Thread):
         continue
 
 
-def send(message,
+def send(query,
          address=DEFAULT_ADDRESS,
          port=DEFAULT_PORT,
          ttl=DEFAULT_TTL,
          timeout_s=2):
-  """Sends a message to the given multicast socket and returns responses.
+  """Sends a query to the given multicast socket and returns responses.
 
   Args:
-    message: The string message to send.
+    query: The string query to send.
     address: Multicast IP address component of the socket to send to.
     port: Multicast UDP port component of the socket to send to.
     ttl: TTL for multicast messages. 1 to keep traffic in-network.
@@ -127,16 +127,16 @@ def send(message,
                   socket.IP_MULTICAST_TTL,
                   ttl)
   sock.settimeout(timeout_s)
-  sock.sendto(message, (address, port))
+  sock.sendto(query, (address, port))
   while True:
     try:
       data, address = sock.recvfrom(MAX_MESSAGE_BYTES)
     except socket.timeout:
       if not result:
-        _LOG.debug('No responses recieved to multicast message "%s".', message)
+        _LOG.debug('No responses recieved to multicast query "%s".', query)
       break
     else:
-      _LOG.debug('Multicast response to message "%s": %s:%s',
-                 message, address[0], data)
+      _LOG.debug('Multicast response to query "%s": %s:%s',
+                 query, address[0], data)
       result.add((address[0], str(data)))
   return result

--- a/openhtf/util/multicast.py
+++ b/openhtf/util/multicast.py
@@ -40,9 +40,10 @@ class MulticastListener(threading.Thread):
 
   Args:
     callback: A callable to invoke upon receipt of a multicast message. Will be
-              called with one argument -- the text of the message received.
-              callback can optionally return a string response, which will be
-              transmitted back to the sender.
+              called with two arguments -- respectively the text of the message
+              received, and the address of the sender. callback can optionally
+              return a string response, which if present will be transmitted
+              back to the sender.
     address: Multicast IP address component of the socket to listen on.
     port: Multicast UDP port component of the socket to listen on.
     ttl: TTL for multicast messages. 1 to keep traffic in-network.
@@ -89,7 +90,7 @@ class MulticastListener(threading.Thread):
       try:
         data, address = self._sock.recvfrom(MAX_MESSAGE_BYTES)
         _LOG.debug('Received multicast message from %s: %s'% (address, data))
-        response = self._callback(data)
+        response = self._callback(data, address)
         if response is not None:
           self._sock.sendto(response, address)
       except socket.timeout:
@@ -105,8 +106,8 @@ def send(message,
 
   Args:
     message: The string message to send.
-    address: Multicast IP address component of the socket to listen on.
-    port: Multicast UDP port component of the socket to listen on.
+    address: Multicast IP address component of the socket to send on.
+    port: Multicast UDP port component of the socket to send on.
     ttl: TTL for multicast messages. 1 to keep traffic in-network.
     timeout_s: Seconds to wait for responses.
 

--- a/openhtf/util/multicast.py
+++ b/openhtf/util/multicast.py
@@ -38,12 +38,14 @@ MAX_MESSAGE_BYTES = 1024  # Maximum allowable message length in bytes.
 class MulticastListener(threading.Thread):
   """Agent that listens (and responds) to short messages on a multicast socket.
 
+  The listener will force-bind to the multicast port via the SO_REUSEADDR
+  option, so it's possible for multiple listeners to bind to the same port.
+
   Args:
     callback: A callable to invoke upon receipt of a multicast message. Will be
-              called with two arguments -- respectively the text of the message
-              received, and the address of the sender. callback can optionally
-              return a string response, which if present will be transmitted
-              back to the sender.
+              called with one argument -- the text of the message received.
+              callback can optionally return a string response, which will be
+              transmitted back to the sender.
     address: Multicast IP address component of the socket to listen on.
     port: Multicast UDP port component of the socket to listen on.
     ttl: TTL for multicast messages. 1 to keep traffic in-network.
@@ -74,7 +76,6 @@ class MulticastListener(threading.Thread):
   def run(self):
     """Listen for pings until stopped."""
     self._live = True
-    self._sock.bind(('', self.port))
     self._sock.settimeout(self.LISTEN_TIMEOUT_S)
     self._sock.setsockopt(
         socket.IPPROTO_IP,
@@ -85,14 +86,20 @@ class MulticastListener(threading.Thread):
             '!4sL',
             socket.inet_aton(self.address),
             socket.INADDR_ANY))  # Listen on all interfaces.
+    self._sock.setsockopt(socket.SOL_SOCKET,
+                          socket.SO_REUSEADDR,
+                          1)  # Allow multiple listeners to bind.
+    self._sock.bind(('', self.port))
 
     while self._live:
       try:
         data, address = self._sock.recvfrom(MAX_MESSAGE_BYTES)
         _LOG.debug('Received multicast message from %s: %s'% (address, data))
-        response = self._callback(data, address)
+        response = self._callback(data)
         if response is not None:
-          self._sock.sendto(response, address)
+          # Send replies out-of-band instead of with the same multicast socket.
+          tx_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+          tx_sock.sendto(response, address)
       except socket.timeout:
         continue
 
@@ -102,12 +109,12 @@ def send(message,
          port=DEFAULT_PORT,
          ttl=DEFAULT_TTL,
          timeout_s=2):
-  """Sends a message on the given multicast socket and returns responses.
+  """Sends a message to the given multicast socket and returns responses.
 
   Args:
     message: The string message to send.
-    address: Multicast IP address component of the socket to send on.
-    port: Multicast UDP port component of the socket to send on.
+    address: Multicast IP address component of the socket to send to.
+    port: Multicast UDP port component of the socket to send to.
     ttl: TTL for multicast messages. 1 to keep traffic in-network.
     timeout_s: Seconds to wait for responses.
 

--- a/openhtf/util/multicast.py
+++ b/openhtf/util/multicast.py
@@ -98,8 +98,8 @@ class MulticastListener(threading.Thread):
         response = self._callback(data)
         if response is not None:
           # Send replies out-of-band instead of with the same multicast socket.
-          tx_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-          tx_sock.sendto(response, address)
+          socket.socket(socket.AF_INET, socket.SOCK_DGRAM).sendto(response,
+                                                                  address)
       except socket.timeout:
         continue
 

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ build.sub_commands.insert(0, ('build_proto', None))
 
 
 INSTALL_REQUIRES = [
-    'contextlib2==0.4.0',
+    'contextlib2==0.5.1',
     'enum34==1.1.2',
     'MarkupSafe==0.23',
     'mutablerecords==0.2.9',


### PR DESCRIPTION
This change moves the port binding side of multicast discovery to the frontend server, and the sender side to the framework instances. This results in slightly more network traffic, but enables multiple framework instances on a single host to all be discovered by a single frontend.

As a side note, this also makes frontend SIGINT response instantaneous, because the multicast listener is now a daemon thread, and the store itself is just an object.

Also addresses an (unfiled) bug where the entire contents of HTTP GET responses are sent as one long header.