### PR TITLE
Allow a phase to be reused with different kwargs

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -259,8 +259,9 @@ class PhaseInfo(mutablerecords.Record(
     """Send these keyword-arguments to the phase when called."""
     # Make a copy so we can have multiple of the same phase with different args
     # in the same test.
-    new_obj = copy.copy(self)
-    new_obj.extra_kwargs.update(kwargs)
+    new_info = mutablerecords.CopyRecord(self)
+    new_info.extra_kwargs.update(kwargs)
+    new_info.measurements = [m.WithArgs(**kwargs) for m in self.measurements]
     return new_obj
 
   def __call__(self, phase_data):

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -16,6 +16,7 @@
 """The main OpenHTF entry point."""
 
 import collections
+import copy
 import inspect
 import itertools
 import json
@@ -216,7 +217,8 @@ class PhasePlug(mutablerecords.Record(
 
 class PhaseInfo(mutablerecords.Record(
     'PhaseInfo', ['func', 'code_info'],
-    {'options': PhaseOptions, 'plugs': list, 'measurements': list})):
+    {'options': PhaseOptions, 'plugs': list, 'measurements': list,
+     'extra_kwargs': dict})):
   """Phase function and related information.
 
   Attributes:
@@ -253,15 +255,24 @@ class PhaseInfo(mutablerecords.Record(
   def doc(self):
     return self.func.__doc__
 
+  def WithArgs(self, **kwargs):
+    """Send these keyword-arguments to the phase when called."""
+    # Make a copy so we can have multiple of the same phase with different args
+    # in the same test.
+    new_obj = copy.copy(self)
+    new_obj.extra_kwargs.update(kwargs)
+    return new_obj
+
   def __call__(self, phase_data):
-    plug_kwargs = {plug.name: phase_data.plugs[plug.name]
-                   for plug in self.plugs if plug.update_kwargs}
+    kwargs = dict(self.extra_kwargs)
+    kwargs.update({plug.name: phase_data.plugs[plug.name]
+                   for plug in self.plugs if plug.update_kwargs})
     arg_info = inspect.getargspec(self.func)
-    if len(arg_info.args) == len(plug_kwargs) and not arg_info.varargs:
+    if len(arg_info.args) == len(kwargs) and not arg_info.varargs:
       # Underlying function has no room for phase_data as an arg. If it expects
       # it but miscounted arguments, we'll get another error farther down.
-      return self.func(**plug_kwargs)
-    return self.func(phase_data, **plug_kwargs)
+      return self.func(**kwargs)
+    return self.func(phase_data, **kwargs)
 
 
 def StopOnSigInt(callbacks):

--- a/openhtf/util/measurements.py
+++ b/openhtf/util/measurements.py
@@ -138,6 +138,19 @@ class Measurement(  # pylint: disable=no-init
     self.validators.append(validator)
     return self
 
+  def WithArgs(self, **kwargs):
+    """Creates a new Measurement, see openhtf.PhaseInfo.WithArgs."""
+    new_meas = mutablerecords.CopyRecord(self)
+    if '{' in new_meas.name:
+      formatter = lambda x: x.format(**kwargs)
+    else:
+      # str % {'a': 1} is harmless if str doesn't use any interpolation.
+      # .format is as well, but % is more likely to be used in other contexts.
+      formatter = lambda x: x % kwargs
+    new_meas.name = formatter(self.name)
+    new_meas.docstring = formatter(self.docstring)
+    return new_meas
+
   def __getattr__(self, attr):
     """Support our default set of validators as direct attributes."""
     # Don't provide a back door to validators.py private stuff accidentally.


### PR DESCRIPTION
This means you can parameterize a phase on something like a voltage to test at or which channel to check.

If this is considered beneficial, I would propose to extend this to the measurement names and docstrings like so:

```py
@measures(Measurement('current_at_%(volts)dV'))
def MeasureCurrent(test_data, volts=None):
  yeah, well, you know that's just like
  test_data.measurements['current_at_%d' % volts] = your opinion man

...

openhtf.Test(
    MeasureCurrent.WithArgs(volts=9),
    MeasureCurrent.WithArgs(volts=12),
    MeasureCurrent.WithArgs(volts=15), ...)
```