### PR TITLE
TestExecutor cleanup

### DIFF
--- a/openhtf/exe/__init__.py
+++ b/openhtf/exe/__init__.py
@@ -171,9 +171,6 @@ class TestExecutor(threads.KillableThread):
       self._ExecuteTestPhases(executor)
       self._status = self.FrameworkStatus.FINISHING
 
-      # Output the test record now that we're done executing.
-      self._output_thread = self._MakeAndStartOutputThread()
-
   def _OutputTestRecord(self):
     """Output the test record by invoking output callbacks."""
     if self._test_state:


### PR DESCRIPTION
Refactor TestExecutor slightly, add comments for clarity, two functional changes are:
  - Output callbacks get run in a separate thread that we `.join()` after all other framework teardown.  This prevents output callbacks from raising exceptions that show up in the TestExecutor, and also allows plugs (and other framework things) to get torn down without waiting on potentially long-running or mis-behaved output callbacks.
  - Access to `self._exit_stack` is locked.  I'm guessing it was very unlikely for race conditions to occur, and if they did we didn't care because we were shutting everything down anyway, but it really should be locked so that calls to Stop() are actually thread-safe.