### PR TITLE
Fixup some debt from TestData

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -80,7 +80,7 @@ class Test(object):
   def __init__(self, *phases, **metadata):
     code_info = test_record.CodeInfo.ForModuleFromStack(levels_up=2)
     self._test_options = TestOptions()
-    self._test_info = TestData(phases, metadata=metadata, code_info=code_info)
+    self._test_data = TestData(phases, metadata=metadata, code_info=code_info)
     self._lock = threading.Lock()
     self._executor = exe.TestExecutor(self)
     self._stopped = False
@@ -108,22 +108,26 @@ class Test(object):
     for output_cb in self._test_options.output_callbacks:
       output_cb(record)
 
+  @property
+  def data(self):
+    return self._test_data
+
   # TODO(fahhem): Cleanup accesses to these attributes and remove these proxies.
   @property
   def plug_type_map(self):
-    return self._test_info.plug_type_map
+    return self._test_data.plug_type_map
 
   @property
   def phases(self):
-    return self._test_info.phases
+    return self._test_data.phases
 
   @property
   def code_info(self):
-    return self._test_info.code_info
+    return self._test_data.code_info
 
   @property
   def metadata(self):
-    return self._test_info.metadata
+    return self._test_data.metadata
 
   def Configure(self, **kwargs):
     """Update test-wide configuration options.

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -112,23 +112,6 @@ class Test(object):
   def data(self):
     return self._test_data
 
-  # TODO(fahhem): Cleanup accesses to these attributes and remove these proxies.
-  @property
-  def plug_type_map(self):
-    return self._test_data.plug_type_map
-
-  @property
-  def phases(self):
-    return self._test_data.phases
-
-  @property
-  def code_info(self):
-    return self._test_data.code_info
-
-  @property
-  def metadata(self):
-    return self._test_data.metadata
-
   def Configure(self, **kwargs):
     """Update test-wide configuration options.
 
@@ -176,10 +159,10 @@ class Test(object):
     with self._lock:
       if self._stopped:
         _LOG.info('Cowardly refusing to execute test after SIGINT: %s',
-                  self.code_info.name)
+                  self.data.code_info.name)
         return
 
-      _LOG.info('Executing test: %s', self.code_info.name)
+      _LOG.info('Executing test: %s', self.data.code_info.name)
       self._executor.SetTestStart(test_start)
       http_server = None
       if self._test_options.http_port:

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -82,6 +82,7 @@ class Test(object):
     self._test_options = TestOptions()
     self._test_info = TestData(phases, metadata=metadata, code_info=code_info)
     self._lock = threading.Lock()
+    self._executor = exe.TestExecutor(self)
     self._stopped = False
     # Make sure Configure() gets called at least once before Execute().  The
     # user might call Configure() again to override options, but we don't want
@@ -94,7 +95,7 @@ class Test(object):
   def AddOutputCallback(self, callback):
     """DEPRECATED: Use AddOutputCallbacks() instead."""
     # TODO(madsci): Remove this before we push to PyPI, here for transitionary
-    # purposes. 
+    # purposes.
     raise AttributeError(
         'DEPRECATED, use AddOutputCallbacks() instead of AddOutputCallback()')
 
@@ -145,20 +146,17 @@ class Test(object):
     with self._lock:
       # Once we're stopped for SIGINT, don't try to start anything else.
       self._stopped = True
-      if self._executor:
-        # TestState str()'s nicely to a descriptive string, so let's log that
-        # just for good measure.
-        _LOG.error('Stopping Test due to SIGINT: %s', self._executor.GetState())
-        self._executor.Stop()
-      else:
-        _LOG.error('No Test running, ignoring SIGINT.')
+      # TestState str()'s nicely to a descriptive string, so let's log that
+      # just for good measure.
+      _LOG.error('Stopping Test due to SIGINT: %s', self._executor.GetState())
+      self._executor.Stop()
 
-  def Execute(self, test_start=lambda: 'UNKNOWN_DUT_ID', loop=None):
+  def Execute(self, test_start=None, loop=None):
     """Starts the framework and executes the given test.
 
     Args:
-      test_start: Trigger for starting the test, defaults to a lambda with a
-          dummy serial number.
+      test_start: Trigger for starting the test, defaults to not setting the DUT
+          serial number.
       loop: DEPRECATED
     """
     # TODO(madsci): Remove this after a transitionary period.
@@ -178,7 +176,7 @@ class Test(object):
         return
 
       _LOG.info('Executing test: %s', self.code_info.name)
-      self._executor = exe.TestExecutor(self, test_start)
+      self._executor.SetTestStart(test_start)
       http_server = None
       if self._test_options.http_port:
         http_server = http_api.Server(

--- a/openhtf/exe/__init__.py
+++ b/openhtf/exe/__init__.py
@@ -179,7 +179,7 @@ class TestExecutor(threads.KillableThread):
     """Create a test_state.TestState for the current test."""
     suppressor.failure_reason = 'Test is invalid.'
     return test_state.TestState(
-        self.test, plug_manager.plug_map, dut_id, conf.station_id)
+        self.test.data, plug_manager.plug_map, dut_id, conf.station_id)
 
   def _MakePlugManager(self, suppressor):
     """Perform some initialization and create a PlugManager."""

--- a/openhtf/exe/__init__.py
+++ b/openhtf/exe/__init__.py
@@ -70,7 +70,7 @@ class TestExecutor(threads.KillableThread):
   def __init__(self, test):
     super(TestExecutor, self).__init__(name='TestExecutorThread')
 
-    self.test = test
+    self._test = test
     self._test_start = None
     self._exit_stack = None
     self._test_state = None
@@ -118,7 +118,7 @@ class TestExecutor(threads.KillableThread):
     with contextlib.ExitStack() as exit_stack, \
         LogSleepSuppress() as suppressor:
       # Top level steps required to run a single iteration of the Test.
-      _LOG.info('Starting test %s', self.test.code_info.name)
+      _LOG.info('Starting test %s', self._test.data.code_info.name)
 
       # Any access to self._exit_stack must be done while holding this lock.
       with self._lock:
@@ -164,7 +164,7 @@ class TestExecutor(threads.KillableThread):
   def _OutputTestRecord(self):
     """Output the test record by invoking output callbacks."""
     if self._test_state:
-      self.test.OutputTestRecord(
+      self._test.OutputTestRecord(
           self._test_state.GetFinishedRecord())
 
   def _WaitForTestStart(self, suppressor):
@@ -179,13 +179,13 @@ class TestExecutor(threads.KillableThread):
     """Create a test_state.TestState for the current test."""
     suppressor.failure_reason = 'Test is invalid.'
     return test_state.TestState(
-        self.test.data, plug_manager.plug_map, dut_id, conf.station_id)
+        self._test.data, plug_manager.plug_map, dut_id, conf.station_id)
 
   def _MakePlugManager(self, suppressor):
     """Perform some initialization and create a PlugManager."""
     _LOG.info('Initializing plugs.')
     suppressor.failure_reason = 'Unable to initialize plugs.'
-    return plugs.PlugManager.InitializeFromTypeMap(self.test.plug_type_map)
+    return plugs.PlugManager.InitializeFromTypeMap(self._test.data.plug_type_map)
 
   def _MakePhaseExecutor(self, exit_stack, suppressor):
     """Create a phase_executor.PhaseExecutor and set it up."""

--- a/openhtf/exe/__init__.py
+++ b/openhtf/exe/__init__.py
@@ -67,11 +67,11 @@ class TestExecutor(threads.KillableThread):
                          ['CREATED', 'START_WAIT', 'INITIALIZING', 'EXECUTING',
                           'STOP_WAIT', 'FINISHING'])
 
-  def __init__(self, test, test_start):
+  def __init__(self, test):
     super(TestExecutor, self).__init__(name='TestExecutorThread')
 
     self.test = test
-    self._test_start = test_start
+    self._test_start = None
     self._exit_stack = None
     self._test_state = None
     self._output_thread = None
@@ -83,6 +83,9 @@ class TestExecutor(threads.KillableThread):
     return {'station_id': conf.station_id,
             'prompt': user_input.get_prompt_manager().prompt,
             'status': self._status.name}
+
+  def SetTestStart(self, test_start):
+    self._test_start = test_start
 
   def Start(self):
     """Style-compliant start method."""
@@ -166,6 +169,8 @@ class TestExecutor(threads.KillableThread):
 
   def _WaitForTestStart(self, suppressor):
     """Wait for the test start trigger to return a DUT ID."""
+    if self._test_start is None:
+      return
     self._status = self.FrameworkStatus.START_WAIT
     suppressor.failure_reason = 'TEST_START failed to complete.'
     return self._test_start()

--- a/openhtf/exe/test_state.py
+++ b/openhtf/exe/test_state.py
@@ -51,24 +51,24 @@ class TestState(object):
   """This class handles tracking the state of the test.
 
   Args:
-    test: openhtf.Test instance describing the test to run.
+    test_data: openhtf.TestData instance describing the test to run.
     plug_map: dict mapping plug name to instances.
     dut_id: DUT identifier, if it's known, otherwise None.
     station_id: Station identifier.
   """
   State = Enum('State', ['CREATED', 'RUNNING', 'COMPLETED'])
 
-  def __init__(self, test, plug_map, dut_id, station_id):
+  def __init__(self, test_data, plug_map, dut_id, station_id):
     self._state = self.State.CREATED
     self.record = test_record.TestRecord(
-        dut_id=dut_id, station_id=station_id, code_info=test.code_info,
-        metadata=test.metadata)
+        dut_id=dut_id, station_id=station_id, code_info=test_data.code_info,
+        metadata=test_data.metadata)
     self.logger = logging.getLogger(logs.RECORD_LOGGER)
     self._record_handler = logs.RecordHandler(self.record)
     self.logger.addHandler(self._record_handler)
     self.phase_data = phase_data.PhaseData(self.logger, plug_map, self.record)
     self.running_phase_record = None
-    self.pending_phases = list(test.phases)
+    self.pending_phases = list(test_data.phases)
 
   def __del__(self):
     self.logger.removeHandler(self._record_handler)

--- a/test/exe/exe_test.py
+++ b/test/exe/exe_test.py
@@ -58,7 +58,7 @@ class TestOpenhtf(unittest.TestCase):
 
   def test_plug_type_map(self):
     test = openhtf.Test(phase_one, phase_two)
-    self.assertIn(type(self.test_plug), test.plug_type_map.itervalues())
+    self.assertIn(type(self.test_plug), test.data.plug_type_map.itervalues())
 
   # Mock test execution.
   def testTestExecutor(self):


### PR DESCRIPTION
`TestState` now only takes `TestData` instead of the whole `Test` object, and `test.data` is used when accessing test data from within `TestExecutor`.