### PR TITLE
Separate plugs and execution

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -82,7 +82,7 @@ class Test(object):
     self._test_options = TestOptions()
     self._test_data = TestData(phases, metadata=metadata, code_info=code_info)
     self._lock = threading.Lock()
-    self._executor = exe.TestExecutor(self._test_data)
+    self._executor = exe.TestExecutor(self._test_data, plugs.PlugManager())
     self._stopped = False
     # Make sure Configure() gets called at least once before Execute().  The
     # user might call Configure() again to override options, but we don't want

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -321,8 +321,8 @@ class PhaseInfo(mutablerecords.Record(
 
   def __call__(self, phase_data):
     kwargs = dict(self.extra_kwargs)
-    kwargs.update({plug.name: phase_data.plug_map[plug.cls]
-                   for plug in self.plugs if plug.update_kwargs})
+    kwargs.update(phase_data.plug_manager.ProvidePlugs(
+        (plug.name, plug.cls) for plug in self.plugs if plug.update_kwargs))
     arg_info = inspect.getargspec(self.func)
     if len(arg_info.args) == len(kwargs) and not arg_info.varargs:
       # Underlying function has no room for phase_data as an arg. If it expects

--- a/openhtf/exe/__init__.py
+++ b/openhtf/exe/__init__.py
@@ -70,7 +70,7 @@ class TestExecutor(threads.KillableThread):
     super(TestExecutor, self).__init__(name='TestExecutorThread')
 
     self._test_data = test_data
-    self._plug_mgr = plug_manager
+    self._plug_manager = plug_manager
     self._test_start = None
     self._lock = threading.Lock()
     self._status = self.FrameworkStatus.CREATED
@@ -134,11 +134,11 @@ class TestExecutor(threads.KillableThread):
           # call to Stop() and we ended up resuming execution here but the
           # exit stack was already cleared, bail.  Try to tear down plugs on a
           # best-effort basis.
-          self._plug_mgr.TearDownPlugs()
+          self._plug_manager.TearDownPlugs()
           raise TestStopError('Test Stopped.')
 
         # Tear down plugs first, then output test record.
-        exit_stack.callback(self._plug_mgr.TearDownPlugs)
+        exit_stack.callback(self._plug_manager.TearDownPlugs)
 
         # Perform initialization of some top-level stuff we need.
         self._test_state = self._MakeTestState(dut_id, suppressor)
@@ -166,13 +166,13 @@ class TestExecutor(threads.KillableThread):
     """Create a test_state.TestState for the current test."""
     suppressor.failure_reason = 'Test is invalid.'
     return test_state.TestState(
-        self._test_data, self._plug_mgr, dut_id, conf.station_id)
+        self._test_data, self._plug_manager, dut_id, conf.station_id)
 
   def _InitializePlugs(self, suppressor):
     """Perform some initialization and create a PlugManager."""
     _LOG.info('Initializing plugs.')
     suppressor.failure_reason = 'Unable to initialize plugs.'
-    self._plug_mgr.InitializePlugs(self._test_data.plug_types)
+    self._plug_manager.InitializePlugs(self._test_data.plug_types)
 
   def _MakePhaseExecutor(self, exit_stack, suppressor):
     """Create a phase_executor.PhaseExecutor and set it up."""

--- a/openhtf/exe/__init__.py
+++ b/openhtf/exe/__init__.py
@@ -166,7 +166,7 @@ class TestExecutor(threads.KillableThread):
     """Create a test_state.TestState for the current test."""
     suppressor.failure_reason = 'Test is invalid.'
     return test_state.TestState(
-        self._test_data, self._plug_mgr.plug_map, dut_id, conf.station_id)
+        self._test_data, self._plug_mgr, dut_id, conf.station_id)
 
   def _InitializePlugs(self, suppressor):
     """Perform some initialization and create a PlugManager."""

--- a/openhtf/exe/phase_data.py
+++ b/openhtf/exe/phase_data.py
@@ -53,15 +53,15 @@ class PhaseData(object):  # pylint: disable=too-many-instance-attributes
     logger: A python logger that goes to the testrun proto, with functions like
         debug, info, warn, error, and exception.
     state: A dictionary for passing state data along to future phases.
-    plug_map: Dict mapping plug types to instances to use in phases.
+    plug_manager: A plugs.PlugManager instance.
     measurements: A measurements.Collection for setting measurement values.
     context: A contextlib.ExitStack, which simplifies context managers in a
         phase.  This stack is pop'd after each phase.
     test_record: The test_record.TestRecord for the currently running test.
   """
-  def __init__(self, logger, plug_map, record):
+  def __init__(self, logger, plug_manager, record):
     self.logger = logger
-    self.plug_map = plug_map
+    self.plug_manager = plug_manager
     self.test_record = record
     self.state = {}
     self.measurements = None  # Will be populated per-phase.
@@ -72,9 +72,7 @@ class PhaseData(object):  # pylint: disable=too-many-instance-attributes
     """Return a dict of this PhaseData's public data."""
     return {'measurements': self.measurements,
             'attachments': self.attachments.keys(),
-            'plugs': {
-                k.__module__ + '.' + k.__name__: str(v)
-                for k, v in self.plug_map.iteritems()}}
+            'plug_manager': self.plug_manager}
 
   def Attach(self, name, data, mimetype=None):
     """Store the given data as an attachment with the given name.

--- a/openhtf/exe/test_state.py
+++ b/openhtf/exe/test_state.py
@@ -52,13 +52,13 @@ class TestState(object):
 
   Args:
     test_data: openhtf.TestData instance describing the test to run.
-    plug_map: dict mapping plug type to instance.
+    plug_manager: A plugs.PlugManager instance.
     dut_id: DUT identifier, if it's known, otherwise None.
     station_id: Station identifier.
   """
   State = Enum('State', ['CREATED', 'RUNNING', 'COMPLETED'])
 
-  def __init__(self, test_data, plug_map, dut_id, station_id):
+  def __init__(self, test_data, plug_manager, dut_id, station_id):
     self._state = self.State.CREATED
     self.record = test_record.TestRecord(
         dut_id=dut_id, station_id=station_id, code_info=test_data.code_info,
@@ -66,7 +66,7 @@ class TestState(object):
     self.logger = logging.getLogger(logs.RECORD_LOGGER)
     self._record_handler = logs.RecordHandler(self.record)
     self.logger.addHandler(self._record_handler)
-    self.phase_data = phase_data.PhaseData(self.logger, plug_map, self.record)
+    self.phase_data = phase_data.PhaseData(self.logger, plug_manager, self.record)
     self.running_phase_record = None
     self.pending_phases = list(test_data.phases)
 

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -90,6 +90,7 @@ This will result in the ExamplePlug being constructed with
 self._my_config having a value of 'my_config_value'.
 """
 
+import collections
 import functools
 import logging
 
@@ -187,7 +188,7 @@ class PlugManager(object):
     plug_map: Dict mapping plug type to instantiated plug.
   """
 
-  def __init__(self, plug_types):
+  def InitializePlugs(self, plug_types):
     self.plug_map = {}
     try:
       for plug_type in plug_types:

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -185,18 +185,28 @@ class PlugManager(object):
   main framework thread anyway.
 
   Attributes:
-    plug_map: Dict mapping plug type to instantiated plug.
+    _plug_map: Dict mapping plug type to instantiated plug.
   """
 
   def InitializePlugs(self, plug_types):
-    self.plug_map = {}
+    self._plug_map = {}
     try:
       for plug_type in plug_types:
-        self.plug_map[plug_type] = plug_type()
+        self._plug_map[plug_type] = plug_type()
     except Exception:  # pylint: disable=broad-except
       _LOG.exception('Exception insantiating plug type %s', plug_type)
       self.TearDownPlugs()
       raise
+
+  @property
+  def _asdict(self):
+    return {'%s.%s' % (k.__module__, k.__name__): str(v)
+            for k, v in self._plug_map.iteritems()}
+
+  def ProvidePlugs(self, plug_name_map):
+    """Provide the requested plugs [(name, type),] as {name: plug instance}."""
+    return {name: self._plug_map[cls]
+            for name, cls in plug_name_map}
 
   def TearDownPlugs(self):
     """Call TearDown() on all instantiated plugs.
@@ -208,9 +218,9 @@ class PlugManager(object):
     Any exceptions in TearDown() methods are logged, but do not get raised
     by this method.
     """
-    for plug in self.plug_map.itervalues():
+    for plug in self._plug_map.itervalues():
       try:
         plug.TearDown()
       except Exception:  # pylint: disable=broad-except
         _LOG.warning('Exception calling TearDown on %s:', plug, exc_info=True)
-    self.plug_map.clear()
+    self._plug_map.clear()

--- a/test/phase_info_test.py
+++ b/test/phase_info_test.py
@@ -14,7 +14,10 @@
 
 import unittest
 
+import mock
+
 import openhtf
+from openhtf import plugs
 
 
 def PlainFunc():
@@ -32,17 +35,20 @@ def ExtraArgFunc(input=None):
 
 class TestPhaseInfo(unittest.TestCase):
 
+  def setUp(self):
+      self._phase_data = mock.Mock(plug_manager=plugs.PlugManager())
+
   def testBasics(self):
       phase = openhtf.PhaseInfo.WrapOrCopy(PlainFunc)
       self.assertIs(phase.func, PlainFunc)
       self.assertEqual(0, len(phase.plugs))
       self.assertEqual('PlainFunc', phase.name)
       self.assertEqual('Plain Docstring', phase.doc)
-      phase(None)
+      phase(self._phase_data)
 
       test_phase = openhtf.PhaseInfo.WrapOrCopy(NormalTestPhase)
       self.assertEqual('NormalTestPhase', test_phase.name)
-      self.assertEqual('return value', test_phase(None))
+      self.assertEqual('return value', test_phase(self._phase_data))
 
   def testMultiplePhases(self):
       phase = openhtf.PhaseInfo.WrapOrCopy(PlainFunc)
@@ -54,11 +60,11 @@ class TestPhaseInfo(unittest.TestCase):
   def testWithArgs(self):
       phase = openhtf.PhaseInfo.WrapOrCopy(ExtraArgFunc)
       phase = phase.WithArgs(input='input arg')
-      result = phase(None)
+      result = phase(self._phase_data)
       self.assertEqual('input arg', result)
 
       second_phase = phase.WithArgs(input='second input')
-      first_result = phase(None)
-      second_result = second_phase(None)
+      first_result = phase(self._phase_data)
+      second_result = second_phase(self._phase_data)
       self.assertEqual('input arg', first_result)
       self.assertEqual('second input', second_result)


### PR DESCRIPTION
Moves the plug manager creation into early test creation and makes its API more concrete.

I also separated the output code into `Test.Execute()` which cleaned up that separation a little, too. I'm not attached to that if either of you don't want that.