### PR TITLE
Allow @monitors to happen after another decorator

### DIFF
--- a/openhtf/util/monitors.py
+++ b/openhtf/util/monitors.py
@@ -109,7 +109,7 @@ def monitors(measurement_name, monitor_func, units=None, poll_interval_ms=1000):
     @measurements.measures(
         measurements.Measurement(measurement_name).WithUnits(
             units).WithDimensions(uom.UOM['MILLISECOND']))
-    @functools.wraps(phase_func)
+    @functools.wraps(phase.func)
     def MonitoredPhaseFunc(phase_data, *args, **kwargs):
       # Start monitor thread, it will call monitor.func(phase_data) periodically
       monitor_thread = _MonitorThread(


### PR DESCRIPTION
phase_func might be a PhaseInfo object already, which means we can't call functools.wraps() on it directly.