### PR TITLE
Be more lenient with source loading

### DIFF
--- a/openhtf/io/test_record.py
+++ b/openhtf/io/test_record.py
@@ -84,7 +84,7 @@ class PhaseRecord(  # pylint: disable=too-few-public-methods,no-init
 def _GetSourceSafely(obj):
   try:
     return inspect.getsource(obj)
-  except IOError:
+  except Exception:
     logs.LogOnce(
         _LOG.warning,
         'Unable to load source code for %s. Only logging this once.', obj)


### PR DESCRIPTION
Internally, our archive fails with IndexError. I figured there's no point in limiting the errors ignored from the builtin library function call.