### PR TITLE
Allow non-float multidims in mfg_inspector output

### DIFF
--- a/openhtf/io/output/mfg_inspector.py
+++ b/openhtf/io/output/mfg_inspector.py
@@ -131,14 +131,21 @@ def _MangleMeasurement(name, value, measurement, mangled_parameters):
       mangled_name += '_'
     mangled_param = test_runs_pb2.TestParameter()
     mangled_param.name = mangled_name
-    mangled_param.numeric_value = float(current_value[-1])
-    if measurement.units:
-      mangled_param.unit_code = UOM_CODE_MAP[measurement.units.uom_code]
     mangled_param.description = (
         'Mangled parameter from measurement %s with dimensions %s' % (
         name, tuple(d.uom_suffix for d in measurement.dimensions)))
+
+    value = current_value[-1]
+    if isinstance(value, numbers.Number):
+      mangled_param.numeric_value = float(value)
+    else:
+      mangled_param.text_value = str(value)
+    # Check for validators we know how to translate.
     for validator in measurement.validators:
       mangled_param.description += '\nValidator: ' + str(validator)
+
+    if measurement.units:
+      mangled_param.unit_code = UOM_CODE_MAP[measurement.units.uom_code]
     mangled_parameters[mangled_name] = mangled_param
 
 


### PR DESCRIPTION
In the output munging, a multi-dim measurement can be a string, and its validator is included in a structured format when possible.