### PR TITLE
Remove unused and indirect dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,14 +107,11 @@ build.sub_commands.insert(0, ('build_proto', None))
 INSTALL_REQUIRES = [
     'contextlib2==0.5.1',
     'enum34==1.1.2',
-    'MarkupSafe==0.23',
     'mutablerecords==0.2.9',
     'oauth2client==1.5.2',
     'protobuf==2.6.1',
     'pyaml==15.3.1',
     'pyOpenSSL==0.15.1',
-    'PyYAML==3.11',
-    'singledispatch==3.4.0.3',
     'tornado==4.3',
 ]
 


### PR DESCRIPTION
singledispatch is a dep of tornado, MarkupSafe was a dep of Werkzeug, and PyYAML of pyaml. I don't see any other indirect dependencies (via pipdeptree).

Fixes #257.