### PR TITLE
Use TCIFLUSH to only flush recieved but not read

### DIFF
--- a/openhtf/io/user_input.py
+++ b/openhtf/io/user_input.py
@@ -157,7 +157,7 @@ class ConsolePrompt(threading.Thread):
         print self._message
 
         # Before reading, clear any lingering buffered terminal input.
-        termios.tcflush(sys.stdin, termios.TCIOFLUSH)
+        termios.tcflush(sys.stdin, termios.TCIFLUSH)
 
         while not self._stopped:
           inputs, _, _ = select.select([sys.stdin], [], [], 0.001)


### PR DESCRIPTION
According to http://linux.die.net/man/3/tcflush, tcflush cares about the 'object referred to by fd', which is shared between stdin, stdout, and stderr. Therefore, when we do a tcflush on IO right after a print, we will drop the data from the print that hasn't been received by the terminal (could be just 1 byte, the newline, and the terminal won't print anything).

By switching to TCIFLUSH, we only drop data that has been sent to us by the terminal but not read by us, such as any stray keyboard input. This shouldn't drop any data going the other way.

Fixes #249