### PR TITLE
add validators and output to names

### DIFF
--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -97,9 +97,9 @@ if __name__ == '__main__':
       # but you can include any metadata fields.
       test_name='MyTest', test_description='OpenHTF Example Test',
       test_version='1.0.0')
-  test.AddOutputCallbacks(json_factory.OutputToJSON(
+  test.AddOutputCallbacks(output.OutputToJSON(
       './%(dut_id)s.%(start_time_millis)s.json', indent=4))
-  #test.AddOutputCallbacks(mfg_inspector.OutputToTestRunProto(
+  #test.AddOutputCallbacks(output.OutputToTestRunProto(
   #    './%(dut_id)s.%(start_time_millis)s.pb'))
   # Example of how to upload to mfg-inspector.  Replace filename with your
   # JSON-formatted private key downloaded from Google Developers Console
@@ -107,7 +107,7 @@ if __name__ == '__main__':
   # 'my_private_key.json'.
   #if os.path.isfile('my_private_key.json'):
   #  with open('my_private_key.json', 'r') as json_file:
-  #    test.AddOutputCallbacks(mfg_inspector.UploadToMfgInspector.from_json(
+  #    test.AddOutputCallbacks(output.UploadToMfgInspector.from_json(
   #        json.load(json_file)))
 
   test.Execute(test_start=triggers.PromptForTestStart())

--- a/openhtf/io/output/__init__.py
+++ b/openhtf/io/output/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Openhtf output modules."""
+
+import openhtf.io.output.json_factory
+import openhtf.io.output.mfg_inspector
+
+# pylint: disable=invalid-name
+
+# Classes used for output
+OutputToJSON = json_factory.OutputToJSON
+UploadToMfgInspector = mfg_inspector.UploadToMfgInspector
+OutputToTestRunProto = mfg_inspector.OutputToTestRunProto

--- a/openhtf/names.py
+++ b/openhtf/names.py
@@ -39,6 +39,7 @@ import openhtf.plugs
 import openhtf.util.measurements
 import openhtf.util.monitors
 import openhtf.util.units
+import openhtf.util.validators
 
 
 # pylint: disable=invalid-name
@@ -46,13 +47,13 @@ import openhtf.util.units
 # Pseudomodules.
 prompts = openhtf.io.user_input.get_prompt_manager()
 triggers = openhtf.exe.triggers
-
+validators = openhtf.util.validators
+output = openhtf.io.output
 
 # Functions used in writing test scripts.
 measures = openhtf.util.measurements.measures
 monitors = openhtf.util.monitors.monitors
 plug = openhtf.plugs.plug
-
 
 # Classes used in writing test scripts.
 Measurement = openhtf.util.measurements.Measurement


### PR DESCRIPTION
Add validators to names for easy access.  The shorthand version of measures requires importing util.

```
from openhtf.names import *
from openhtf.util import validators
@measures('inline_kwargs', docstring='This measurement is declared inline!',
units=UOM['HERTZ'], validators=[validators.InRange(0, 10)])
```
becomes
```
from openhtf.names import *
@measures('inline_kwargs', docstring='This measurement is declared inline!',
units=UOM['HERTZ'], validators=[InRange(0, 10)])
```
