### PR TITLE
Add responsiveness tags to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![Build Status](https://travis-ci.org/google/openhtf.svg?branch=master)](https://travis-ci.org/google/openhtf)
 [![Coverage Status](https://coveralls.io/repos/google/openhtf/badge.svg?branch=master&service=github)](https://coveralls.io/github/google/openhtf?branch=master)
 
+[![Issue Stats](http://issuestats.com/github/google/openhtf/badge/pr)](http://issuestats.com/github/google/openhtf)
+[![Issue Stats](http://issuestats.com/github/google/openhtf/badge/issue)](http://issuestats.com/github/google/openhtf)
+
 The open-source hardware testing framework.
 
 


### PR DESCRIPTION
Add average PR and issue close time tags (from issuestats.com) to our README.md file.