### PR TITLE
Raise errors from uploading correctly

### DIFF
--- a/openhtf/io/output/mfg_inspector.py
+++ b/openhtf/io/output/mfg_inspector.py
@@ -460,9 +460,10 @@ class UploadToMfgInspector(object):  # pylint: disable=too-few-public-methods
     if resp.status != 200:
       try:
         results = json.loads(content)
-        raise UploadFailedError(results['error'], results)
       except Exception:
         raise UploadFailedError(resp, content)
+      else:
+        raise UploadFailedError(results['error'], results)
 
     # Return True if successful
     return True


### PR DESCRIPTION
Previously the UploadFailedError would get caught and re-raised differently right away