### PR TITLE
Encode unicode before shoving into a bytes field

### DIFF
--- a/openhtf/io/output/mfg_inspector.py
+++ b/openhtf/io/output/mfg_inspector.py
@@ -151,6 +151,8 @@ def _ExtractAttachments(phase, testrun, used_parameter_names):
     name = _EnsureUniqueParameterName(name, used_parameter_names)
     testrun_param = testrun.info_parameters.add()
     testrun_param.name = name
+    if isinstance(data, unicode):
+      data = data.encode('utf8')
     testrun_param.value_binary = data
     if mimetype in MIMETYPE_MAP:
       testrun_param.type = MIMETYPE_MAP[mimetype]


### PR DESCRIPTION
protos expect `value_binary` to be Python `bytes` or `str` objects. If we pass in `unicode` for any reason, it's understandably expected to be encoded. UTF-8 is as good an encoding as any.