### PR TITLE
Optionally disable capturing source code

### DIFF
--- a/openhtf/io/test_record.py
+++ b/openhtf/io/test_record.py
@@ -29,6 +29,7 @@ from openhtf import util
 from openhtf.util import logs
 
 _LOG = logging.getLogger(__name__)
+CAPTURE_SOURCE_CODE = True  # Override before creating an openhtf.Test()
 
 
 class InvalidMeasurementDimensions(Exception):
@@ -82,6 +83,8 @@ class PhaseRecord(  # pylint: disable=too-few-public-methods,no-init
 
 
 def _GetSourceSafely(obj):
+  if not CAPTURE_SOURCE_CODE:
+    return ''
   try:
     return inspect.getsource(obj)
   except Exception:


### PR DESCRIPTION
This is a quick, simple way to disable source code capturing so it's not even in memory (other than as bytecode).

Fixes #360
