### PR TITLE
Overhaul the included web frontend to use the new station_api.

### DIFF
--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -119,6 +119,5 @@ if __name__ == '__main__':
   #  with open('my_private_key.json', 'r') as json_file:
   #    test.AddOutputCallbacks(output.UploadToMfgInspector.from_json(
   #        json.load(json_file)))
-  #test.Configure(teardown_function=teardown)
-  while True:
-    test.Execute(test_start=triggers.PromptForTestStart())
+  test.Configure(teardown_function=teardown)
+  test.Execute(test_start=triggers.PromptForTestStart())

--- a/openhtf/io/frontend/__init__.py
+++ b/openhtf/io/frontend/__init__.py
@@ -16,10 +16,10 @@
 """Frontend server for OpenHTF using the station API.
 
 This server has two ways of knowing which stations to track:
-
+  
   (1) Discovery pings sent using OpenHTF's multicast station discovery service.
       These pings can be disabled via the '--disable-multicast' flag if desired.
-
+  
   (2) A list of stations provided via the server's config yaml file (specified
       via the '--config-file' flag). This list will be sought under the config
       key 'stations', which should contain a list of station entries:
@@ -96,7 +96,7 @@ class TestWatcher(threading.Thread):
     wait_timeout_s: Seconds to wait for an update before timeout and retry.
   """
   daemon = True
-  DEFAULT_WAIT_TIMEOUT_S = 15
+  DEFAULT_WAIT_TIMEOUT_S = 5
 
   def __init__(self, hostport, test, callback,
                wait_timeout_s=DEFAULT_WAIT_TIMEOUT_S):
@@ -170,9 +170,9 @@ class StationStore(threading.Thread):
           if (hostport, test_uid) not in self._watchers:
             self._watchers[hostport, test_uid] = TestWatcher(
                 hostport, remote_test,self._on_update_callback)
-      except (socket.error, station_api.StationUnreachableError) as e:
+      except station_api.StationUnreachableError:
         _LOG.debug('Station at %s is unreachable.', hostport)
-
+    
     if self._on_discovery_callback:
       self._on_discovery_callback(self.stations)
 
@@ -296,7 +296,7 @@ class StationPubSub(PubSub):
     try:
       for test_uid, remote_test in self._store[hostport].tests.iteritems():
         self.send(self.make_msg(test_uid, remote_test.state))
-    except socket.error:
+    except station_api.StationUnreachableError:
       _LOG.debug('Station %s unreachable during on_subscribe.', hostport)
 
   def on_unsubscribe(self):

--- a/openhtf/io/frontend/__main__.py
+++ b/openhtf/io/frontend/__main__.py
@@ -13,259 +13,31 @@
 # limitations under the License.
 
 
-"""A basic frontend server for OpenHTF using the HTTP frontend API.
+"""Entry point to run OpenHTF's built-in web gui server."""
 
-This server has two ways of knowing which stations to track:
-  
-  (1) Discovery pings sent using OpenHTF's multicast station discovery service.
-      These pings can be disabled via the '--disable-multicast' flag if desired.
-  
-  (2) A list of stations provided via the server's config yaml file (specified
-      via the '--config-file' flag). This list will be sought under the config
-      key 'stations', which should contain a list of station entries:
-
-        stations:
-          - id: <station_id 1>
-            host: <ip address 1>
-            port: <port number 1>
-          - id: <station_id 2>
-            host: <ip address 2>
-            port: <port number 2>
-          - id: <station_id 3>
-            host: <ip address 3>
-            port: <port number 3>
-
-To start the frontend server, invoke python with the -m flag in a python
-environment where openhtf is installed:
-
-$ python -m openhtf.io.frontend
-
-To access the frontend once it's running, simply point a web browser at the
-frontend server.
-"""
 
 from __future__ import print_function
 import argparse
-import json
 import logging
-import os
 import signal
-import socket
-import sys
-import threading
 
-import requests
-import tornado.escape
-import tornado.ioloop
-import tornado.web
-
+import openhtf.io.frontend
 from openhtf import conf
-from openhtf.io.http_api import PING_STRING
-from openhtf.io.http_api import PING_RESPONSE_KEY
 from openhtf.util import logs
-from openhtf.util import multicast
 
 
 _LOG = logging.getLogger(__name__)
 
-UNKNOWN_STATION_ID = 'UNKNOWN_STATION'
-BUILD_PATH = os.path.join(os.path.dirname(__file__), 'src', 'dist')
-PREBUILT_PATH = os.path.join(os.path.dirname(__file__), 'prebuilt')
 
-conf.Declare('stations',
-             default_value=[],
-             description='List of manually declared stations.')
-
-
-class Station(object):
-  """Represents a station seen on the local network.
-
-  Args:
-    hostport: A tuple of (<ip address>, <port>).
-
-  Attributes:
-    station_id: Station's ID string.
-    state: A dictionary representation of station state with two keys:
-      framework: A dictionary representation of a TestExecutor object.
-      test: A dictionary representation of a TestState object.
-    """
-  def __init__(self, hostport, station_id=UNKNOWN_STATION_ID):
-    self.history = []
-    self.hostport = hostport
-    self.station_id = station_id
-    self.state = None
-
-
-  def Refresh(self):
-    """Update state with a GET request to OpenHTF's HTTP API.
-
-    Returns: True iff refresh was successful, otherwise False.
-    """
-    try:
-      response = requests.get('http://%s:%s' % self.hostport)
-      if response.status_code == 200:
-        state = json.loads(response.text)
-        station_id = state['framework']['station_id']
-        if (self.station_id is not UNKNOWN_STATION_ID) and (
-            station_id != self.station_id):
-          _LOG.warning('Station (%s) underwent an identity change from "%s" to'
-                       ' "%s"' % (self.hostport, self.station_id, station_id))
-        self.station_id = station_id
-        self.state = state
-        return True
-    except requests.RequestException as e:
-      _LOG.debug('Station (%s) unreachable: %s', self.hostport, e)
-      self.state = None
-    except KeyError:
-      _LOG.warning('Malformed station state response from (%s): %s',
-                   self.hostport, response)
-    return False
-
-  def Notify(self, message):
-    """Send a message to an OpenHTF instance in response to a prompt.
-
-    Args:
-      message: Prompt response.
-    """
-    try:
-      requests.post('http://%s:%s' % self.hostport, data=message)
-    except requests.RequestException as e:
-      _LOG.warning('Error notifying station (%s): %s', self.hostport, e)
-
-  def AddToHistory(self, json_record):
-    """Add a test record to the history for this station."""
-    self.history.append(json_record)
-
-
-class StationStore(threading.Thread):
-  """Self-updating store of stations visible on the local network(s).
-
-  Station data is stored in the 'stations' attribute, a dictionary mapping
-  tuples of (host_ip, port) to Station records.
-  """
-  def __init__(self, discovery_address, discovery_port, discovery_ttl,
-               discovery_interval_s, disable_discovery):
-    super(StationStore, self).__init__()
-    self._discovery_address = discovery_address
-    self._discovery_port = discovery_port
-    self._discovery_ttl = discovery_ttl
-    self._discovery_interval_s = discovery_interval_s
-    self._disable_discovery = disable_discovery
-    self._stop_event = threading.Event()
-    self.stations = {}
-
-    for station in conf.stations:
-      hostport = (station['host'], int(station['port']))
-      self.stations[hostport] = Station(hostport, station['id'])
-
-
-  def __getitem__(self, hostport):  # pylint:disable=invalid-name
-    """Provide dictionary-like access to the station store."""
-    station = self.stations.setdefault(hostport, Station(hostport))
-    station.Refresh()
-    return station
-
-  def _Discover(self):
-    """Use multicast to discover stations on the local network."""
-    responses = multicast.send(PING_STRING,
-                               self._discovery_address,
-                               self._discovery_port,
-                               self._discovery_ttl)
-    for host, response in responses:
-      port = None
-      try:
-        port = json.loads(response)[PING_RESPONSE_KEY]
-        self._Track(host, int(port))
-      except (KeyError, ValueError):
-        _LOG.debug('Ignoring unrecognized discovery response from %s: %s' % (
-            host, response))
-
-  def run(self):
-    """Continuously scan for new stations and add them to the store."""
-    if self._disable_discovery:
-      _LOG.debug('Station discovery is disabled; StationStore won\'t update.')
-      return
-    while not self._stop_event.is_set():
-      self._Discover()
-      self._stop_event.wait(self._discovery_interval_s)
-
-  def _Track(self, *hostport):
-    """Start tracking the given station."""
-    station = self[hostport]
-    if station.station_id is UNKNOWN_STATION_ID:
-      station.Refresh()
-
-  def Stop(self):
-    """Stop the store."""
-    self._stop_event.set()
-    self.join()
-
-
-class MainHandler(tornado.web.RequestHandler):
-  """Main handler for OpenHTF frontend app."""
-  def initialize(self, port):
-    self.port = port
-
-  def get(self):
-    self.render('index.html', host=socket.gethostname(), port=self.port)
-
-
-class DashboardHandler(tornado.web.RequestHandler):
-  """Handles requests from the DashListService."""
-  def initialize(self, store):
-    self.store = store
-
-  def get(self):
-    result = {}
-    for key, station in self.store.stations.items():
-      status = 'ONLINE' if station.Refresh() else 'OFFLINE'
-      result['%s:%s' % key] = {
-          'station_id': station.station_id,
-          'hostport': station.hostport,
-          'status': status}
-    self.write(json.JSONEncoder().encode(result))
-
-
-class StationHandler(tornado.web.RequestHandler):
-  """Handles requests for station state."""
-  def initialize(self, store):
-    self.store = store
-
-  def get(self, host, port):
-    self.write(json.JSONEncoder().encode(self.store[host, int(port)].state))
-
-
-class PromptHandler(tornado.web.RequestHandler):
-  """Handles POST requests that repond to prompts."""
-  def initialize(self, store):
-    self.store = store
-
-  def post(self, host, port, prompt_id):
-    msg = json.JSONEncoder().encode(
-        {'id': prompt_id, 'response': self.request.body})
-    self.store[host, port].Notify(msg)
-
-
-def main(argv):
+def main():
   """Start the frontend."""
   parser = argparse.ArgumentParser(description='OpenHTF web frontend server.',
                                    parents=[conf.ARG_PARSER],
                                    prog='python -m openhtf.io.frontend')
   parser.add_argument('--port', type=int, default=12000,
                       help='Port on which to serve the frontend.')
-  parser.add_argument('--poll_interval_ms', type=int, default=3000,
-                      help='Time between frontend polls in milliseconds.')
-  parser.add_argument('--discovery_interval_s', type=int, default=5,
+  parser.add_argument('--discovery_interval_s', type=int, default=3,
                       help='Seconds between station discovery attempts.')
-  parser.add_argument('--discovery_address', type=str,
-                      default=multicast.DEFAULT_ADDRESS,
-                      help='Multicast address to ping for station discovery.')
-  parser.add_argument('--discovery_port', type=int,
-                      default=multicast.DEFAULT_PORT,
-                      help='Multicast port to use for station discovery.')
-  parser.add_argument('--discovery_ttl', type=int,
-                      default=multicast.DEFAULT_TTL,
-                      help='TTL for station discovery pings.')
   parser.add_argument('--disable_discovery', action='store_true',
                       help='Disable multicast-based station discovery.')
   parser.add_argument('--dev', action='store_true',
@@ -274,50 +46,20 @@ def main(argv):
 
   logs.SetupLogger()
 
-  path = BUILD_PATH if os.path.exists(BUILD_PATH) else PREBUILT_PATH
-  
-  settings = {
-      'template_path': path,
-      'static_path': path,
-      'debug': args.dev
-  }
-
-  store = StationStore(args.discovery_address,
-                       args.discovery_port,
-                       args.discovery_ttl,
-                       args.discovery_interval_s,
-                       args.disable_discovery)
-
-  routes = [
-      (r'/', MainHandler, dict(port=args.port)),
-      (r'/raw/dashboard(?:/*)', DashboardHandler, dict(store=store)),
-      (r'/raw/station/((?:[0-9]{1,3}\.){3}[0-9]{1,3})/([0-9]{1,5})(?:/*)',
-       StationHandler, dict(store=store)),
-      (r'/station/(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})/(?:[0-9]{1,5})(?:/*)',
-       MainHandler, dict(port=args.port)),
-      (r'/station/((?:[0-9]{1,3}\.){3}[0-9]{1,3})/([0-9]{1,5})/'
-       r'prompt/(.*)(?:/*)',
-       PromptHandler, dict(store=store)),
-      (r"/(.*\..*)", tornado.web.StaticFileHandler,
-       dict(path=settings['static_path'])),
-      (r"/(styles\.css)", tornado.web.StaticFileHandler,
-       dict(path=settings['static_path'])),
-  ]
-
-  frontend_server = tornado.web.Application(routes, **settings)
-  frontend_server.listen(args.port)
+  web_server = openhtf.io.frontend.WebGuiServer(args.discovery_interval_s,
+                                                args.disable_discovery,
+                                                args.port,
+                                                args.dev)
 
   def sigint_handler(*dummy):
     """Handle SIGINT by stopping running executor and handler."""
-    _LOG.error('Received SIGINT. Stopping frontend server.')
-    tornado.ioloop.IOLoop.instance().stop()
-    store.Stop()
+    _LOG.error('Received SIGINT. Stopping web server.')
+    web_server.stop()
   signal.signal(signal.SIGINT, sigint_handler)
 
-  print('Starting openhtf frontend server on http://localhost:%s.' % args.port)
-  store.start()
-  tornado.ioloop.IOLoop.instance().start()
+  print('Starting openhtf web server on http://localhost:%s.' % args.port)
+  web_server.start()
 
 
 if __name__ == '__main__':
-  main(sys.argv)
+  main()

--- a/openhtf/io/frontend/src/app/dashboard.css
+++ b/openhtf/io/frontend/src/app/dashboard.css
@@ -1,20 +1,44 @@
+#dashboard {
+  padding: 0px 12px 0px 12px;
+}
+
 .card {
   display: inline-block;
   margin-right: 20px;
   padding: 8px;
 }
 
+.cardfooter {
+  display: table;
+  font-size: 14pt;
+  min-width: 16ch;
+  max-width: 40ch;
+  width: 100%;
+}
+
 .details {
-  font-size: 10px;
+  font-size: 10pt;
+}
+
+.leftcell {
+  display: table-cell;
+  vertical-align: bottom;
+}
+
+.rightcell {
+  display: table-cell;
+  text-align: right;
+  vertical-align: bottom;
 }
 
 .station-name {
-  font-size: 17px;
+  font-size: 12pt;
 }
 
-.status {
-  font-size: 10px;
-  font-weight: 300;
-  text-align: right;
-  margin-top: .5em;
+.star {
+  vertical-align: bottom;
+}
+
+.unreachable-label {
+  font-size: 8pt;
 }

--- a/openhtf/io/frontend/src/app/dashboard.service.ts
+++ b/openhtf/io/frontend/src/app/dashboard.service.ts
@@ -12,114 +12,59 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+declare var jsonpatch; // Global provided by the fast-json-patch package.
 
 import {Injectable} from 'angular2/core';
-import {Http, Response} from 'angular2/http';
-import 'rxjs/Rx';
+
+import {SubscriptionService} from './utils';
 
 
 /** Provider of Dashboard updates from the OpenHTF frontend server. **/
 @Injectable()
-export class DashboardService {
-  POLLING_INTERVAL_MS: number = 3000;
-  URL: string = '/raw/dashboard';
+export class DashboardService extends SubscriptionService {
+  URL: string = '/sub/dashboard';
 
-  listings: Listing[];
-  dashMap: {};
-  server: any;
-  polling_job: number;
+  private dashMap: any;
+  private listings: any[];
 
   /**
    * Create a DashboardService.
    */
-  constructor(private http: Http) {
-    this.listings = []; // Because ngFor only takes lists.
+  constructor() {
+    super();
     this.dashMap = {}; // Because we want persistent records.
-    this.start();
+    this.listings = []; // Because ngFor only takes lists.
+    this.setUrl(this.URL);
   }
 
   /**
-   * Start polling the frontend server for dashboard updates.
+   * Parse the server's messages and update state accordingly.
+   * @param message - A JSON dashboard state from the frontend server.
    */
-  start() {
-    this.requestListings(); // Avoid waiting for the first poll interval.
-    this.polling_job = setInterval(() => {
-      this.requestListings();
-    }, this.POLLING_INTERVAL_MS);
-  }
-
-  /**
-   * Stop polling for dashboard updates.
-   */
-  stop() {
-    clearInterval(this.polling_job);
-  }
-
-  /**
-   * Make an HTTP request for dashboard listings from the frontend server.
-   */
-  requestListings() {
-    this.http.get(this.URL)
-      .map(res => res.json())
-      .subscribe(
-        data => this.updateListings(data),
-        err => console.log('Error: ' + err)
-      );
-  }
-
-  /**
-   * Parse the server's response and update state accordingly.
-   * @param data - A JSON dashboard response from the frontend server.
-   */
-  updateListings(data: any) {
-    for (var key in data) {
-      if (this.dashMap[key] === undefined) {
-        this.dashMap[key] = new Listing(data[key]);
-        this.listings.push(this.dashMap[key]);
+  updateListings(message: any) {
+    for (var key in message) {
+      if (this.dashMap[key] == undefined) {
+        this.dashMap[key] = message[key];
+        this.listings.push(message[key]);
       }
       else {
-        this.dashMap[key].update(data[key]);
+        let diff = jsonpatch.compare(this.dashMap[key], message[key]);
+        jsonpatch.apply(this.dashMap[key], diff);
       }
     }
   }
 
-  /*
+  /**
    * Return the current dashboard listing.
    */
   getListings() {
     return this.listings;
   }
-}
-
-
-/** Data class representing a single known station. **/
-export class Listing {
-  name: string;
-  ip: string;
-  port: number;
-  status: string;
-  starred: boolean;
 
   /**
-   * Create a Listing from a JSON object.
+   * Open the sockjs connection. Attempt to reconnect after timeout.
    */
-  constructor(jsonData) {
-    this.update(jsonData)
-    this.starred = false;
-  }
-
-  /**
-   * Update a Listing from a JSON object.
-   *
-   * The JSON object passed in should have the following structure:
-   *   * station_id: string
-   *   * hostport: [host: string, port: number]
-   *   * status: string
-   */
-  update(jsonData: any) {
-    this.name = jsonData['station_id'];
-    this.ip = jsonData['hostport'][0];
-    this.port = jsonData['hostport'][1];
-    this.status = jsonData['status'];
+  onmessage(msg) {
+    this.updateListings(JSON.parse(msg.data));
   }
 }

--- a/openhtf/io/frontend/src/app/index.html
+++ b/openhtf/io/frontend/src/app/index.html
@@ -13,20 +13,34 @@
   <base href="/">
   <body>
     <div class="nav-wrapper blue lighten-1 white-text">
-      <div id="title_bar">
+      <div id="title-bar">
         <div>
         <div id="title">
           <a href="/" class="white-text">OpenHTF</a>
         </div>
-          <div id="served_tag">
-            <span class="served_message">frontend served on </span>
-            <span class="served_stats">{{host}}:{{port}}</span>
+          <div id="served-tag">
+            <span class="served-message">web gui served on </span>
+            <span class="served-stats">{{host}}:{{port}}</span>
           </div>
         </div>
       </div>
     </div>
     <div id="content" class="container">
-      <app>loading...</app>
+      <app>
+        <div class="preloader center-align">
+        <div class="preloader-wrapper big active">
+          <div class="spinner-layer spinner-blue-only">
+            <div class="circle-clipper left">
+              <div class="circle"></div>
+            </div><div class="gap-patch">
+              <div class="circle"></div>
+            </div><div class="circle-clipper right">
+              <div class="circle"></div>
+            </div>
+          </div>
+        </div>
+        </div>
+      </app>
     </div>
   </body>
 </html>

--- a/openhtf/io/frontend/src/app/main.ts
+++ b/openhtf/io/frontend/src/app/main.ts
@@ -41,7 +41,7 @@ import 'file?name=/styles.css!./styles.css';
 })
 @RouteConfig([
   { path: '/', name: 'Dashboard', component: Dashboard },
-  {path: '/station/:ip/:port', name: 'Station', component: Station}
+  {path: '/station/:host/:port', name: 'Station', component: Station}
 ])
 export class AppComponent {
 

--- a/openhtf/io/frontend/src/app/station.css
+++ b/openhtf/io/frontend/src/app/station.css
@@ -1,3 +1,6 @@
+#station {
+}
+
 #toast-container {
   width: 70%;
   bottom: 0%;

--- a/openhtf/io/frontend/src/app/station.header.css
+++ b/openhtf/io/frontend/src/app/station.header.css
@@ -2,29 +2,26 @@
   display: table-cell;
 }
 
+#cell-selection {
+  color: #303030;
+}
+
+#cell-selection .tabs .tab a {
+  color: blue;
+}
+
 .countdown {
   display: table-cell;
   background: #303030;
   border-radius: 5px;
   color: #e0e0e0;
   padding: 0px 5px 0px 5px;
-  font-size: 21px;
-  font-weight: 600;
+  font-size: 10pt;
+  font-weight: 500;
 }
 
 .left {
   display: table;
-}
-
-.navbar i {
-  font-size: 30px;
-}
-
-.navbar > div {
-  display: inline-block;
-  font-size: 8pt;
-  padding: 3px 10px 3px 10px;
-  text-align: center;
 }
 
 .right {
@@ -44,9 +41,13 @@
 }
 
 .station-id-area .station-id-label {
-  font-size: 18pt;
+  font-size: 14pt;
 }
 
 .station-id-area .socket-label {
-  font-size: 8pt;
+  font-size: 10pt;
+}
+
+:host >>> .indicator {
+  height: 5px;
 }

--- a/openhtf/io/frontend/src/app/station.header.html
+++ b/openhtf/io/frontend/src/app/station.header.html
@@ -6,23 +6,29 @@
                         and possibly an "offline" tag after the name if the
                         station is offline. -->
       <div class="card blue lighten-1 white-text">
-        <div class="navbar">
-          <div>
-            <div><i class="material-icons">bookmark</i></div>
-            <div>CURRENT</div>
-          </div>
-          <div class="blue-grey-text text-lighten-3">
-            <div><i class="material-icons">history</i></div>
-            <div>HISTORY</div>
-          </div>
-        </div>
+        <div class="navbar"><ul class="tabs">
+          <li class="tab"><a href="#current">
+            <div class="nav-button">
+              <div><i class="material-icons">bookmark</i></div>
+              <div class="nav-label">CURRENT</div>
+            </div>
+          </a></li>
+          <li class="tab"><a href="#history">
+            <div class="nav-button">
+              <div><i class="material-icons">history</i></div>
+              <div class="nav-label">HISTORY</div>
+            </div>
+          </a></li>
+        </ul></div>
       </div>
     </div>
     <div class="station-id-area blue-text text-lighten-1">
       <div class="station-id-label">
-        {{state?.framework?.station_id}}
+        {{stationInfo?.station_id}}
       </div>
-      <div class="socket-label">{{ip}} : {{port}}</div>
+      <div class="socket-label">
+        {{stationInfo?.host}} : {{stationInfo?.port}}
+      </div>
     </div>
   </div>
   <div class="right">

--- a/openhtf/io/frontend/src/app/station.header.ts
+++ b/openhtf/io/frontend/src/app/station.header.ts
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 
-import {Component, Input} from 'angular2/core';
+declare var $: any;  // Global provided by the jquery package.
+
+import {Component, Input, OnInit} from 'angular2/core';
 
 import {Countdown} from './utils';
 import 'file?name=/styles/station.header.css!./station.header.css';
@@ -24,9 +26,16 @@ import 'file?name=/templates/station.header.html!./station.header.html';
   templateUrl: 'templates/station.header.html',
   styleUrls: ['styles/station.header.css']
 })
-export class StationHeader {
+export class StationHeader implements OnInit {
   @Input() countdown: Countdown;
-  @Input() state: any;
-  @Input() ip: string;
-  @Input() port: string;
+  @Input() stationInfo: any;
+
+  /**
+   * Executed when this component's properties change.
+   * @param changes - Object describing the changes.
+   */
+  ngOnInit() {
+    $('.navbar .indicator').addClass("blue lighten-1");
+    $(".dropdown-button").dropdown();
+  }
 }

--- a/openhtf/io/frontend/src/app/station.html
+++ b/openhtf/io/frontend/src/app/station.html
@@ -1,27 +1,38 @@
 <!-- Template for the Station component; top level of the Station view. -->
-<div>
+<div id="station">
   <station-header [countdown]="countdown"
-                  [state]="stationState"
-                  [ip]="ip"
-                  [port]="port">
+                  [stationInfo]="stationInfo">
   </station-header>
-  <div class="currentTab">
-    <prompt [framework]="stationState?.framework"></prompt>
-    <test-header
-      [dutID]="stationState?.test?.record?.dut_id"
-      [startTime]="stationState?.test?.record?.start_time_millis"
-      [endTime]="stationState?.test?.record?.end_time_millis"
-      [currentMillis]="currentMillis"
-      [status]="stationState?.test?.record?.outcome
-                || stationState?.framework?.status || 'OFFLINE'">
-    </test-header>
-    <phase-listing id="phases" [state]="stationState"
-                               [currentMillis]="currentMillis">
-    </phase-listing>
-    <logs id="logs" [test]="stationState?.test">
-    </logs>
-    <metadata id="metadata" [test]="stationState?.test">
-    </metadata>
+  <div class="currentTab" id="current">
+    <div *ngIf="tests.length == 0" class="big-message">
+      No tests available for display.
+    </div>
+    <div *ngFor="let test of tests">
+      <div class="test">
+        <test-header
+          [dutID]="test.test_record?.dut_id"
+          [startTime]="test.test_record?.start_time_millis"
+          [endTime]="test.test_record?.end_time_millis"
+          [currentMillis]="currentMillis"
+          [status]="test.test_record?.outcome
+                    || test.status || 'OFFLINE'">
+        </test-header>
+        <div class="test-content">
+          <phase-listing id="phases" [state]="test"
+                                     [currentMillis]="currentMillis">
+          </phase-listing>
+          <logs id="logs" [log_records]="test.test_record?.log_records">
+          </logs>
+          <metadata id="metadata" [metadata]="test.test_record.metadata">
+          </metadata>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div id="history">
+    <div class="big-message">
+      History feature coming soon!
+    </div>
   </div>
   <!-- TODO(jethier): Iterate over included station-level plugins and display
                       them here. Also need to wire them to tabs. -->

--- a/openhtf/io/frontend/src/app/station.logs.ts
+++ b/openhtf/io/frontend/src/app/station.logs.ts
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 
-import {Component, Input} from 'angular2/core';
+declare var $;  // Global provided by the jquery package.
+
+import {Component, Input, OnInit} from 'angular2/core';
 
 import {LoggingLevelToColor} from './utils';
 import 'file?name=/styles/station.logs.css!./station.logs.css';
@@ -24,11 +26,11 @@ import 'file?name=/styles/station.logs.css!./station.logs.css';
   selector: 'logs',
   template: `
     <div class="log-listing">
-      <div *ngIf="!test?.record?.log_records?.length > 0"
-           class="center-align grey-text">
-        <h5>Log is currently empty.</h5>
+      <div *ngIf="!log_records?.length > 0"
+           class="big-message">
+        Log is currently empty.
       </div>
-      <div *ngFor="let entry of test?.record?.log_records"
+      <div *ngFor="let entry of log_records"
             class="log-entry {{entry.level | loggingLevelToColor}}">
         <span class='timestamp'>
           {{entry.timestamp_millis | date:'short'}}
@@ -40,6 +42,10 @@ import 'file?name=/styles/station.logs.css!./station.logs.css';
   styleUrls: ['styles/station.logs.css'],
   pipes: [LoggingLevelToColor]
 })
-export class Logs {
-  @Input() test: any[];
+export class Logs implements OnInit {
+  @Input() log_records: any[];
+
+  ngOnInit() {
+    // $('ul.tabs').tabs();
+  }
 }

--- a/openhtf/io/frontend/src/app/station.metadata.ts
+++ b/openhtf/io/frontend/src/app/station.metadata.ts
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 
-import {Component, Input} from 'angular2/core';
+declare var $;  // Global provided by the jquery package.
+
+import {Component, Input, OnInit} from 'angular2/core';
 
 import {LoggingLevelToColor, ObjectToUl} from './utils';
 import 'file?name=/styles/station.metadata.css!./station.metadata.css';
@@ -24,19 +26,23 @@ import 'file?name=/styles/station.metadata.css!./station.metadata.css';
   selector: 'metadata',
   template: `
     <div class="meta-listing">
-      <div *ngIf="!test?.record?.metadata"
-           class="center-align grey-text">
-        <h5>Test metadata is currently unpopulated.</h5>
+      <div *ngIf="!metadata"
+           class="big-message">
+        Test metadata is currently unpopulated.
       </div>
-      <div *ngIf="test?.record?.metadata"
+      <div *ngIf="metadata"
            class="{{20 | loggingLevelToColor}}"
-           [innerHTML]="test.record.metadata | objectToUl">
+           [innerHTML]="metadata | objectToUl">
       </div>
     </div>
   `,
   styleUrls: ['styles/station.metadata.css'],
   pipes: [LoggingLevelToColor, ObjectToUl]
 })
-export class Metadata {
-  @Input() test: any;
+export class Metadata implements OnInit {
+  @Input() metadata: any;
+
+  ngOnInit() {
+    // $('ul.tabs').tabs();
+  }
 }

--- a/openhtf/io/frontend/src/app/station.phases.css
+++ b/openhtf/io/frontend/src/app/station.phases.css
@@ -24,6 +24,11 @@
   text-align: right;
 }
 
+.measurement .value {
+  max-width: 300px;
+  overflow-x: hidden;
+}
+
 .measurement td {
   border-radius: 0;
   padding: .3em 1em .3em 1em;

--- a/openhtf/io/frontend/src/app/station.phases.html
+++ b/openhtf/io/frontend/src/app/station.phases.html
@@ -1,6 +1,6 @@
 <!-- Template for the PhaseListing component. -->
-<div *ngIf="!state?.test?.record?.phases" class="center-align grey-text">
-  <h5>Phase list is currently empty or uninitialized.</h5>
+<div *ngIf="state?.test_record?.phases.length == 0 && !state.running_phase_state" class="big-message">
+  Phase list is currently empty or uninitialized.
 </div>
 <div>
 <!-- It might have been cleaner to have a "phase" component to build these
@@ -10,14 +10,14 @@
      would break the popout list. -->
 <ul class="collapsible popout" data-collapsible="accordion">
   <!-- Completed phases from records. -->
-  <li *ngFor="let phase of state?.test?.record?.phases">
+  <li *ngFor="let phase of state?.test_record?.phases">
     <div class="collapsible-header {{phase.measurements | measToPassFail | statusToColor}} waves-effect waves-light">
       <div class="phase-header-text">
         <div class="name">
           {{phase.name}}
         </div>
         <div class="cycle-time">
-          {{((phase.end_time_millis - phase.start_time_millis) / 1000) | number:['1.2-2']}}s
+          {{((phase.end_time_millis - phase.start_time_millis) / 1000) | number:['1.0-0']}}s
         </div>
         <div class="status">
           {{phase.measurements | measToPassFail}}
@@ -36,25 +36,30 @@
           </tr>
           <tr *ngFor="let meas of phase.measurements | objectToArray" class="measurement {{phase.measurements | measToPassFail | statusToSuperDark}}">
             <td class="name">{{meas.key}}</td>
-            <td class="validator">{{meas.value.validators | firstEltOrBlank}}</td>
-            <td class="value">{{phase?.measured_values[meas.key] || ''}}</td>
+            <td class="validator">
+              {{meas.value.validators | firstEltOrBlank}}
+            </td>
+            <td class="value">
+              {{meas.value.measured_value || ''}}
+            </td>
             <td class="outcome {{meas.value.outcome | outcomeToColor}}">{{meas.value.outcome}}</td>
           </tr>
         </table>
       </div>
     </div>
   </li>
-  <!-- Running phase from its record. -->
-  <li *ngIf="state?.test?.running_phase_record">
+  <!-- Running phase. -->
+  <li *ngIf="state?.running_phase_state">
     <div class="collapsible-header
                 {{'RUNNING' | statusToColor}}
                 waves-effect waves-light">
       <div class="phase-header-text">
         <div class="name">
-          {{state.test.running_phase_record.name}}
+          {{state.running_phase_state?.name}}
         </div>
         <div class="cycle-time">
-          {{((currentMillis - state.test.running_phase_record.start_time_millis) / 1000) | number:['1.2-2']}}s
+          <!-- Disable this for now, because station_api is giving back zeroes.
+          {{((currentMillis - state.running_phase_state?.start_time_millis) / 1000) | number:['1.0-0']}}s -->
         </div>
         <div class="status">
           RUNNING
@@ -62,7 +67,7 @@
       </div>
     </div>
     <div class="collapsible-body {{'RUNNING' | statusToDark}}">
-      <p *ngIf="state.test.running_phase_record.docstring" class="docstring">{{state.test.running_phase_record.docstring}}</p>
+      <p *ngIf="state?.running_phase_state?.docstring" class="docstring">{{state.running_phase_state.docstring}}</p>
       <div class="measurement-container">
         <table class="measurement-listing white-text">
           <tr class="header-row">
@@ -71,12 +76,13 @@
             <td>value</td>
             <td class="outcome">outcome</td>
           </tr>
-          <tr *ngFor="let meas of state.test.running_phase_record.measurements | objectToArray" class="measurement {{'RUNNING' | statusToSuperDark}}">
+          <tr *ngFor="let meas of state.running_phase_state?.measurements | objectToArray" class="measurement {{'RUNNING' | statusToSuperDark}}">
             <td class="name">{{meas.key}}</td>
-            <td class="validator">{{meas.value.validators | firstEltOrBlank}}</td>
+            <td class="validator">
+              {{meas.value.validators | firstEltOrBlank}}
+            </td>
             <td class="value">
-              <span *ngIf="state?.test?.running_phase_record?.measured_values">   {{state.test.running_phase_record?.measured_values[meas.key] || ''}}
-              </span>
+              {{state.running_phase_state?.measurements[meas.key].measured_value || ''}}
             </td>
             <td class="outcome {{meas.value.outcome | outcomeToColor}}">{{meas.value.outcome}}</td>
           </tr>
@@ -85,7 +91,7 @@
     </div>
   </li>
   <!-- Pending phases from their list. -->
-  <li *ngFor="let phase of state?.test?.pending_phases">
+  <li *ngFor="let phase of state.test_record.pending_phases">
       <div class="collapsible-header {{'PENDING' | statusToColor}} waves-effect waves-light">
       <div class="phase-header-text">
         <div class="name">

--- a/openhtf/io/frontend/src/app/station.testheader.css
+++ b/openhtf/io/frontend/src/app/station.testheader.css
@@ -50,8 +50,8 @@
 
 .test-status-tag {
   display: table-cell;
-  font-size: 30pt;
-  font-weight: 600;
+  font-size: 24pt;
+  font-weight: 500;
   text-align: right;
   vertical-align: middle;
   width: 30%;

--- a/openhtf/io/frontend/src/app/station.testheader.html
+++ b/openhtf/io/frontend/src/app/station.testheader.html
@@ -27,7 +27,7 @@
         <li class="tab">
           <a href="#logs">
             <div class="nav-button">
-              <i class="material-icons">assignment</i>
+              <i class="material-icons">subject</i>
               <div class="nav-label">LOGS</div>
             </div>
           </a>
@@ -45,7 +45,7 @@
     <div class="test-status-tag">
       {{status | simplifyStatus}}
         <div class="duration" *ngIf="startTime">
-          {{(((endTime || currentMillis) - startTime) / 1000 | number:['1.2-2'])}}s
+          {{(((endTime || currentMillis) - startTime) / 1000 | number:['1.0-0'])}}s
         </div>
     </div>
   </div>

--- a/openhtf/io/frontend/src/app/station.testheader.ts
+++ b/openhtf/io/frontend/src/app/station.testheader.ts
@@ -19,6 +19,7 @@ import {
   Component,
   Input,
   OnChanges,
+  OnInit,
   SimpleChange
 } from 'angular2/core';
 
@@ -46,6 +47,17 @@ export class TestHeader implements OnChanges {
   constructor() {
     this.indicatorColorPipe = new StatusToColor();
     this.indicatorStatusPipe = new SimplifyStatus();
+  }
+
+  ngOnInit() {
+    $('.test-content').hide()
+    setTimeout(() => {
+      $('.test-header .tabs').tabs();
+      let status = this.indicatorStatusPipe.transform(this.status);
+      let color_class = this.indicatorColorPipe.transform(status);
+      $('.test-header-nav .indicator').addClass(color_class);
+      $('.test-content').show()
+    }, 100); // Timing hacks to make materialize-css play nice with Angular2.
   }
 
   /**

--- a/openhtf/io/frontend/src/app/styles.css
+++ b/openhtf/io/frontend/src/app/styles.css
@@ -1,16 +1,93 @@
+.big-message {
+  color: #bdbdbd;
+  font-size: 14pt;
+  font-weight: 500;
+  padding-top: 1em;
+  text-align: center;
+}
+
 #content {
-  padding: 10px 0px 0px 0px;
-}
-
-.served_message {
+  padding: 10px 3px 10px 3px;
   font-weight: 300;
+  width: 100%;
 }
 
-.served_stats {
+.iconlabel {
   font-weight: 500;
 }
 
-#served_tag {
+.iconlabel i {
+  vertical-align: middle;
+}
+
+.iconlabel span {
+  vertical-align: middle;
+}
+
+.labelicon {
+  font-weight: 500;
+}
+
+.labelicon i {
+  vertical-align: middle;
+}
+
+.labelicon span {
+  vertical-align: middle;
+}
+
+.navbar {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+}
+
+.navbar i {
+  font-size: 30px;
+}
+
+.navbar .nav-button {
+  margin-top: 10px;
+}
+
+.navbar .nav-button .nav-label {
+  font-size: 8pt;
+  line-height: 1rem;
+}
+
+.navbar .tabs {
+  background: transparent;
+  height: 125%;
+  overflow-x: hidden;
+  overflow-y: visible;
+}
+
+.navbar .tabs .tab {
+  height: 100%;
+}
+
+.navbar .tabs .tab a {
+  color: white;
+  position: relative;
+}
+
+.navbar .tabs .tab a:hover {
+  color: white;
+}
+
+.preloader {
+  margin-top: 80px;
+}
+
+.served-message {
+  font-weight: 300;
+}
+
+.served-stats {
+  font-weight: 500;
+}
+
+#served-tag {
   display: table-cell;
   font-size: 8pt;
   text-align: right;
@@ -23,12 +100,12 @@
   font-weight: 300;
 }
 
-#title_bar {
+#title-bar {
   padding: 3px;
   position: relative;
 }
 
-#title_bar>div {
+#title-bar > div {
   display: table;
   width: 100%;
 }

--- a/openhtf/io/frontend/src/app/vendor.ts
+++ b/openhtf/io/frontend/src/app/vendor.ts
@@ -25,3 +25,4 @@ import 'material-design-icons/iconfont/material-icons.css';
 import 'script!jquery/dist/jquery.min.js';
 import 'script!materialize-css/bin/materialize.js';
 import 'script!fast-json-patch/src/json-patch-duplex.js';
+import 'script!../other_modules/sockjs.min.js';

--- a/openhtf/io/frontend/src/other_modules/get_other_modules.py
+++ b/openhtf/io/frontend/src/other_modules/get_other_modules.py
@@ -1,0 +1,45 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+
+"""One-off script to download third-party deps that don't play well with npm."""
+
+
+import argparse
+import os
+import urllib
+
+TARGETS = [
+    'http://cdn.jsdelivr.net/sockjs/1/sockjs.min.js',  # sockjs
+]
+
+
+def main():
+  """Download all the targets."""
+
+  parser = argparse.ArgumentParser(description='get_other_modules.py',
+                                   prog='python get_other_modules.py')
+  parser.add_argument('--force', action='store_true',
+                      help='Force download even if target files already exist.')
+  args = parser.parse_args()
+
+  for src in TARGETS:
+    filename = src.split('/')[-1].split('#')[0].split('?')[0]
+    dst = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+    if args.force or not os.path.exists(dst):
+      urllib.urlretrieve(src, dst)
+
+
+if __name__ == '__main__':
+  main()

--- a/openhtf/io/frontend/src/package.json
+++ b/openhtf/io/frontend/src/package.json
@@ -2,8 +2,11 @@
   "name": "OpenHTFClient",
   "version": "0.9.0",
   "scripts": {
+    "postinstall": "python ./other_modules/get_other_modules.py",
     "build": "webpack",
+    "prestart": "python ./other_modules/get_other_modules.py",
     "start": "webpack --watch",
+    "get_other_modules": "python ./other_modules/get_other_modules.py --force",
     "update_prebuilt": "cp -r ./dist/* ../prebuilt"
   },
   "license": "Apache-2.0",
@@ -24,16 +27,18 @@
     "script-loader": "~0.7.0"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.13",
+    "angular2": "~2.0.0-beta.13",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.35.0",
-    "reflect-metadata": "0.1.2",
-    "zone.js": "^0.6.6",
+    "fast-json-patch": "~0.5.7",
     "jquery": "~2.2.3",
-    "materialize-css": "~0.97.6",
-    "velocity-animate": "~1.2.3",
-    "material-icons": "~0.1.0",
     "material-design-icons": "~2.2.3",
-    "fast-json-patch": "~0.5.7"
+    "material-icons": "~0.1.0",
+    "materialize-css": "~0.97.6",
+    "reflect-metadata": "0.1.2",
+    "rxjs": "^5.0.0-beta.10",
+    "symbol-observable": "^1.0.1",
+    "velocity-animate": "~1.2.3",
+    "zone.js": "^0.6.6"
   }
 }

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -89,3 +89,17 @@ class NonLocalResult(mutablerecords.Record('NonLocal', [], {'result': None})):
     InnerFunction()
     return x.result
   """
+
+
+class classproperty(object):
+  """Exactly what it sounds like.
+
+  Note that classproperties don't have setters, so setting them will replace
+  the classproperty with the new value. In most use cases (forcing subclasses
+  to override the classproperty, for example) this is desired.
+  """
+  def __init__(self, func):
+    self._func = func
+
+  def __get__(self, instance, owner):
+    return self._func(owner)


### PR DESCRIPTION
  * Implement a pub/sub abstraction in both server and client.
  * Display multiple tests per station (listed one after the other).
  * Pause test display for 15 seconds when the test completes.
  * Small style improvements and updates.
  * Unlock the history tab (still unpopulated as yet, though).