### PR TITLE
Add extra_kwargs to name of phases

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -69,6 +69,7 @@ from enum import Enum
 import mutablerecords
 
 import openhtf
+from openhtf import util
 from openhtf.util import validators
 from openhtf.util import units
 
@@ -203,16 +204,9 @@ class Measurement(  # pylint: disable=no-init
 
   def with_args(self, **kwargs):
     """Creates a new Measurement, see openhtf.PhaseInfo.with_args."""
-    new_meas = mutablerecords.CopyRecord(self)
-    if '{' in new_meas.name:
-      formatter = lambda x: x.format(**kwargs) if x else x
-    else:
-      # str % {'a': 1} is harmless if str doesn't use any interpolation.
-      # .format is as well, but % is more likely to be used in other contexts.
-      formatter = lambda x: x % kwargs if x else x
-    new_meas.name = formatter(self.name)
-    new_meas.docstring = formatter(self.docstring)
-    return new_meas
+    return mutablerecords.CopyRecord(
+        self, name=util.format_string(self.name, **kwargs),
+        docstring=util.format_string(self.docstring, **kwargs))
 
   def __getattr__(self, attr):  # pylint: disable=invalid-name
     """Support our default set of validators as direct attributes."""

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -27,6 +27,7 @@ import os
 import shutil
 import tempfile
 
+from openhtf import util
 from openhtf.util import data
 
 
@@ -76,20 +77,10 @@ class OutputToFile(object):
   @contextlib.contextmanager
   def open_output_file(self, test_record):
     """Open file based on pattern."""
-    output_file = None
     record_dict = data.convert_to_base_types(test_record)
-    if isinstance(self.filename_pattern, basestring):
-      if '{' in self.filename_pattern:
-        output_file = self.open_file(
-            self.filename_pattern.format(**record_dict))
-      elif '%' in self.filename_pattern:
-        raise ValueError(
-            '%-style filename patterns deprecated, use .format() syntax')
-      else:
-        output_file = self.open_file(self.filename_pattern)
-    elif callable(self.filename_pattern):
-      output_file = self.open_file(self.filename_pattern(record_dict))
-    if output_file:
+    pattern = self.filename_pattern
+    if isinstance(pattern, basestring) or callable(pattern):
+      output_file = self.open_file(util.format_string(pattern, **record_dict))
       try:
         yield output_file
       finally:

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -104,3 +104,27 @@ class classproperty(object):
 
   def __get__(self, instance, owner):
     return self._func(owner)
+
+
+def format_string(target, **kwargs):
+  """Formats a string in any of three ways (or not at all).
+
+  Args:
+    target: The target string to format. This can be a function that takes a
+        dict as its only argument, a string with {}- or %-based formatting, or
+        a basic string with none of those. In the latter case, the string is
+        returned as-is, but in all other cases the string is formatted (or the
+        callback called) with the given kwargs.
+        If this is None (or otherwise falsey), it is returned immediately.
+    **kwargs: The arguments to use for formatting.
+        Passed to string.format, %, or target if it's callable.
+  """
+  if not target:
+    return target
+  if callable(target):
+    return target(kwargs)
+  if '{' in target:
+    return target.format(**kwargs)
+  if '%' in target:
+    return target % kwargs
+  return target

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ build.sub_commands.insert(0, ('build_proto', None))
 INSTALL_REQUIRES = [
     'contextlib2==0.5.1',
     'enum34==1.1.2',
-    'mutablerecords==0.3.0',
+    'mutablerecords==0.4.1',
     'oauth2client==1.5.2',
     'protobuf==2.6.1',
     'pyaml==15.3.1',

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -29,6 +29,7 @@ def normal_test_phase(test):
   return 'return value'
 
 
+@openhtf.PhaseOptions(name='func-name({input[0]})')
 def extra_arg_func(input=None):
   return input
 
@@ -62,9 +63,13 @@ class TestPhaseDescriptor(unittest.TestCase):
       phase = phase.with_args(input='input arg')
       result = phase(self._phase_data)
       self.assertEqual('input arg', result)
+      self.assertEqual('func-name(i)', phase.name)
 
-      second_phase = phase.with_args(input='second input')
+      # Must do with_args() on the original phase, otherwise it has already been
+      # formatted and the format-arg information is lost.
+      second_phase = extra_arg_func.with_args(input='second input')
       first_result = phase(self._phase_data)
       second_result = second_phase(self._phase_data)
       self.assertEqual('input arg', first_result)
       self.assertEqual('second input', second_result)
+      self.assertEqual('func-name(s)', second_phase.name)


### PR DESCRIPTION
This makes the name of phases include their args, so if you repeat a phase multiple times with different arguments, the output (and frontend) is much more useful.

This will likely conflict with Joe's reorg-the-world PR, so feel free to get that in then I'll fix this afterward. I just want to get feedback on the idea ahead of time