### PR TITLE
Allow the station_api.ApiServer to be started multiple times in the same process

### DIFF
--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -807,16 +807,20 @@ class ApiServer(threading.Thread):
 
 # Singleton instances.
 STATION_API = StationApi()
-API_SERVER = ApiServer()
+API_SERVER = None
 
 def start_server():
-  if not API_SERVER.isAlive() and (conf.station_api_port or
+  global API_SERVER
+  if API_SERVER is None and (conf.station_api_port or
       conf.enable_station_discovery):
     _LOG.debug('Starting Station API server on port %s (discovery %sabled).',
                conf.station_api_port and int(conf.station_api_port),
                'en' if conf.enable_station_discovery else 'dis')
+    API_SERVER = ApiServer()
     API_SERVER.start()
 
 def stop_server():
+  global API_SERVER
   _LOG.debug('Stopping Station API server.')
   API_SERVER.stop()
+  API_SERVER = None


### PR DESCRIPTION
This fixes the bug seen by @wallacbe 