### PR TITLE
Skip handling new plugs when the state goes away

### DIFF
--- a/openhtf/output/web_gui/__init__.py
+++ b/openhtf/output/web_gui/__init__.py
@@ -368,6 +368,9 @@ class WebGuiServer(tornado.web.Application):
     This handler updates our URL handlers with any newly available plug
     information and notifies the StationPubSub of the event.
     """
+    if state is None:
+      return
+
     def _make_sockjs_url(rel_url):
       """SockJS URL is /plugs/<host>/<port>/<test_uid>/<plug_name>"""
       return r'/plugs/%s/%s/%s/%s' % (hostport + (test_uid, rel_url))


### PR DESCRIPTION
This is triggered when the station is killed while the frontend is waiting for an update.