### PR TITLE
Support for string formatting of name and docstring when using with_plugs

### DIFF
--- a/examples/with_plugs.py
+++ b/examples/with_plugs.py
@@ -76,9 +76,9 @@ class PingDnsA(PingPlug):
 class PingDnsB(PingPlug):
   host = '8.8.4.4'
 
-@htf.PhaseOptions(name='Ping-{pinger.host}-$count')
+@htf.PhaseOptions(name='Ping-{pinger.host}-{count}')
 @plugs.plug(pinger=PingPlug.placeholder)
-@htf.measures('total_time_{pinger.host}_$count', 'retcode')
+@htf.measures('total_time_{pinger.host}_{count}', 'retcode')
 def test_ping(test, pinger, count):
   """This tests that we can ping a host.
 

--- a/examples/with_plugs.py
+++ b/examples/with_plugs.py
@@ -76,9 +76,9 @@ class PingDnsA(PingPlug):
 class PingDnsB(PingPlug):
   host = '8.8.4.4'
 
-
+@htf.PhaseOptions(name='Ping-{pinger.host}-$count')
 @plugs.plug(pinger=PingPlug.placeholder)
-@htf.measures('total_time', 'retcode')
+@htf.measures('total_time_{pinger.host}_$count', 'retcode')
 def test_ping(test, pinger, count):
   """This tests that we can ping a host.
 
@@ -88,7 +88,7 @@ def test_ping(test, pinger, count):
   start = time.time()
   retcode = pinger.run(count)
   elapsed = time.time() - start
-  test.measurements.total_time = elapsed
+  test.measurements['total_time_%s_%s' % (pinger.host, count)] = elapsed
   test.measurements.retcode = retcode
 
 
@@ -103,8 +103,8 @@ if __name__ == '__main__':
     PingDnsB,
   ]
 
-  test = htf.Test(
-      *(test_ping.with_plugs(pinger=plug) for plug in ping_plugs))
+  test = htf.Test(*(test_ping.with_plugs(pinger=plug).with_args(count=2)
+                    for plug in ping_plugs))
 
   # Unlike hello_world.py, where we prompt for a DUT ID, here we'll just
   # use an arbitrary one.

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -303,8 +303,8 @@ class PhaseOptions(mutablerecords.Record('PhaseOptions', [], {
   """Options used to override default test phase behaviors.
 
   Attributes:
-    name: Override for the name of the phase. Can be formatted in many different
-        formats defined in util.format_string.
+    name: Override for the name of the phase. Can be formatted in several
+        different ways as defined in util.format_string.
     timeout_s: Timeout to use for the phase, in seconds.
     run_if: Callback that decides whether to run the phase or not.
     requires_state: If True, pass the whole TestState into the first argument,

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -303,8 +303,8 @@ class PhaseOptions(mutablerecords.Record('PhaseOptions', [], {
   """Options used to override default test phase behaviors.
 
   Attributes:
-    name: Override for the name of the phase. Can be formatted similar to
-        measurements using with_args() to distinguish multiple similar phases.
+    name: Override for the name of the phase. Can be formatted in many different
+        formats defined in util.format_string.
     timeout_s: Timeout to use for the phase, in seconds.
     run_if: Callback that decides whether to run the phase or not.
     requires_state: If True, pass the whole TestState into the first argument,
@@ -322,7 +322,8 @@ class PhaseOptions(mutablerecords.Record('PhaseOptions', [], {
       pass
   """
 
-  def with_args(self, **kwargs):
+  def format_strings(self, **kwargs):
+    """String substitution of name."""
     return mutablerecords.CopyRecord(
         self, name=util.format_string(self.name, **kwargs))
 
@@ -399,9 +400,9 @@ class PhaseDescriptor(mutablerecords.Record(
     # Make a copy so we can have multiple of the same phase with different args
     # in the same test.
     new_info = mutablerecords.CopyRecord(self)
-    new_info.options = new_info.options.with_args(**kwargs)
+    new_info.options = new_info.options.format_strings(**kwargs)
     new_info.extra_kwargs.update(kwargs)
-    new_info.measurements = [m.with_args(**kwargs) for m in self.measurements]
+    new_info.measurements = [m.format_strings(**kwargs) for m in self.measurements]
     return new_info
 
   def with_plugs(self, **subplugs):
@@ -418,7 +419,13 @@ class PhaseDescriptor(mutablerecords.Record(
             'Could not find valid placeholder for substitute plug %s '
             'required for phase %s' % (name, self.name))
       new_plugs[name] = mutablerecords.CopyRecord(original_plug, cls=sub_class)
-    return mutablerecords.CopyRecord(self, plugs=new_plugs.values())
+
+    return mutablerecords.CopyRecord(
+        self,
+        plugs=new_plugs.values(),
+        options=self.options.format_strings(**kwargs),
+        measurements=[m.format_strings(**kwargs) for m in self.measurements])
+
 
   def __call__(self, test_state):
     """Invoke this Phase, passing in the appropriate args.

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -423,8 +423,8 @@ class PhaseDescriptor(mutablerecords.Record(
     return mutablerecords.CopyRecord(
         self,
         plugs=new_plugs.values(),
-        options=self.options.format_strings(**kwargs),
-        measurements=[m.format_strings(**kwargs) for m in self.measurements])
+        options=self.options.format_strings(**subplugs),
+        measurements=[m.format_strings(**subplugs) for m in self.measurements])
 
 
   def __call__(self, test_state):

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -202,8 +202,8 @@ class Measurement(  # pylint: disable=no-init
     self.validators.append(validator)
     return self
 
-  def with_args(self, **kwargs):
-    """Creates a new Measurement, see openhtf.PhaseInfo.with_args."""
+  def format_strings(self, **kwargs):
+    """String substitution for names and docstrings."""
     return mutablerecords.CopyRecord(
         self, name=util.format_string(self.name, **kwargs),
         docstring=util.format_string(self.docstring, **kwargs))

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -108,7 +108,7 @@ class classproperty(object):
     return self._func(owner)
 
 
-def safe_format(target, **kwargs):
+def partial_format(target, **kwargs):
   """Formats a string without requiring all values to be present.
 
   This function allows substitutions to be gradually made in several steps
@@ -144,7 +144,7 @@ def format_string(target, **kwargs):
   if callable(target):
     return target(kwargs)
   if '{' in target:
-    return safe_format(target, **kwargs)
+    return partial_format(target, **kwargs)
   if '%' in target:
     return target % kwargs
   return target

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -109,7 +109,15 @@ class classproperty(object):
 def format_string_safe_substitute(target, **kwargs):
   """Formats string with Template.safe_substitute so calls can be chained."""
   t = Template(target)
-  return t.safe_substitute(**kwargs)
+  res = t.safe_substitute(**kwargs)
+
+  # also run through string.format
+  try:
+    return res.format(**kwargs)
+  except KeyError:
+    pass
+
+  return res
 
 def format_string(target, **kwargs):
   """Formats a string in any of four ways (or not at all).

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -16,6 +16,7 @@
 """One-off utilities."""
 
 import logging
+import re
 import time
 from datetime import datetime
 from pkg_resources import get_distribution, DistributionNotFound
@@ -106,41 +107,44 @@ class classproperty(object):
   def __get__(self, instance, owner):
     return self._func(owner)
 
-def format_string_safe_substitute(target, **kwargs):
-  """Formats string with Template.safe_substitute so calls can be chained."""
-  t = Template(target)
-  res = t.safe_substitute(**kwargs)
 
-  # also run through string.format
-  try:
-    return res.format(**kwargs)
-  except KeyError:
-    pass
+def safe_format(target, **kwargs):
+  """Formats a string without requiring all values to be present.
 
-  return res
+  This function allows substitutions to be gradually made in several steps
+  rather than all at once.  Similar to string.Template.safe_substitute.
+  """
+  output = target[:]
+  tags = dict(re.findall(r'(\{(.*?)\})', target))
+
+  for tag, var in re.findall(r'(\{(.*?)\})', output):
+    root = var.split('.')[0]  # dot notation
+    root = root.split('[')[0]  # dict notation
+    if root in kwargs:
+      output = output.replace(tag, tag.format(**{root: kwargs[root]}))
+
+  return output
 
 def format_string(target, **kwargs):
-  """Formats a string in any of four ways (or not at all).
+  """Formats a string in any of three ways (or not at all).
 
   Args:
     target: The target string to format. This can be a function that takes a
-        dict as its only argument, a string with $- {}- or %-based formatting,
+        dict as its only argument, a string with {}- or %-based formatting,
         or a basic string with none of those. In the latter case, the string is
         returned as-is, but in all other cases the string is formatted (or the
         callback called) with the given kwargs.
         If this is None (or otherwise falsey), it is returned immediately.
     **kwargs: The arguments to use for formatting.
-        Passed to Template.safe_substitue string.format, %, or target if it's
+        Passed to safe_format, %, or target if it's
         callable.
   """
   if not target:
     return target
   if callable(target):
     return target(kwargs)
-  if '$' in target:
-    return format_string_safe_substitute(target, **kwargs)
   if '{' in target:
-    return target.format(**kwargs)
+    return safe_format(target, **kwargs)
   if '%' in target:
     return target % kwargs
   return target

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -130,8 +130,8 @@ def format_string(target, **kwargs):
 
   Args:
     target: The target string to format. This can be a function that takes a
-        dict as its only argument, a string with {}- or %-based formatting,
-        or a basic string with none of those. In the latter case, the string is
+        dict as its only argument, a string with {}- or %-based formatting, or
+        a basic string with none of those. In the latter case, the string is
         returned as-is, but in all other cases the string is formatted (or the
         callback called) with the given kwargs.
         If this is None (or otherwise falsey), it is returned immediately.

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -90,6 +90,7 @@ class TestPhaseDescriptor(unittest.TestCase):
       phase = extra_plug_func.with_plugs(plug=ExtraPlug).with_args(phrase='hello')
       self.assertIs(phase.func, extra_plug_func.func)
       self.assertEqual(1, len(phase.plugs))
+      self.assertEqual('extra_plug_func[extra_plug_0][hello]', phase.options.name)
       self.assertEqual('extra_plug_func[extra_plug_0][hello]', phase.name)
 
       result = phase(self._phase_data)

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -40,7 +40,7 @@ class ExtraPlug(plugs.BasePlug):
   def echo(self, phrase):
     return '%s says %s' % (self.name, phrase)
 
-@openhtf.PhaseOptions(name='extra_plug_func[$plug][$arg]')
+@openhtf.PhaseOptions(name='extra_plug_func[{plug.name}][$arg]')
 @plugs.plug(plug=ExtraPlug.placeholder)
 def extra_plug_func(plug, arg):
   return plug.echo(arg)

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -87,7 +87,7 @@ class TestPhaseDescriptor(unittest.TestCase):
       self.assertEqual('func-name(s)', second_phase.name)
 
   def test_with_plugs(self):
-      phase = extra_plug_func.with_plugs(ExtraPlug).with_args(phrase='hello')
+      phase = extra_plug_func.with_plugs(plug=ExtraPlug).with_args(phrase='hello')
       self.assertIs(phase.func, extra_plug_func.func)
       self.assertEqual(1, len(phase.plugs))
       self.assertEqual('extra_plug_func[extra_plug_0][hello]', phase.name)

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -87,6 +87,9 @@ class TestPhaseDescriptor(unittest.TestCase):
       self.assertEqual('func-name(s)', second_phase.name)
 
   def test_with_plugs(self):
+      self._phase_data.provide_plugs.return_value = {
+          'plug': ExtraPlug(),
+      }
       phase = extra_plug_func.with_plugs(plug=ExtraPlug).with_args(phrase='hello')
       self.assertIs(phase.func, extra_plug_func.func)
       self.assertEqual(1, len(phase.plugs))

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -87,8 +87,8 @@ class TestPhaseDescriptor(unittest.TestCase):
       self.assertEqual('func-name(s)', second_phase.name)
 
   def test_with_plugs(self):
-      phase = phase.with_plugs(ExtraPlug).with_args(phrase='hello')
-      self.assertIs(phase.func, extra_plug_func)
+      phase = extra_plug_func.with_plugs(ExtraPlug).with_args(phrase='hello')
+      self.assertIs(phase.func, extra_plug_func.func)
       self.assertEqual(1, len(phase.plugs))
       self.assertEqual('extra_plug_func[extra_plug_0][hello]', phase.name)
 

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -87,7 +87,7 @@ class TestPhaseDescriptor(unittest.TestCase):
       self.assertEqual('func-name(s)', second_phase.name)
 
   def test_with_plugs(self):
-      self._phase_data.provide_plugs.return_value = {
+      self._phase_data.plug_manager.provide_plugs.return_value = {
           'plug': ExtraPlug(),
       }
       phase = extra_plug_func.with_plugs(plug=ExtraPlug).with_args(phrase='hello')

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -87,7 +87,7 @@ class TestPhaseDescriptor(unittest.TestCase):
       self.assertEqual('func-name(s)', second_phase.name)
 
   def test_with_plugs(self):
-      self._phase_data.plug_manager.provide_plugs.return_value = {
+      self._phase_data.plug_manager.return_value.provide_plugs.return_value = {
           'plug': ExtraPlug(),
       }
       phase = extra_plug_func.with_plugs(plug=ExtraPlug).with_args(phrase='hello')

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -42,8 +42,8 @@ class ExtraPlug(plugs.BasePlug):
 
 @openhtf.PhaseOptions(name='extra_plug_func[{plug.name}][{phrase}]')
 @plugs.plug(plug=ExtraPlug.placeholder)
-def extra_plug_func(plug, arg):
-  return plug.echo(arg)
+def extra_plug_func(plug, phrase):
+  return plug.echo(phrase)
 
 
 class TestPhaseDescriptor(unittest.TestCase):
@@ -95,4 +95,4 @@ class TestPhaseDescriptor(unittest.TestCase):
       self.assertEqual('extra_plug_func[extra_plug_0][hello]', phase.name)
 
       result = phase(self._phase_data)
-      self.assertEqual('extra_plug_0 says hello', second_result)
+      self.assertEqual('extra_plug_0 says hello', result)

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -40,7 +40,7 @@ class ExtraPlug(plugs.BasePlug):
   def echo(self, phrase):
     return '%s says %s' % (self.name, phrase)
 
-@openhtf.PhaseOptions(name='extra_plug_func[{plug.name}][$arg]')
+@openhtf.PhaseOptions(name='extra_plug_func[{plug.name}][{phrase}]')
 @plugs.plug(plug=ExtraPlug.placeholder)
 def extra_plug_func(plug, arg):
   return plug.echo(arg)

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -87,9 +87,7 @@ class TestPhaseDescriptor(unittest.TestCase):
       self.assertEqual('func-name(s)', second_phase.name)
 
   def test_with_plugs(self):
-      self._phase_data.plug_manager.return_value.provide_plugs.return_value = {
-          'plug': ExtraPlug(),
-      }
+      self._phase_data.plug_manager.initialize_plugs([ExtraPlug])
       phase = extra_plug_func.with_plugs(plug=ExtraPlug).with_args(phrase='hello')
       self.assertIs(phase.func, extra_plug_func.func)
       self.assertEqual(1, len(phase.plugs))

--- a/test/util/util_test.py
+++ b/test/util/util_test.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import time
+
+import copy
 import mock
+import time
+import unittest
 
 from openhtf import util
 from openhtf.util import timeouts
@@ -45,10 +47,12 @@ class TestUtil(unittest.TestCase):
     self.polledtimeout.expire()
     self.assertTrue(self.polledtimeout.has_expired())
 
-  def test_safe_format(self):
-    text = ('Apples are {apple[color]} and {apple[taste]}. '
+  def test_partial_format(self):
+    original = ('Apples are {apple[color]} and {apple[taste]}. '
         'Pears are {pear.color} and {pear.taste}. '
         'Oranges are {orange_color} and {orange_taste}.')
+    text = copy.copy(original)
+
     apple = {
         'color': 'red',
         'taste': 'sweet',
@@ -60,15 +64,15 @@ class TestUtil(unittest.TestCase):
     pear = Pear()
 
     # Partial formatting
-    res = util.safe_format(text, apple=apple)
-    res = util.safe_format(res, pear=pear)
+    res = util.partial_format(text, apple=apple)
+    res = util.partial_format(res, pear=pear)
     self.assertEqual('Apples are red and sweet. Pears are green and tart. '
       'Oranges are {orange_color} and {orange_taste}.', res)
 
     # Format rest of string
-    res = util.safe_format(res, orange_color='orange', orange_taste='sour')
+    res = util.partial_format(res, orange_color='orange', orange_taste='sour')
     self.assertEqual('Apples are red and sweet. Pears are green and tart. '
       'Oranges are orange and sour.', res)
 
     #  The original text has not changed
-    self.assertNotEqual(text, res)
+    self.assertEqual(original, text)

--- a/test/util/util_test.py
+++ b/test/util/util_test.py
@@ -71,4 +71,4 @@ class TestUtil(unittest.TestCase):
       'Oranges are orange and sour.', res)
 
     #  The original text has not changed
-    self.assertNotEqual(text, res)ß
+    self.assertNotEqual(text, res)

--- a/test/util/util_test.py
+++ b/test/util/util_test.py
@@ -16,8 +16,9 @@ import unittest
 import time
 import mock
 
-
+from openhtf import util
 from openhtf.util import timeouts
+
 
 class TestUtil(unittest.TestCase):
 
@@ -43,3 +44,31 @@ class TestUtil(unittest.TestCase):
   def test_time_expired_true(self):
     self.polledtimeout.expire()
     self.assertTrue(self.polledtimeout.has_expired())
+
+  def test_safe_format(self):
+    text = ('Apples are {apple[color]} and {apple[taste]}. '
+        'Pears are {pear.color} and {pear.taste}. '
+        'Oranges are {orange_color} and {orange_taste}.')
+    apple = {
+        'color': 'red',
+        'taste': 'sweet',
+    }
+
+    class Pear(object):
+      color = 'green'
+      taste = 'tart'
+    pear = Pear()
+
+    # Partial formatting
+    res = util.safe_format(text, apple=apple)
+    res = util.safe_format(res, pear=pear)
+    self.assertEqual('Apples are red and sweet. Pears are green and tart. '
+      'Oranges are {orange_color} and {orange_taste}.', res)
+
+    # Format rest of string
+    res = util.safe_format(res, orange_color='orange', orange_taste='sour')
+    self.assertEqual('Apples are red and sweet. Pears are green and tart. '
+      'Oranges are orange and sour.', res)
+
+    #  The original text has not changed
+    self.assertNotEqual(text, res)ß


### PR DESCRIPTION
I realized that passing variables to `PhaseOptions.name`, `Measurement.name` and `Measurement.docstring` for string formatting was not supported by with_plugs.

The previous implementation of `PhaseDescriptor.with_args` also assumed that all necessary variables would be present when it called otherwise string.format raises a KeyError.

Changes: 
* `safe_format` in util that allows partial substitution of variables into the template string, similar to [string.Template.safe_substitute](https://docs.python.org/2/library/string.html#string.Template.safe_substitute).
* Renamed method names on `PhaseOptions` and `Measurement` from `with_args` -> `format_strings`.  Reason: I didn't want to call `with_args` from within `with_plugs` and all these two methods were doing were string formatting so `with_args` was a misnomer.
* Added unit test for with_plugs
* Updated examples/with_plugs.py