### PR TITLE
Fix bug when prompt is none (#456)

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -114,6 +114,8 @@ class UserInput(plugs.BasePlug):
 
   def _asdict(self):
     """Return a dict representation of the current prompt."""
+    if self._prompt is None:
+      return None
     return {'id': self._prompt.id.hex,
             'message': self._prompt.message,
             'text-input': self._prompt.text_input}


### PR DESCRIPTION
See #456 for the repro steps for the bug.

Note: This took me a while to debug the first time I ran into it. Take a look at the stack trace in the screenshot referenced by #456—it's hard to tell where the error really occurred. Is there something we can do to better surface bugs in RPC calls?