### PR TITLE
Move converting of test_start into a phase

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -234,19 +234,8 @@ class Test(object):
       self._test_desc.metadata['config'] = conf._asdict()
       self.last_run_time_millis = util.time_millis()
 
-      if isinstance(test_start, LambdaType):
-        @TestPhase()
-        def trigger_phase(test):
-          test.test_record.dut_id = test_start()
-        trigger = trigger_phase
-      else:
-        trigger = test_start
-
-      if conf.capture_source:
-        trigger.code_info = test_record.CodeInfo.for_function(trigger.func)
-
       self._executor = core.TestExecutor(
-          self._test_desc, trigger, self._test_options.teardown_function)
+          self._test_desc, test_start, self._test_options.teardown_function)
       _LOG.info('Executing test: %s', self.descriptor.code_info.name)
       self._executor.start()
 

--- a/openhtf/core/__init__.py
+++ b/openhtf/core/__init__.py
@@ -112,7 +112,8 @@ class TestExecutor(threads.KillableThread):
     """Handles one whole test from start to finish."""
     with contextlib.ExitStack() as exit_stack:
       # Top level steps required to run a single iteration of the Test.
-      self.test_state = test_state.TestState(self._test_descriptor)
+      self.test_state = test_state.TestState.from_test_descriptor(
+          self._test_descriptor)
       executor = phase_executor.PhaseExecutor(self.test_state)
 
       # Any access to self._exit_stack must be done while holding this lock.

--- a/openhtf/core/__init__.py
+++ b/openhtf/core/__init__.py
@@ -58,9 +58,9 @@ class TestExecutor(threads.KillableThread):
     if not isinstance(test_start, openhtf.PhaseDescriptor):
       @openhtf.TestPhase()
       def trigger_phase(test):
-        test.dut_id = test_start_function()
+        test.dut_id = test_start()
     else:
-      trigger_phase = test_start_function
+      trigger_phase = test_start
 
     self._test_start = _sanitize_to_phase(
         trigger_phase, default_timeout_s=60*60*24*365)

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -94,17 +94,23 @@ class TestState(util.SubscribableStateMixin):
   """
   Status = Enum('Status', ['WAITING_FOR_TEST_START', 'RUNNING', 'COMPLETED'])
 
-  def __init__(self, test_desc):
-    super(TestState, self).__init__()
-    self._status = self.Status.WAITING_FOR_TEST_START
-
-    self.test_record = test_record.TestRecord(
+  @classmethod
+  def from_test_descriptor(cls, test_desc):
+    test_record_obj = test_record.TestRecord(
         dut_id=None, station_id=conf.station_id, code_info=test_desc.code_info,
         # Copy metadata so we don't modify test_desc.
         metadata=copy.deepcopy(test_desc.metadata))
-    self.logger = logs.initialize_record_logger(
-        test_desc.uid, self.test_record, self.notify_update)
-    self.plug_manager = plugs.PlugManager(test_desc.plug_types, self.logger)
+    subscription = Subscribable()
+    logger = logs.initialize_record_logger(
+        test_desc.uid, test_record_obj, subscription.notify)
+    plug_manager = plugs.PlugManager(test_desc.plug_types, logger)
+    return cls(test_record_obj, logger, plug_manager, subscription)
+
+  def __init__(self, test_record_obj, logger, plug_manager, subscription):
+    self._status = self.Status.WAITING_FOR_TEST_START
+    self.test_record = test_record_obj
+    self.logger = logger
+    self.plug_manager = plug_manager
     self.running_phase_state = None
     self.user_defined_state = {}
 
@@ -125,7 +131,7 @@ class TestState(util.SubscribableStateMixin):
                 running_phase_state.attachments,
                 running_phase_state.attach,
                 running_phase_state.attach_from_file,
-                self.notify_update))
+                self.subscription.notify))
 
   @contextlib.contextmanager
   def running_phase_context(self, phase_desc):
@@ -140,10 +146,10 @@ class TestState(util.SubscribableStateMixin):
     """
     assert not self.running_phase_state, 'Phase already running!'
     self.running_phase_state = PhaseState.from_descriptor(
-        phase_desc, self.notify_update)
+        phase_desc, self.subscription.notify)
     try:
       with self.running_phase_state.record_timing_context:
-        self.notify_update()  # New phase started.
+        self.subscription.notify()  # New phase started.
         yield self.running_phase_state
     finally:
       # Clear notification callbacks so we can serialize measurements.
@@ -151,7 +157,7 @@ class TestState(util.SubscribableStateMixin):
         meas.set_notification_callback(None)
       self.test_record.phases.append(self.running_phase_state.phase_record)
       self.running_phase_state = None
-      self.notify_update()  # Phase finished.
+      self.subscription.notify()  # Phase finished.
 
   def _asdict(self):
     """Return a dict representation of the test's state."""
@@ -160,6 +166,17 @@ class TestState(util.SubscribableStateMixin):
         'plugs': self.plug_manager._asdict(),
         'running_phase_state': self.running_phase_state,
     }
+
+  @threads.synchronized
+  def asdict_with_event(self):
+    """Get a dict representation of this test's state and an update event.
+
+    The event returned is guaranteed to be set if an update has been triggered
+    since the returned dict was generated.
+
+    Returns: dict-representation, update-event
+    """
+    return self._asdict(), self.subscription.subscribe()
 
   @property
   def is_finalized(self):
@@ -219,13 +236,13 @@ class TestState(util.SubscribableStateMixin):
     # Blow up instead of blowing away a previously set start_time_millis.
     assert self.test_record.start_time_millis is 0
     self.test_record.start_time_millis = util.time_millis()
-    self.notify_update()
+    self.subscription.notify()
 
   def set_status_running(self):
     """Mark the test as actually running, can't be done once finalized."""
     assert self._status == self.Status.WAITING_FOR_TEST_START
     self._status = self.Status.RUNNING
-    self.notify_update()
+    self.subscription.notify()
 
   def finalize(self, test_outcome=None):
     """Mark the state as finished.
@@ -271,7 +288,7 @@ class TestState(util.SubscribableStateMixin):
     self.logger.handlers = []
     self.test_record.end_time_millis = util.time_millis()
     self._status = self.Status.COMPLETED
-    self.notify_update()
+    self.subscription.notify()
 
   def __str__(self):
     return '<%s: %s@%s Running Phase: %s>' % (

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -29,7 +29,6 @@ import copy
 import logging
 import socket
 import threading
-import weakref
 
 import mimetypes
 from enum import Enum

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -15,13 +15,13 @@
 
 """One-off utilities."""
 
+from datetime import datetime
 import logging
+from pkg_resources import get_distribution, DistributionNotFound
 import re
 import threading
 import time
 import weakref
-from datetime import datetime
-from pkg_resources import get_distribution, DistributionNotFound
 
 import mutablerecords
 

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -164,14 +164,12 @@ class SubscribableStateMixin(object):
 
   def __init__(self):
     super(SubscribableStateMixin, self).__init__()
-    self._lock = threading.Lock()  # Used by threads.synchronized.
-    self._update_events = weakref.WeakSet()
+    self._subscribable = Subscribable()
 
   def _asdict(self):
     raise NotImplementedError(
         'Subclasses of SubscribableStateMixin must implement _asdict.')
 
-  @threads.synchronized
   def asdict_with_event(self):
     """Get a dict representation of this object and an update event.
 
@@ -180,13 +178,29 @@ class SubscribableStateMixin(object):
       update_event: An event that is guaranteed to be set if an update has been
           triggered since the returned dict was generated.
     """
-    event = threading.Event()
-    self._update_events.add(event)
-    return self._asdict(), event
+    return self._asdict(), self._subscribable.subscribe()
 
-  @threads.synchronized
   def notify_update(self):
     """Notify any update events that there was an update."""
-    for event in self._update_events:
-      event.set()
-    self._update_events.clear()
+    self._subscribable.notify()
+
+
+class Subscribable(object):
+  """This allows notifications/callbacks to propagate to other threads."""
+
+  def __init__(self):
+    self._events = weakref.WeakSet()
+    self._lock = threading.Lock()
+
+  def subscribe(self):
+    event = threading.Event()
+    with self._lock:
+      self._events.add(event)
+    return event
+
+  def notify(self):
+    with self._lock:
+      for event in self._events:
+        event.set()
+      self._events.clear()
+

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -176,8 +176,9 @@ class PhaseOrTestIterator(collections.Iterator):
     # Cobble together a fake TestState to pass to the test phase.
     with mock.patch(
         'openhtf.plugs.PlugManager', new=lambda _, __: self.plug_manager):
-      test_state_ = test_state.TestState(openhtf.TestDescriptor(
-          'Unittest:StubTest:UID', (phase_desc,), phase_desc.code_info, {}))
+      test_state_ = test_state.TestState.from_test_descriptor(
+          openhtf.TestDescriptor(
+              'Unittest:StubTest:UID', (phase_desc,), phase_desc.code_info, {}))
       test_state_.mark_test_started()
 
     # Actually execute the phase, saving the result in our return value.


### PR DESCRIPTION
Also makes TestState's constructor simpler via a 'named constructor', and pulls out the subscription logic into a separate class.