### PR TITLE
Fix visual bug in frontend navs when window is large

### DIFF
--- a/openhtf/output/web_gui/prebuilt/styles.css
+++ b/openhtf/output/web_gui/prebuilt/styles.css
@@ -56,6 +56,7 @@
 }
 
 .navbar .tabs {
+  display: flex;
   background: transparent;
   height: 125%;
   overflow-x: hidden;
@@ -63,6 +64,7 @@
 }
 
 .navbar .tabs .tab {
+  flex-grow: 1;
   height: 100%;
 }
 

--- a/openhtf/output/web_gui/prebuilt/styles/station.testheader.css
+++ b/openhtf/output/web_gui/prebuilt/styles/station.testheader.css
@@ -33,6 +33,7 @@
 }
 
 .test-header-nav .tabs {
+  display: flex;
   background: transparent;
   height: 130%;
   overflow-x: hidden;
@@ -40,10 +41,12 @@
 }
 
 .test-header-nav .tabs .tab {
+  flex-grow: 1;
   height: 100%;
 }
 
 .test-header-nav .tabs .tab a {
+  padding: 0;
   color: white;
   position: relative;
 }

--- a/openhtf/output/web_gui/src/app/station.testheader.css
+++ b/openhtf/output/web_gui/src/app/station.testheader.css
@@ -33,6 +33,7 @@
 }
 
 .test-header-nav .tabs {
+  display: flex;
   background: transparent;
   height: 130%;
   overflow-x: hidden;
@@ -40,10 +41,12 @@
 }
 
 .test-header-nav .tabs .tab {
+  flex-grow: 1;
   height: 100%;
 }
 
 .test-header-nav .tabs .tab a {
+  padding: 0;
   color: white;
   position: relative;
 }

--- a/openhtf/output/web_gui/src/app/styles.css
+++ b/openhtf/output/web_gui/src/app/styles.css
@@ -56,6 +56,7 @@
 }
 
 .navbar .tabs {
+  display: flex;
   background: transparent;
   height: 125%;
   overflow-x: hidden;
@@ -63,6 +64,7 @@
 }
 
 .navbar .tabs .tab {
+  flex-grow: 1;
   height: 100%;
 }
 


### PR DESCRIPTION
This bug seems to go back at least as far as #411 (c9845da229d93e1ad46fce47b3f0fc68e0bc7c60 on master) but didn't surface until #460 because `prebuilt/` wasn't up to date. I can't tell when or where it happened but I think it might have to do with changes that happened at some point to materialize-css.

**Before**

![screen shot 2016-11-30 at 4 27 04 pm](https://cloud.githubusercontent.com/assets/3301218/20777285/d31f0a1c-b71a-11e6-9874-e129ab5a8d21.png)

**After**

![screen shot 2016-11-30 at 4 26 37 pm](https://cloud.githubusercontent.com/assets/3301218/20777287/d9f668a8-b71a-11e6-8a7c-76c5d010b1e3.png)

**Note that there is a pre-existing visual bug when the window is small:**

![screen shot 2016-11-30 at 4 31 28 pm](https://cloud.githubusercontent.com/assets/3301218/20777278/ccaa28e2-b71a-11e6-9dcc-c0e0d54cff49.png)
