### PR TITLE
Add RemotePhaseDescriptor to provide remote access to phase descriptors.

### DIFF
--- a/contrib/poll_stations.py
+++ b/contrib/poll_stations.py
@@ -64,6 +64,13 @@ def phase_to_str(phase):
 
 def print_test(remote_test):
   print(' |-- %s' % (remote_test,))
+  phase_descriptors = remote_test.phase_descriptors
+  if phase_descriptors:
+    print(' |    |-- RemoteTest PhaseDescriptors:')
+    for desc in phase_descriptors:
+      print(' |    |    |-- Name: %s, Doc (summary): %s' % (
+          desc.name, desc.doc and desc.doc.splitlines()[0]))
+    print(' |    |')
   remote_state = remote_test.cached_state
   if remote_state:
     print(' |    |-- RemoteTest State:')

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -138,10 +138,10 @@ class Test(object):
     station_api.start_server()
 
   @classmethod
-  def state_by_uid(cls, test_uid):
-    """Get TestState of a test by UID.
+  def from_uid(cls, test_uid):
+    """Get Test by UID.
 
-    Returns: TestState of currently running test, given by test_uid.
+    Returns: Test object, given by UID.
 
     Raises:
       UnrecognizedTestUidError: If the test_uid is not recognized.
@@ -149,7 +149,7 @@ class Test(object):
     test = cls.TEST_INSTANCES.get(test_uid)
     if not test:
       raise UnrecognizedTestUidError('Test UID %s not recognized' % test_uid)
-    return test.state
+    return test
 
   @property
   def uid(self):

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -428,6 +428,14 @@ class PhaseDescriptor(mutablerecords.Record(
     retval.options.update(**options)
     return retval
 
+  def _asdict(self):
+    asdict = {
+        key: data.convert_to_base_types(getattr(self, key), ignore_keys=('cls',))
+        for key in self.optional_attributes
+    }
+    asdict.update(name=self.name, doc=self.doc)
+    return asdict
+
   @property
   def name(self):
     return self.options.name or self.func.__name__
@@ -497,6 +505,15 @@ class PhaseDescriptor(mutablerecords.Record(
           test_state if self.options.requires_state else test_state.test_api,
           **kwargs)
     return self.func(**kwargs)
+
+
+class RemotePhaseDescriptor(mutablerecords.Record('RemotePhaseDescriptor', [
+    'name', 'doc'], PhaseDescriptor.optional_attributes)):
+  """Representation of a PhaseDescriptor on a remote test (see station_api).
+
+  This is static information attached to a RemoteTest.  It's defined here to
+  avoid a circular dependency with station_api.
+  """
 
 
 class TestApi(collections.namedtuple('TestApi', [

--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -644,7 +644,7 @@ class StationApi(object):
           it's not in use or it's not frontend-aware.
     """
     _LOG.debug('RPC:wait_for_plug_update(timeout_s=%s)', timeout_s)
-    test_state = openhtf.Test.from_uid(test_uid)
+    test_state = openhtf.Test.from_uid(test_uid).state
     if test_state is None:
       raise TestNotRunningError('Test %s is not running.' % test_uid)
     return test_state.plug_manager.wait_for_plug_update(
@@ -768,7 +768,7 @@ class StationApi(object):
   def get_frontend_aware_plug_names(self, test_uid):
     """Returns the names of frontend-aware plugs."""
     _LOG.debug('RPC:get_frontend_aware_plug_names()')
-    state = openhtf.Test.from_uid(test_uid)
+    state = openhtf.Test.from_uid(test_uid).state
     if state is None:
       return
     return state.plug_manager.get_frontend_aware_plug_names()


### PR DESCRIPTION
This is required to support display of pending phases in the frontend.