### PR TITLE
Add an explicit Equals validator for non-basic types

### DIFF
--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -121,8 +121,25 @@ class Validators(object):
   def equals(self, value):
     if isinstance(value, self.modules['numbers'].Number):
       return self.InRange(minimum=value, maximum=value)
-    else:
+    elif isinstance(value, basestring):
       return self._matches_regex(self.modules['re'].escape(value))
+    else:
+      return self.Equals(value)
+    
+  class Equals(object):
+    """Validator to verify an object is equal to the expected value."""
+    
+    def __init__(self, expected):
+      self.expected = expected
+      
+    def __call__(self, value):
+      return value == self.expected
+    
+    def __str__(self):
+      return "'x' is equal to '%s'" % self.expected
+    
+    def __eq__(self, other):
+      return isinstance(other, type(self)) and self.expected == other.expected
 
   class RegexMatcher(object):
     """Validator to verify a string value matches a regex."""


### PR DESCRIPTION
This allows equality checks to be done for measurements that aren't strings or integers. My use-case is a list of button presses that I want to verify are done in the right order. I could create N measurements and fill them all in, or just 1 measurement and put a list in directly.