### PR TITLE
Do not re-initialize PlugManager's XML-RPC server

### DIFF
--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -38,16 +38,16 @@ This API is based around the following hierarchy of abstractions:
       +------------------------------------------------------------------+
 
 A station discovery mechanism is implemented to provide multicast-based
-discovery of OpenHTF Stations possible.  To discover stations, use the
-Station.discover_stations() method:
+discovery of OpenHTF Stations.  To discover stations, use the Station.discover()
+method:
 
-  for station in Station.discover_stations():
+  for station in Station.discover():
     print 'Found station:', station
 
 This iterator yields Station instances, which contain the necessary
 information to connect to the station via XML-RPC to obtain more details:
 
-  for station in Station.discover_stations():
+  for station in Station.discover():
     print 'Found station "%s", with tests:' % station.station_id
     for test in station.tests.itervalues():
       print '  %s' % test.test_name  # test is a RemoteTest object.


### PR DESCRIPTION
This PR changes PlugManager so that it reuses its RPC server instead of shutting it down when initialize_plugs is called a second time. This addresses the first problem described in https://github.com/google/openhtf/issues/479#issuecomment-271060500.

This partially addresses #479 to the extent that `all_the_things.py` and other tests that use a test start and prompts should *usually* run as expected with the caveat that there is a race condition described in #483. Tests with more complicated front-end plug use would expect more serious problems.
