### PR TITLE
Fix reference to matches_regex in validators.py

### DIFF
--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -124,7 +124,7 @@ class Validators(object):
     if isinstance(value, self.modules['numbers'].Number):
       return self.InRange(minimum=value, maximum=value)
     elif isinstance(value, basestring):
-      return self._matches_regex(self.modules['re'].escape(value))
+      return self.matches_regex(self.modules['re'].escape(value))
     else:
       return self.Equals(value)
     


### PR DESCRIPTION
This method was renamed matches_regex, but references to _matches_regex still existed.