### PR TITLE
Remove a Condition.wait(None) from user_input

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -189,7 +189,10 @@ class UserInput(plugs.FrontendAwareBasePlug):
     """Waits for and returns the user's response to the last prompt."""
     with self._cond:
       if self._prompt:
-        self._cond.wait(timeout_s)
+        if timeout_s is None:
+          self._cond.wait(3600 * 24 * 365)
+        else:
+          self._cond.wait(timeout_s)
       if self._response is None:
         raise PromptUnansweredError
       return self._response


### PR DESCRIPTION
It turns out, the kryptonite to KillableThread is a thread waiting on a Condition with a timeout of None. If the current phase (such as a test_start trigger, or any user phase) is waiting on a Condition because of user_input.UserInput, then it'll never exit until the prompt is answered.

Part of a series of incoming PRs to address OpenHTF 1.0's lack of a proper exit-on-Ctrl-C setup