### PR TITLE
Don't stop server if API_SERVER never started.

### DIFF
--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -851,6 +851,7 @@ def start_server():
 
 def stop_server():
   global API_SERVER
-  _LOG.debug('Stopping Station API server.')
-  API_SERVER.stop()
-  API_SERVER = None
+  if API_SERVER is not None:
+     _LOG.debug('Stopping Station API server.')
+     API_SERVER.stop()
+     API_SERVER = None


### PR DESCRIPTION
You get a traceback when you ctrl-c out of a process that imports (even indirectly) openhtf.