### PR TITLE
Also log plug init exceptions to the test record.

### DIFF
--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -852,8 +852,8 @@ def start_server():
 def stop_server():
   global API_SERVER
   if API_SERVER is not None:
-     _LOG.debug('Stopping Station API server.')
-     API_SERVER.stop()
+    _LOG.debug('Stopping Station API server.')
+    API_SERVER.stop()
     _LOG.debug('Stopped Station API server.')
-     API_SERVER = None
+    API_SERVER = None
 

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -482,7 +482,11 @@ class PlugManager(object):
           # Now the instance has its own copy of the test logger.
           plug_instance.logger = self._logger
       except Exception:  # pylint: disable=broad-except
-        _LOG.error('Exception instantiating plug type %s', plug_type)
+        _LOG.error('Exception instantiating plug type %s', plug_type,
+                   exc_info=True)
+        # Also log to the test record.
+        self._logger.error('Exception instantiating plug type %s', plug_type,
+                           exc_info=True)
         self.tear_down_plugs()
         raise
       self.update_plug(plug_type, plug_instance)

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -482,11 +482,7 @@ class PlugManager(object):
           # Now the instance has its own copy of the test logger.
           plug_instance.logger = self._logger
       except Exception:  # pylint: disable=broad-except
-        _LOG.error('Exception instantiating plug type %s', plug_type,
-                   exc_info=True)
-        # Also log to the test record.
-        self._logger.error('Exception instantiating plug type %s', plug_type,
-                           exc_info=True)
+        self._logger.exception('Exception instantiating plug type %s', plug_type)
         self.tear_down_plugs()
         raise
       self.update_plug(plug_type, plug_instance)

--- a/test/plugs_test.py
+++ b/test/plugs_test.py
@@ -15,6 +15,7 @@
 import threading
 import time
 
+import mock
 import openhtf
 
 from openhtf import plugs
@@ -62,7 +63,7 @@ class TearDownRaisesPlug2(plugs.BasePlug):
 class PlugsTest(test.TestCase):
 
   def setUp(self):
-    self.logger = object()
+    self.logger = mock.MagicMock()
     self.plug_manager = plugs.PlugManager({AdderPlug}, self.logger)
     AdderPlug.INSTANCE_COUNT = 0
 


### PR DESCRIPTION
Fixes #492.

Also:
  * Fixes a bug in station_api.py that was causing unit tests to fail.
  * Replaces the object() logger in plugs_test.py with a MagicMock.