### PR TITLE
Make PhaseState._asdict return a non-zero start_time_millis

### DIFF
--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -51,7 +51,7 @@ class Attachment(collections.namedtuple('Attachment', 'data mimetype')):
 class TestRecord(  # pylint: disable=no-init
     mutablerecords.Record(
         'TestRecord', ['dut_id', 'station_id'],
-        {'start_time_millis': None, 'end_time_millis': None,
+        {'start_time_millis': int, 'end_time_millis': None,
          'outcome': None, 'outcome_details': list,
          'code_info': None,
          'metadata': dict,
@@ -72,7 +72,7 @@ class PhaseRecord(  # pylint: disable=no-init
     mutablerecords.Record(
         'PhaseRecord', ['name', 'codeinfo'],
         {'measurements': None,
-         'start_time_millis': None, 'end_time_millis': None,
+         'start_time_millis': int, 'end_time_millis': None,
          'attachments': dict, 'result': None})):
   """The record of a single run of a phase.
 

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -305,7 +305,7 @@ class PhaseState(mutablerecords.Record('PhaseState', [
   def _asdict(self):
     return {
         'name': self.name, 'codeinfo': self.phase_record.codeinfo,
-        'start_time_millis': 0, # long(self.phase_record.start_time_millis),
+        'start_time_millis': long(self.phase_record.start_time_millis),
         # We only serialize attachment hashes, they can be large.
         'attachments': {
             name: attachment.sha1 for name, attachment in

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -217,7 +217,7 @@ class TestState(util.SubscribableStateMixin):
   def mark_test_started(self):
     """Set the TestRecord's start_time_millis field."""
     # Blow up instead of blowing away a previously set start_time_millis.
-    assert self.test_record.start_time_millis is None
+    assert self.test_record.start_time_millis is 0
     self.test_record.start_time_millis = util.time_millis()
     self.notify_update()
 


### PR DESCRIPTION
This makes the frontend show the right start time for the phase