### PR TITLE
Alter the RemotePlug management to accept the latest connection instead of only caching them

### DIFF
--- a/openhtf/output/web_gui/__init__.py
+++ b/openhtf/output/web_gui/__init__.py
@@ -414,6 +414,7 @@ class WebGuiServer(tornado.web.Application):
         self.set_status(500)
         self.write('Plug "%s" not found in "%s"' % (
             self.request.path, self._plugs.keys()))
+        return
       try:
         response = plug.respond(self.request.body)
       except Exception as e:  # pylint: disable=broad-except
@@ -460,9 +461,10 @@ class WebGuiServer(tornado.web.Application):
     if not plugs_port:
       return
 
-    # Update the plugs we're interacting with. The PlugManager we're interacting
-    # with may have gone and come back since the last update, so we have to
-    # open a new connection each time to avoid getting an update
+    # Update the plugs we're interacting with. On each state update, we open new
+    # connections to the XML-RPC server via RemotePlug.discover because the
+    # PlugManager we're interacting with may have gone and come back since the
+    # last update.
     self.remote_plugs.update({
         (hostport.host, hostport.port, test_uid, plug_name): handler
         for plug_name, handler

--- a/openhtf/output/web_gui/__init__.py
+++ b/openhtf/output/web_gui/__init__.py
@@ -404,9 +404,8 @@ class WebGuiServer(tornado.web.Application):
     def initialize(self, remote_plugs):
       self._plugs = remote_plugs
 
-    def post(self):
-      host, port_str, test_uid, plug_name = self.request.path.split('/')[2:]
-      plug = self._plugs.get((host, int(port_str), test_uid, plug_name))
+    def post(self, host, port, test_uid, plug_name):
+      plug = self._plugs.get((host, int(port), test_uid, plug_name))
       if plug is None:
         self.set_status(500)
         self.write('Plug "%s" not found in "%s"' % (
@@ -436,7 +435,9 @@ class WebGuiServer(tornado.web.Application):
         (r'/', self.MainHandler, {'port': http_port}),
         (r'/station/(?:\d{1,3}\.){3}\d{1,3}/(?:\d{1,5})/?',
          self.MainHandler, {'port': http_port}),
-        (r'/plugs/.*', self.PlugsHandler, {'remote_plugs': self.remote_plugs}),
+        (r'/plugs/(?P<host>[\d\.]+)/(?P<port>\d+)/(?P<test_uid>.+)/'
+         '(?P<plug_name>.+)', self.PlugsHandler,
+         {'remote_plugs': self.remote_plugs}),
         (r'/(.*\..*)', tornado.web.StaticFileHandler, {'path': frontend_path}),
     ] + dash_router.urls + station_router.urls
     super(WebGuiServer, self).__init__(

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -245,12 +245,6 @@ class RemotePlug(xmlrpcutil.TimeoutProxyServer):
 
       return json.dumps(result)
 
-    def _write_error(self, message):
-      """Helper that returns an HTTP 500 error and logs the error details."""
-      _LOG.warning('%s: %s', message, self.request.body, exc_info=True)
-      self.set_status(500)
-      self.write('RemotePlug error: %s.' % message)
-
   def __init__(self, host, port, plug_name):
     super(RemotePlug, self).__init__('http://%s:%s' % (host, port))
     self.plug_name = plug_name

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -223,29 +223,27 @@ class RemotePlug(xmlrpcutil.TimeoutProxyServer):
   in use by a remotely running OpenHTF test.
   """
 
-  class RemotePlugHandler(tornado.web.RequestHandler):
-    """Handles HTTP POST requests directed at remote plugs."""
+  class RemotePlugHandler(object):
+    """Handles requests directed at remote plugs."""
 
-    def initialize(self, remote_plug):
+    def __init__(self, remote_plug):
       self.remote_plug = remote_plug
 
-    def post(self):
+    def respond(self, request):
       """Called when we receive a JSON message from a frontend client."""
       try:
-        data = json.loads(self.request.body)
+        data = json.loads(request)
         method = data['method']
         args = data['args']
       except (KeyError, ValueError):
-        self._write_error('Malformed JSON request')
-        return
+        raise ValueError('Malformed JSON request')
 
       try:
         result = getattr(self.remote_plug, method)(*args)
       except (AttributeError, TypeError, ValueError):
-        self._write_error('Error in RPC request')
-        return
+        raise Exception('Error in RPC request')
 
-      self.write(json.dumps(result))
+      return json.dumps(result)
 
     def _write_error(self, message):
       """Helper that returns an HTTP 500 error and logs the error details."""
@@ -314,7 +312,7 @@ class RemotePlug(xmlrpcutil.TimeoutProxyServer):
       if plug_name not in seen:
         seen.add(plug_name)
         remote_plug = cls(host, port, plug_name)
-        yield (plug_name, cls.RemotePlugHandler, {'remote_plug': remote_plug})
+        yield (plug_name, cls.RemotePlugHandler(remote_plug))
 
 
 def plug(update_kwargs=True, **plugs):


### PR DESCRIPTION
This is because the remote PlugManager may go away and come back between test state updates, but everything stay the same, such as when the test is being looped within the same process.