### PR TITLE
Frontend-aware plugs must enable remote access

### DIFF
--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -214,6 +214,7 @@ class FrontendAwareBasePlug(BasePlug, util.SubscribableStateMixin):
   Since the Station API runs in a separate thread, the _asdict() method of
   frontend-aware plugs should be written with thread safety in mind.
   """
+  enable_remote = True
 
 
 class RemotePlug(xmlrpcutil.TimeoutProxyServer):

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -123,7 +123,6 @@ class ConsolePrompt(threading.Thread):
 
 class UserInput(plugs.FrontendAwareBasePlug):
   """Get user input from inside test phases."""
-  enable_remote = True
 
   def __init__(self):
     super(UserInput, self).__init__()


### PR DESCRIPTION
Otherwise, what's the point of being frontend-aware? Just exposing your data, but not your API?