### PR TITLE
Change the test UID into an execution UID

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -28,6 +28,7 @@ import socket
 import sys
 import textwrap
 import threading
+import uuid
 import weakref
 from types import LambdaType
 
@@ -107,7 +108,7 @@ class Test(object):
     self._lock = threading.Lock()
     self._executor = None
     self._test_desc = TestDescriptor(
-        self.uid, phases, test_record.CodeInfo.uncaptured(), metadata)
+        phases, test_record.CodeInfo.uncaptured(), metadata)
 
     if conf.capture_source:
       # First, we copy the phases with the real CodeInfo for them.
@@ -132,7 +133,7 @@ class Test(object):
     else:
       self.configure()
 
-    self.TEST_INSTANCES[self.uid] = self
+    self._increment_next_uid()
     # This is a noop if the server is already running, otherwise start it now
     # that we have at least one Test instance.
     station_api.start_server()
@@ -151,15 +152,18 @@ class Test(object):
       raise UnrecognizedTestUidError('Test UID %s not recognized' % test_uid)
     return test
 
-  @property
-  def uid(self):
-    """Return a unique identifier for this Test instance.
+  def get_current_or_next_uid(self):
+    if self._executor is not None:
+      return self._executor.uid
+    return self._uid
 
-    Note that this identifier must be unique across Python invokations, so the
-    station_api UID is used as a prefix to guarantee that.  Test UID's need not
-    be unique across different hosts.
+  def _increment_next_uid(self):
+    """Increments the next execution's UID.
+
+    This identifier must be unique across invocations of execute() to
+    differentiate between different runs of the same test.
     """
-    return '%s:%s' % (station_api.STATION_API.UID, id(self))
+    self._uid = '%s:%s' % (station_api.STATION_API.UID, uuid.uuid4().hex)
 
   @property
   def descriptor(self):
@@ -246,10 +250,12 @@ class Test(object):
         trigger.code_info = test_record.CodeInfo.for_function(trigger.func)
 
       self._executor = core.TestExecutor(
-          self._test_desc, trigger, self._test_options.teardown_function)
+          self._test_desc, self.get_current_or_next_uid(), trigger,
+          self._test_options.teardown_function)
       _LOG.info('Executing test: %s', self.descriptor.code_info.name)
+      self._increment_next_uid()
+      self.TEST_INSTANCES[self._executor.uid] = self
       self._executor.start()
-
 
     try:
       self._executor.wait()
@@ -259,14 +265,16 @@ class Test(object):
 
         _LOG.debug('Test completed for %s, saving to history and outputting.',
                    final_state.test_record.metadata['test_name'])
-        for output_cb in (self._test_options.output_callbacks +
-                          [functools.partial(history.append_record, self.uid)]):
+        for output_cb in (
+            self._test_options.output_callbacks +
+            [functools.partial(history.append_record, self._executor.uid)]):
           try:
             output_cb(final_state.test_record)
           except Exception:  # pylint: disable=broad-except
             _LOG.exception(
                 'Output callback %s raised; continuing anyway', output_cb)
       finally:
+        del self.TEST_INSTANCES[self._executor.uid]
         self._executor = None
 
     return final_state.test_record.outcome == test_record.Outcome.PASS
@@ -288,23 +296,22 @@ class TestOptions(mutablerecords.Record('TestOptions', [], {
 
 
 class TestDescriptor(collections.namedtuple(
-    'TestDescriptor', ['uid', 'phases', 'code_info', 'metadata'])):
+    'TestDescriptor', ['phases', 'code_info', 'metadata'])):
   """An object that represents the reusable portions of an OpenHTF test.
 
   This object encapsulates the static test information that is set once and used
   by the framework along the way.
 
   Attributes:
-    uid: Test UID for this Test.
     phases: The phases to execute for this Test.
     metadata: Any metadata that should be associated with test records.
     code_info: Information about the module that created the Test.
   """
 
-  def __new__(cls, uid, phases, code_info, metadata):
+  def __new__(cls, phases, code_info, metadata):
     phases = [PhaseDescriptor.wrap_or_copy(phase) for phase in phases]
     return super(TestDescriptor, cls).__new__(
-        cls, uid, phases, code_info, metadata)
+        cls, phases, code_info, metadata)
 
   @property
   def plug_types(self):

--- a/openhtf/core/__init__.py
+++ b/openhtf/core/__init__.py
@@ -27,6 +27,7 @@ import openhtf
 from openhtf import plugs
 from openhtf import util
 from openhtf.core import phase_executor
+from openhtf.core import station_api
 from openhtf.core import test_record
 from openhtf.core import test_state
 from openhtf.util import conf
@@ -50,7 +51,8 @@ class TestStopError(Exception):
 class TestExecutor(threads.KillableThread):
   """Encompasses the execution of a single test."""
 
-  def __init__(self, test_descriptor, test_start, teardown_function=None):
+  def __init__(self, test_descriptor, execution_uid, test_start,
+               teardown_function=None):
     super(TestExecutor, self).__init__(name='TestExecutorThread')
     self.test_state = None
 
@@ -70,6 +72,7 @@ class TestExecutor(threads.KillableThread):
     self._test_start = test_start
     self._lock = threading.Lock()
     self._exit_stack = None
+    self.uid = execution_uid
 
   def stop(self):
     """Stop this test."""
@@ -109,7 +112,7 @@ class TestExecutor(threads.KillableThread):
     """Handles one whole test from start to finish."""
     with contextlib.ExitStack() as exit_stack:
       # Top level steps required to run a single iteration of the Test.
-      self.test_state = test_state.TestState(self._test_descriptor)
+      self.test_state = test_state.TestState(self._test_descriptor, self.uid)
       executor = phase_executor.PhaseExecutor(self.test_state)
 
       # Any access to self._exit_stack must be done while holding this lock.

--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -562,7 +562,7 @@ class StationApi(object):
       List of RemoteTest tuple values (as a dict).
     """
     retval = [{
-        'test_uid': test.uid,
+        'test_uid': test.get_current_or_next_uid(),
         'test_name': test.get_option('name'),
         'created_time_millis': long(test.created_time_millis),
         'last_run_time_millis':

--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -559,15 +559,16 @@ class StationApi(object):
     station_api performance to degrade; don't do that.
 
     Returns:
-      List of RemoteTest tuple values (as a dict).
+      List of RemoteTest tuple values (as a dict). Only currently-executing
+      tests are returned.
     """
     retval = [{
-        'test_uid': test.get_current_or_next_uid(),
+        'test_uid': test.uid,
         'test_name': test.get_option('name'),
         'created_time_millis': long(test.created_time_millis),
         'last_run_time_millis':
             test.last_run_time_millis and long(test.last_run_time_millis),
-    } for test in openhtf.Test.TEST_INSTANCES.values()]
+    } for test in openhtf.Test.TEST_INSTANCES.values() if test.uid is not None]
     _LOG.debug('RPC:list_tests() -> %s results', len(retval))
     return retval
 

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -94,7 +94,7 @@ class TestState(util.SubscribableStateMixin):
   """
   Status = Enum('Status', ['WAITING_FOR_TEST_START', 'RUNNING', 'COMPLETED'])
 
-  def __init__(self, test_desc):
+  def __init__(self, test_desc, test_uid):
     super(TestState, self).__init__()
     self._status = self.Status.WAITING_FOR_TEST_START
 
@@ -103,7 +103,7 @@ class TestState(util.SubscribableStateMixin):
         # Copy metadata so we don't modify test_desc.
         metadata=copy.deepcopy(test_desc.metadata))
     self.logger = logs.initialize_record_logger(
-        test_desc.uid, self.test_record, self.notify_update)
+        test_uid, self.test_record, self.notify_update)
     self.plug_manager = plugs.PlugManager(test_desc.plug_types, self.logger)
     self.running_phase_state = None
     self.user_defined_state = {}

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -94,7 +94,7 @@ class TestState(util.SubscribableStateMixin):
   """
   Status = Enum('Status', ['WAITING_FOR_TEST_START', 'RUNNING', 'COMPLETED'])
 
-  def __init__(self, test_desc, test_uid):
+  def __init__(self, test_desc, execution_uid):
     super(TestState, self).__init__()
     self._status = self.Status.WAITING_FOR_TEST_START
 
@@ -103,7 +103,7 @@ class TestState(util.SubscribableStateMixin):
         # Copy metadata so we don't modify test_desc.
         metadata=copy.deepcopy(test_desc.metadata))
     self.logger = logs.initialize_record_logger(
-        test_uid, self.test_record, self.notify_update)
+        execution_uid, self.test_record, self.notify_update)
     self.plug_manager = plugs.PlugManager(test_desc.plug_types, self.logger)
     self.running_phase_state = None
     self.user_defined_state = {}

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -177,7 +177,7 @@ class PhaseOrTestIterator(collections.Iterator):
     with mock.patch(
         'openhtf.plugs.PlugManager', new=lambda _, __: self.plug_manager):
       test_state_ = test_state.TestState(openhtf.TestDescriptor(
-          'Unittest:StubTest:UID', (phase_desc,), phase_desc.code_info, {}), '')
+          (phase_desc,), phase_desc.code_info, {}), 'Unittest:StubTest:UID')
       test_state_.mark_test_started()
 
     # Actually execute the phase, saving the result in our return value.

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -177,7 +177,7 @@ class PhaseOrTestIterator(collections.Iterator):
     with mock.patch(
         'openhtf.plugs.PlugManager', new=lambda _, __: self.plug_manager):
       test_state_ = test_state.TestState(openhtf.TestDescriptor(
-          'Unittest:StubTest:UID', (phase_desc,), phase_desc.code_info, {}))
+          'Unittest:StubTest:UID', (phase_desc,), phase_desc.code_info, {}), '')
       test_state_.mark_test_started()
 
     # Actually execute the phase, saving the result in our return value.

--- a/test/core/measurements_test.py
+++ b/test/core/measurements_test.py
@@ -34,7 +34,7 @@ from openhtf.util import units
 
 # Fields that are considered 'volatile' for record comparison.
 _VOLATILE_FIELDS = {'start_time_millis', 'end_time_millis', 'timestamp_millis',
-                    'lineno'}
+                    'lineno', 'codeinfo', 'code_info'}
 
 RECORD_FILENAME = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'measurements_record.pickle')
@@ -103,7 +103,6 @@ class TestMeasurements(unittest.TestCase):
     result = util.NonLocalResult()
     def _save_result(test_record):
       result.result = test_record
-    htf.Test.uid = 'UNITTEST:MOCK:UID'
     test = htf.Test(hello_phase, again_phase, lots_of_measurements,
                     measure_seconds, measure_dimensions, inline_phase)
 
@@ -111,6 +110,7 @@ class TestMeasurements(unittest.TestCase):
       test.add_output_callbacks(callbacks.OutputToFile(RECORD_FILENAME))
     else:
       test.add_output_callbacks(_save_result)
+    test.make_uid = lambda: 'UNITTEST:MOCK:UID'
     test.execute(test_start=lambda: 'TestDUT')
     if not self.UPDATE_OUTPUT:
       data.assert_records_equal_nonvolatile(


### PR DESCRIPTION
This allows the frontend to track executions between loops and not
poison its cache nor history's cache.