### PR TITLE
Do not pickle the TestRecord in the station API

### DIFF
--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -62,7 +62,6 @@ in this module.
 """
 
 import collections
-import cPickle as pickle
 import functools
 import json
 import logging
@@ -755,7 +754,7 @@ class StationApi(object):
         state._asdict(), remote_state_dict['test_record'])
 
   def get_history_after(self, test_uid, start_time_millis):
-    """Get a list of pickled TestRecords for test_uid from the History."""
+    """Get a list of TestRecords for test_uid from the History."""
     _LOG.debug('RPC:get_history_after(%s)', start_time_millis)
     # TODO(madsci): We really should pull attachments out of band here.
     return [data.convert_to_base_types(test_record)


### PR DESCRIPTION
The TestRecord may include things that the tester binary knows about,
such as numpy arrays (as measurement data, for instance), but that the
frontend doesn't (it may be built in a different virtualenv). In these
scenarios, the frontend cannot unpickle a TestRecord, so we first
convert to basic data types in order to avoid such problems.