### PR TITLE
Fastboot, ADB Plugs: Forward attributes to devices

### DIFF
--- a/openhtf/plugs/usb/__init__.py
+++ b/openhtf/plugs/usb/__init__.py
@@ -86,32 +86,48 @@ def _open_usb_handle(**kwargs):
 class FastbootPlug(plugs.BasePlug):
   """Plug that provides fastboot."""
 
-  def __new__(cls):
-    device = fastboot_device.FastbootDevice.connect(
+  def __init__(self):
+    self._device = fastboot_device.FastbootDevice.connect(
         _open_usb_handle(
             interface_class=fastboot_device.CLASS,
             interface_subclass=fastboot_device.SUBCLASS,
             interface_protocol=fastboot_device.PROTOCOL))
-    device.tearDown = device.close  # pylint: disable=invalid-name
-    return device
+
+  def tearDown(self):
+    self._device.close()
+
+  def __getattr__(self, attr):
+    """Forward other attributes to the device."""
+    # Use the class version of logger.
+    if attr == 'logger':
+      return self.__getattribute__(attr)
+    return getattr(self._device, attr)
 
 
 class AdbPlug(plugs.BasePlug):
   """Plug that provides ADB."""
 
-  def __new__(cls):
+  def __init__(self):
     kwargs = {}
     if conf.libusb_rsa_key:
       kwargs['rsa_keys'] = [adb_device.M2CryptoSigner(conf.libusb_rsa_key)]
 
-    device = adb_device.AdbDevice.connect(
+    self._device = adb_device.AdbDevice.connect(
         _open_usb_handle(
             interface_class=adb_device.CLASS,
             interface_subclass=adb_device.SUBCLASS,
             interface_protocol=adb_device.PROTOCOL),
         **kwargs)
-    device.tearDown = device.close  # pylint: disable=invalid-name
-    return device
+
+  def tearDown(self):
+    self._device.close()
+
+  def __getattr__(self, attr):
+    """Forward other attributes to the device."""
+    # Use the class version of logger.
+    if attr == 'logger':
+      return self.__getattribute__(attr)
+    return getattr(self._device, attr)
 
 
 class AndroidTriggers(object):  # pylint: disable=invalid-name

--- a/openhtf/plugs/usb/__init__.py
+++ b/openhtf/plugs/usb/__init__.py
@@ -98,9 +98,6 @@ class FastbootPlug(plugs.BasePlug):
 
   def __getattr__(self, attr):
     """Forward other attributes to the device."""
-    # Use the class version of logger.
-    if attr == 'logger':
-      return self.__getattribute__(attr)
     return getattr(self._device, attr)
 
 
@@ -124,9 +121,6 @@ class AdbPlug(plugs.BasePlug):
 
   def __getattr__(self, attr):
     """Forward other attributes to the device."""
-    # Use the class version of logger.
-    if attr == 'logger':
-      return self.__getattribute__(attr)
     return getattr(self._device, attr)
 
 


### PR DESCRIPTION
Rather than construct a fake BasePlug for the FastbootPlug and AdbPlug classes, construct a device member and forward all attributes there.  This allows the plugs to be used with the new logger checks enforced by the PlugManager.