### PR TITLE
Ensure take_at_least_n_seconds never sleeps a negative amount

### DIFF
--- a/openhtf/util/timeouts.py
+++ b/openhtf/util/timeouts.py
@@ -88,7 +88,7 @@ class PolledTimeout(object):
     """Returns True if the timeout has expired."""
     if self.timeout_s is None:
       return False
-    return self.seconds > self.timeout_s
+    return self.seconds >= self.timeout_s
 
   # Bad API. alusco is sometimes bad at naming.
   Poll = has_expired  # pylint: disable=invalid-name

--- a/openhtf/util/timeouts.py
+++ b/openhtf/util/timeouts.py
@@ -369,7 +369,9 @@ def take_at_least_n_seconds(time_s):
   timeout = PolledTimeout(time_s)
   yield
   while not timeout.has_expired():
-    time.sleep(timeout.remaining)
+    # We max() against 0 to ensure we don't pass a (slightly) negative number
+    # in the race between .has_expired() being True and .remaining going negative.
+    time.sleep(max(0, timeout.remaining))
 
 
 def take_at_most_n_seconds(time_s, func, *args, **kwargs):


### PR DESCRIPTION
`time.sleep()` can raise an `IOError` when given a negative number