### PR TITLE
Don't collide kwargs when formatting names, etc.

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -375,7 +375,7 @@ class PhaseOptions(mutablerecords.Record('PhaseOptions', [], {
   def format_strings(self, **kwargs):
     """String substitution of name."""
     return mutablerecords.CopyRecord(
-        self, name=util.format_string(self.name, **kwargs))
+        self, name=util.format_string(self.name, kwargs))
 
   def update(self, **kwargs):
     for key, value in kwargs.iteritems():

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -205,8 +205,8 @@ class Measurement(  # pylint: disable=no-init
   def format_strings(self, **kwargs):
     """String substitution for names and docstrings."""
     return mutablerecords.CopyRecord(
-        self, name=util.format_string(self.name, **kwargs),
-        docstring=util.format_string(self.docstring, **kwargs))
+        self, name=util.format_string(self.name, kwargs),
+        docstring=util.format_string(self.docstring, kwargs))
 
   def __getattr__(self, attr):  # pylint: disable=invalid-name
     """Support our default set of validators as direct attributes."""

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -82,7 +82,7 @@ class OutputToFile(object):
         test_record, ignore_keys=('code_info', 'phases', 'log_records'))
     pattern = self.filename_pattern
     if isinstance(pattern, basestring) or callable(pattern):
-      output_file = self.open_file(util.format_string(pattern, **record_dict))
+      output_file = self.open_file(util.format_string(pattern, record_dict))
       try:
         yield output_file
       finally:

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -127,7 +127,7 @@ def partial_format(target, **kwargs):
 
   return output
 
-def format_string(target, **kwargs):
+def format_string(target, kwargs):
   """Formats a string in any of three ways (or not at all).
 
   Args:
@@ -137,7 +137,7 @@ def format_string(target, **kwargs):
         returned as-is, but in all other cases the string is formatted (or the
         callback called) with the given kwargs.
         If this is None (or otherwise falsey), it is returned immediately.
-    **kwargs: The arguments to use for formatting.
+    kwargs: The arguments to use for formatting.
         Passed to safe_format, %, or target if it's
         callable.
   """


### PR DESCRIPTION
This allows phases to accept a plug or argument by the name 'target',
which was previously colliding with the argument 'target' in
`util.format_string`