### PR TITLE
Return prompt ID from UserInput.start_prompt

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -153,6 +153,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
 
     self._console_prompt.start()
     self.notify_update()
+    return prompt_id
 
   def _remove_prompt(self):
     """Ends the prompt."""
@@ -184,7 +185,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
     with self._cond:
       if self._prompt:
         raise MultiplePromptsError
-      self._create_prompt(message, text_input)
+      return self._create_prompt(message, text_input)
 
   def wait_for_prompt(self, timeout_s=None):
     """Waits for and returns the user's response to the last prompt."""


### PR DESCRIPTION
This allows non-interactive prompts to be created:

```py
@htf.plugs(user=user_input.UserInput)
def ShowPromptForASecond(user):
  prompt_id = user.start_prompt(message='Hey Operator!')
  time.sleep(1)
  user.respond(prompt_id, 'ignored')
```

The other option is to make `remove_prompt()` public