### PR TITLE
Make UserInput._remove_prompt public

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -154,7 +154,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
     self._console_prompt.start()
     self.notify_update()
 
-  def _remove_prompt(self):
+  def remove_prompt(self):
     """Ends the prompt."""
     self._prompt = None
     self._console_prompt.Stop()
@@ -218,7 +218,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
       if not (self._prompt and self._prompt.id == prompt_id):
         return False
       self._response = response
-      self._remove_prompt()
+      self.remove_prompt()
       self._cond.notifyAll()
     return True
 


### PR DESCRIPTION
UserInput.prompt will raise a PromptUnansweredError.  You can catch these exceptions and react appropriately, but won't be able to fully recover because of MultiplePromptsError.