### PR TITLE
Making attach_from_file handle paths

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -366,7 +366,7 @@ class PhaseState(mutablerecords.Record('PhaseState', [
     """
     with open(filename, 'rb') as f:  # pylint: disable=invalid-name
       self.attach(
-          os.path.basename(name) if name is not None else filename, f.read(),
+          name if name is not None else os.path.basename(filename), f.read(),
           mimetype=mimetype if mimetype is not None else mimetypes.guess_type(
               filename)[0])
 

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -27,6 +27,7 @@ invokation of an openhtf.Test instance.
 import contextlib
 import copy
 import logging
+import os
 import socket
 import threading
 import weakref
@@ -365,7 +366,7 @@ class PhaseState(mutablerecords.Record('PhaseState', [
     """
     with open(filename, 'rb') as f:  # pylint: disable=invalid-name
       self.attach(
-          name if name is not None else filename, f.read(),
+          os.path.basename(name) if name is not None else filename, f.read(),
           mimetype=mimetype if mimetype is not None else mimetypes.guess_type(
               filename)[0])
 


### PR DESCRIPTION
if you call test.attach_from_file('/foo/bar/baz.txt') it will save attachment
Existing behavior:   attachment is named '/foo/bar/baz.txt'
After this commit:  attachment is named baz.txt

Note: this could break existing tests that rely upon file directory to be in name to ensure uniqueness.