### PR TITLE
Allow measurement validators to receive phase arguments

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -483,7 +483,7 @@ class PhaseDescriptor(mutablerecords.Record(
         self,
         plugs=new_plugs.values(),
         options=self.options.format_strings(**subplugs),
-        measurements=[m.format_strings(**subplugs) for m in self.measurements])
+        measurements=[m.with_args(**subplugs) for m in self.measurements])
 
 
   def __call__(self, test_state):

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -461,7 +461,7 @@ class PhaseDescriptor(mutablerecords.Record(
     new_info = mutablerecords.CopyRecord(self)
     new_info.options = new_info.options.format_strings(**kwargs)
     new_info.extra_kwargs.update(kwargs)
-    new_info.measurements = [m.format_strings(**kwargs) for m in self.measurements]
+    new_info.measurements = [m.with_args(**kwargs) for m in self.measurements]
     return new_info
 
   def with_plugs(self, **subplugs):

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -49,7 +49,7 @@ Examples:
 
   @measurements.measures(
       measurements.Measurement(
-          'number_widgets').InRange(5, 10).doc(
+          'number_widgets').in_range(5, 10).doc(
           '''This phase parameter tracks the number of widgets.'''))
   @measurements.measures(
       *(measurements.Measurement('level_%s' % lvl)

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -145,6 +145,8 @@ def format_string(target, kwargs):
     return target
   if callable(target):
     return target(**kwargs)
+  if not isinstance(target, basestring):
+    return target
   if '{' in target:
     return partial_format(target, **kwargs)
   if '%' in target:

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -101,9 +101,6 @@ class InRange(object):
       return False
     minimum = self._type(self.minimum)
     maximum = self._type(self.maximum)
-    # Check for equal bounds first so we can use with non-numeric values.
-    if minimum == maximum and value != minimum:
-      return False
     if minimum is not None and value < minimum:
       return False
     if maximum is not None and value > maximum:

--- a/test/util/test_test.py
+++ b/test/util/test_test.py
@@ -37,8 +37,8 @@ class MyPlug(plugs.BasePlug):
 
 @plugs.plug(my_plug=MyPlug)
 @measurements.measures('test_measurement', 'othr_measurement')
-@measurements.measures('passes', validators=[validators.InRange(1, 10)])
-@measurements.measures('fails', validators=[validators.InRange(1, 10)])
+@measurements.measures('passes', validators=[validators.in_range(1, 10)])
+@measurements.measures('fails', validators=[validators.in_range(1, 10)])
 @measurements.measures('unset_measurement')
 def test_phase(phase_data, my_plug):
   phase_data.logger.error('in phase_data %s', id(phase_data))


### PR DESCRIPTION
This also removes the class-as-module trick in validators.py since it was causing problems (had to pass modules into the validators, causing deepcopy to try to deepcopy builtins like `NotImplementedType`)