### PR TITLE
In UserInput plug, allow unicode prompt_id

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -212,7 +212,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
     Returns:
       True if the prompt was used, otherwise False.
     """
-    if type(prompt_id) == str:
+    if isinstance(prompt_id, basestring):
       prompt_id = uuid.UUID(prompt_id)
     _LOG.debug('Responding to prompt (%s): "%s"', prompt_id.hex, response)
     with self._cond:


### PR DESCRIPTION
Minor change:

When responding to a prompt, allow the prompt_id to be a unicode string.

Currently if prompt_id is unicode, the expression `prompt_id.hex` throws an error.