### PR TITLE
Fix custom measurement validators

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -218,7 +218,7 @@ class Measurement(  # pylint: disable=no-init
   def __getattr__(self, attr):  # pylint: disable=invalid-name
     """Support our default set of validators as direct attributes."""
     # Don't provide a back door to validators.py private stuff accidentally.
-    if attr.startswith('_') or not hasattr(validators, attr):
+    if attr.startswith('_') or not validators.has_validator(attr):
       raise AttributeError("'%s' object has no attribute '%s'" % (
           type(self).__name__, attr))
 

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -65,6 +65,10 @@ def register(validator, name=None):
   _VALIDATORS[name] = validator
 
 
+def has_validator(name):
+  return name in _VALIDATORS
+
+
 def create_validator(name, *args, **kwargs):
   return _VALIDATORS[name](*args, **kwargs)
 


### PR DESCRIPTION
This was broken by a previous pull request that changed the validators.py API and I missed a particular use of it.