### PR TITLE
Make PhaseExecutorThread and TestExecutor daemon threads

### DIFF
--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -131,6 +131,7 @@ class PhaseExecutorThread(threads.KillableThread):
   once it is known (_phase_execution_outcome is None until then), and it will be
   a PhaseExecutionOutcome instance.
   """
+  daemon = True
 
   def __init__(self, phase_desc, test_state):
     super(PhaseExecutorThread, self).__init__(

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -47,6 +47,7 @@ class TestStopError(Exception):
 # pylint: disable=too-many-instance-attributes
 class TestExecutor(threads.KillableThread):
   """Encompasses the execution of a single test."""
+  daemon = True
 
   def __init__(self, test_descriptor, execution_uid, test_start,
                teardown_function=None):


### PR DESCRIPTION
They don't exit very quickly (and the PhaseExecutorThread may stay around for a long time depending on the phase). This allows a binary to exit faster if the test is not looping.