### PR TITLE
Stop executing phases if test_start fails

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -293,6 +293,10 @@ class TestState(util.SubscribableStateMixin):
 
     self.test_record.outcome = test_outcome
 
+    # If we've reached here without 'starting' the test, then we 'start' it just
+    # so we can properly 'end' it.
+    if self.test_record.start_time_millis == 0:
+      self.test_record.start_time_millis = util.time_millis()
     # The test is done at this point, no further updates to test_record.
     self.logger.handlers = []
     self.test_record.end_time_millis = util.time_millis()


### PR DESCRIPTION
Any terminal outcome (timeout, stop, error) will stop a test early, rather than continuing the way it does now