### PR TITLE
Allow phases to return SKIP

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -349,7 +349,7 @@ PhaseResult = Enum('PhaseResult', [
     # repeat_limit option, this will be treated as a STOP.
     'REPEAT',
     # Causes the framework to ignore the measurement outcomes and execute the
-    # next phase.
+    # next phase.  The phase is still logged, unlike with run_if.
     'SKIP',
     # Causes the framework to stop executing, indicating a failure.
     'STOP'
@@ -365,7 +365,8 @@ class PhaseOptions(mutablerecords.Record('PhaseOptions', [], {
     name: Override for the name of the phase. Can be formatted in several
         different ways as defined in util.format_string.
     timeout_s: Timeout to use for the phase, in seconds.
-    run_if: Callback that decides whether to run the phase or not.
+    run_if: Callback that decides whether to run the phase or not; if not run,
+        the phase will also not be logged.
     requires_state: If True, pass the whole TestState into the first argument,
         otherwise only the TestApi will be passed in.  This is useful if a
         phase needs to wrap another phase for some reason, as

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -447,7 +447,7 @@ class PhaseState(mutablerecords.Record(
   def _set_phase_outcome(self):
     if self.result is None or self.result.is_terminal or self.hit_repeat_limit:
       outcome = test_record.PhaseOutcome.ERROR
-    elif self.result.is_repeat:
+    elif self.result.is_repeat or self.result.is_skip:
       outcome = test_record.PhaseOutcome.SKIP
     else:
       outcome = (test_record.PhaseOutcome.PASS

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -384,6 +384,9 @@ class TestCase(unittest.TestCase):
   def assertPhaseRepeat(self, phase_record):
     self.assertIs(openhtf.PhaseResult.REPEAT, phase_record.result.phase_result)
 
+  def assertPhaseSkip(self, phase_record):
+    self.assertIs(openhtf.PhaseResult.SKIP, phase_record.result.phase_result)
+
   def assertPhaseStop(self, phase_record):
     self.assertIs(openhtf.PhaseResult.STOP, phase_record.result.phase_result)
 


### PR DESCRIPTION
Allow phases to return SKIP after they have started in case they need
some additional data to determine if they should actually run.

This functions differently than run_if in that if run_if returns false,
the phase is not logged.  If the phase returns SKIP, it will be logged.