### PR TITLE
Fix string equality validator and add test for the previously broken case

### DIFF
--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -178,7 +178,7 @@ def equals(value, type=None):
   elif isinstance(value, basestring):
     assert type is None or issubclass(type, basestring), (
         'Cannot use a non-string type when matching a string')
-    return matches_regex(re.escape(value))
+    return matches_regex('^{}$'.format(re.escape(value)))
   else:
     return Equals(value, type=type)
 

--- a/test/util/validators_test.py
+++ b/test/util/validators_test.py
@@ -93,6 +93,7 @@ class TestEqualsFactory(unittest.TestCase):
     string_validator = validators.equals('aardvark')
     self.assertTrue(string_validator('aardvark'))
     self.assertFalse(string_validator('aard'))
+    self.assertFalse(string_validator('aardvarka'))
 
   def test_with_object(self):
     class MyType(object):


### PR DESCRIPTION
Previously for the equality validator, we'd just pass in the string as a regex pattern and use re.match() - but match will accept trailing characters in the candidate strings. Add fix for the [issue](https://github.com/google/openhtf/issues/593) and unit test.