### PR TITLE
Add tests for measurements module

### DIFF
--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -18,16 +18,14 @@ Run with (your virtualenv must be activated first):
 python all_the_things.py
 """
 
-import json
-import os
 import time
 
 import openhtf as htf
+from openhtf import util
 from openhtf.util import units
 from openhtf.plugs import user_input
 from openhtf.output import callbacks
 from openhtf.output.callbacks import json_factory
-from openhtf.output.callbacks import mfg_inspector
 
 import example_plugs
 
@@ -47,7 +45,10 @@ def example_monitor(example, frontend_aware):
             '''This measurement tracks the type of widgets.'''),
     htf.Measurement(
         'widget_color').doc('Color of the widget'),
-    htf.Measurement('widget_size').in_range(1, 4))
+    htf.Measurement('widget_size').in_range(1, 4).doc('Size of widget'))
+@htf.measures('specified_as_args', docstring='Helpful docstring',
+              units=units.HERTZ,
+              validators=[util.validators.matches_regex('Measurement')])
 @htf.plug(example=example_plugs.ExamplePlug)
 @htf.plug(prompts=user_input.UserInput)
 def hello_world(test, example, prompts):
@@ -59,6 +60,7 @@ def hello_world(test, example, prompts):
     raise Exception()
   test.measurements.widget_color = 'Black'
   test.measurements.widget_size = 3
+  test.measurements.specified_as_args = 'Measurement args specified directly'
   test.logger.info('Plug value: %s', example.increment())
 
 
@@ -90,6 +92,17 @@ def dimensions(test):
     test.measurements.lots_of_dims[x, y, z] = x + y + z
 
 
+@htf.measures(
+    htf.Measurement('replaced_min_only').in_range('{min}', 5, type=int),
+    htf.Measurement('replaced_max_only').in_range(0, '{max}', type=int),
+    htf.Measurement('replaced_min_max').in_range('{min}', '{max}', type=int),
+)
+def measures_with_args(test, min, max):
+  test.measurements.replaced_min_only = 1
+  test.measurements.replaced_max_only = 1
+  test.measurements.replaced_min_max = 1
+
+
 def attachments(test):
   test.attach('test_attachment', 'This is test attachment data.')
   test.attach_from_file('example_attachment.txt')
@@ -98,7 +111,6 @@ def attachments(test):
 @htf.TestPhase(run_if=lambda: False)
 def skip_phase(test):
   """Don't run this phase."""
-  pass
 
 
 def teardown(test):
@@ -108,6 +120,7 @@ def teardown(test):
 if __name__ == '__main__':
   test = htf.Test(
       hello_world, set_measurements, dimensions, attachments, skip_phase,
+      measures_with_args.with_args(min=2, max=4),
       # Some metadata fields, these in particular are used by mfg-inspector,
       # but you can include any metadata fields.
       test_name='MyTest', test_description='OpenHTF Example Test',

--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -19,6 +19,7 @@ python all_the_things.py
 """
 
 import time
+import os.path
 
 import openhtf as htf
 from openhtf import util
@@ -105,7 +106,8 @@ def measures_with_args(test, min, max):
 
 def attachments(test):
   test.attach('test_attachment', 'This is test attachment data.')
-  test.attach_from_file('example_attachment.txt')
+  test.attach_from_file(
+      os.path.join(os.path.dirname(__file__), 'example_attachment.txt'))
 
 
 @htf.TestPhase(run_if=lambda: False)

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -38,6 +38,8 @@ class TestOutput(test.TestCase):
       result.result = test_record
     cls._test = htf.Test(
         all_the_things.hello_world,
+        all_the_things.dimensions,
+        all_the_things.attachments,
     )
     cls._test.add_output_callbacks(_save_result)
     cls._test.make_uid = lambda: 'UNITTEST:MOCK:UID'

--- a/test/util/conf_test.py
+++ b/test/util/conf_test.py
@@ -95,6 +95,7 @@ class TestConf(unittest.TestCase):
         'flag_key': 'flag_value',
         'cancel_timeout_s': 2,
         'enable_station_discovery': True,
+        'example_plug_increment_size': 1,
         'station_api_port': 8888,
         'allow_unset_measurements': False,
         'capture_source': False,


### PR DESCRIPTION
PTAL, if this looks good, I'll add similar tests to callbacks_test.py.
I think that test file should be split into separate test modules for mfg_inspector and json_factory - thoughts?

---

The fact that conf is a global required editing conf_test.py because I imported all_the_things.py in a test.