### PR TITLE
Always remove attachment data when converting to dict

### DIFF
--- a/openhtf/core/station_api.py
+++ b/openhtf/core/station_api.py
@@ -167,8 +167,8 @@ class RemotePhase(collections.namedtuple('RemotePhase', [
 
   See PhaseState._asdict() in exe/test_state.py for attribute details.
 
-  Notably, 'attachments' is a dict mapping name to sha1 hash of the
-  attachment's data, not the actual attachment data itself.
+  Note that 'attachments' does not contain the attachment data itself, as it is
+  stripped out by Attachment._asdict().
   """
 
 

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -48,6 +48,12 @@ class Attachment(collections.namedtuple('Attachment', 'data mimetype')):
   def sha1(self):
     return hashlib.sha1(self.data).hexdigest()
 
+  def _asdict(self):
+    # Don't include the attachment data when converting to dict.
+    return {
+        'mimetype': self.mimetype,
+        'sha1': self.sha1,
+    }
 
 class TestRecord(  # pylint: disable=no-init
     mutablerecords.Record(

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -350,13 +350,7 @@ class PhaseState(mutablerecords.Record(
         'descriptor_id': self.phase_record.descriptor_id,
         'start_time_millis': long(self.phase_record.start_time_millis),
         'options': self.phase_record.options,
-        # We only serialize attachment hashes, they can be large.
-        'attachments': {
-            name: attachment.sha1 for name, attachment in
-            self.attachments.iteritems()
-        },
-        # Measurements have their own _asdict() implementation.
-        'measurements': self.measurements,
+        'attachments': self.attachments,
     }
 
   @property

--- a/openhtf/output/callbacks/json_factory.py
+++ b/openhtf/output/callbacks/json_factory.py
@@ -43,6 +43,5 @@ class OutputToJSON(callbacks.OutputToFile):
         for value in phase['attachments'].itervalues():
           value['data'] = base64.standard_b64encode(value['data'])
     else:
-      as_dict = data.convert_to_base_types(test_record,
-                                           ignore_keys=('attachments',))
+      as_dict = data.convert_to_base_types(test_record)
     return as_dict

--- a/openhtf/output/callbacks/json_factory.py
+++ b/openhtf/output/callbacks/json_factory.py
@@ -1,8 +1,7 @@
 """Module for outputting test record to JSON-formatted files."""
 
-
 import base64
-from json import JSONEncoder
+import json
 
 from openhtf.output import callbacks
 from openhtf.util import data
@@ -31,17 +30,16 @@ class OutputToJSON(callbacks.OutputToFile):
   def __init__(self, filename_pattern=None, inline_attachments=True, **kwargs):
     super(OutputToJSON, self).__init__(filename_pattern)
     self.inline_attachments = inline_attachments
-    self.json_encoder = JSONEncoder(**kwargs)
+    self.json_encoder = json.JSONEncoder(**kwargs)
 
   def serialize_test_record(self, test_record):
     return self.json_encoder.encode(self.convert_to_dict(test_record))
 
   def convert_to_dict(self, test_record):
+    as_dict = data.convert_to_base_types(test_record)
     if self.inline_attachments:
-      as_dict = data.convert_to_base_types(test_record)
-      for phase in as_dict['phases']:
-        for value in phase['attachments'].itervalues():
-          value['data'] = base64.standard_b64encode(value['data'])
-    else:
-      as_dict = data.convert_to_base_types(test_record)
+      for phase, original_phase in zip(as_dict['phases'], test_record.phases):
+        for name, attachment in phase['attachments'].iteritems():
+          original_data = original_phase.attachments[name].data
+          attachment['data'] = base64.standard_b64encode(original_data)
     return as_dict


### PR DESCRIPTION
This PR aims to standardize the dictionary format of attachments.

In the use cases I've seen, we always remove attachment data at some point—with this PR, it will happen by default when calling data.convert_to_base_types.