### PR TITLE
Only log debug messages about cancelling phase if phase_thread is alive

### DIFF
--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -254,14 +254,15 @@ class PhaseExecutor(object):
     if not phase_thread:
       return
 
-    phase_thread.kill()
-
-    _LOG.debug('Waiting for cancelled phase to exit: %s', phase_thread)
-    timeout = timeouts.PolledTimeout.from_seconds(timeout_s)
-    while phase_thread.is_alive() and not timeout.has_expired():
-      time.sleep(0.1)
-    _LOG.debug('Cancelled phase %s exit',
-               "didn't" if phase_thread.is_alive() else 'did')
+    if phase_thread.is_alive():
+      phase_thread.kill()
+    
+      _LOG.debug('Waiting for cancelled phase to exit: %s', phase_thread)
+      timeout = timeouts.PolledTimeout.from_seconds(timeout_s)
+      while phase_thread.is_alive() and not timeout.has_expired():
+        time.sleep(0.1)
+      _LOG.debug('Cancelled phase %s exit',
+                 "didn't" if phase_thread.is_alive() else 'did')
     # Clear the currently running phase, whether it finished or timed out.
     self.test_state.stop_running_phase()
 


### PR DESCRIPTION
Currently at the end of every test, when the test phases are complete phase_executor will log:
[D 170628 13:45:56 phase_executor:259] Waiting for cancelled phase to exit: <PhaseExecutorThread: (PhaseName)>
[D 170628 13:45:56 phase_executor:264] Cancelled phase did exit

This is a little misleading, so should only log if the phase_thread is actually still alive and you are actually waiting for it to exit.