### PR TITLE
Only calling _initialize_value on Measurement if measured_value isn't passed in.

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -132,7 +132,7 @@ class Measurement(  # pylint: disable=no-init
 
   def _initialize_value(self):
     if self.measured_value and self.measured_value.is_value_set:
-        raise ValueError('Cannot update a Measurement once a value is set.')
+      raise ValueError('Cannot update a Measurement once a value is set.')
     if self.dimensions:
       self.measured_value = DimensionedMeasuredValue(
           self.name, len(self.dimensions))

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -62,6 +62,7 @@ Examples:
 
 
 import collections
+import copy
 import logging
 
 from enum import Enum
@@ -138,6 +139,19 @@ class Measurement(  # pylint: disable=no-init
           self.name, len(self.dimensions))
     else:
       self.measured_value = MeasuredValue(self.name)
+
+  def __deepcopy__(self, memo):
+      kwargs = {
+          attr: copy.deepcopy(getattr(self, attr), memo)
+          for attr in self.__slots__
+      }
+      measured_value = kwargs.pop('measured_value', None)
+
+      new_measurement = type(self)(**kwargs)
+      new_measurement.measured_value = measured_value
+
+      return new_measurement
+
 
   def __setattr__(self, attr, value):
     super(Measurement, self).__setattr__(attr, value)

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -62,7 +62,6 @@ Examples:
 
 
 import collections
-import copy
 import logging
 
 from enum import Enum
@@ -128,30 +127,17 @@ class Measurement(  # pylint: disable=no-init
 
   def __init__(self, name, **kwargs):
     super(Measurement, self).__init__(name, **kwargs)
-    self._initialize_value()
+    if 'measured_value' not in kwargs:
+      self._initialize_value()
 
   def _initialize_value(self):
     if self.measured_value and self.measured_value.is_value_set:
-      raise ValueError('Cannot update a Measurement once a value is set.')
-
+        raise ValueError('Cannot update a Measurement once a value is set.')
     if self.dimensions:
       self.measured_value = DimensionedMeasuredValue(
           self.name, len(self.dimensions))
     else:
       self.measured_value = MeasuredValue(self.name)
-
-  def __deepcopy__(self, memo):
-      kwargs = {
-          attr: copy.deepcopy(getattr(self, attr), memo)
-          for attr in self.__slots__
-      }
-      measured_value = kwargs.pop('measured_value', None)
-
-      new_measurement = type(self)(**kwargs)
-      new_measurement.measured_value = measured_value
-
-      return new_measurement
-
 
   def __setattr__(self, attr, value):
     super(Measurement, self).__setattr__(attr, value)

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -133,6 +133,7 @@ class Measurement(  # pylint: disable=no-init
   def _initialize_value(self):
     if self.measured_value and self.measured_value.is_value_set:
       raise ValueError('Cannot update a Measurement once a value is set.')
+
     if self.dimensions:
       self.measured_value = DimensionedMeasuredValue(
           self.name, len(self.dimensions))


### PR DESCRIPTION
Currently cannot deepcopy a Measurement where the value is set due to call to _initialize_value which will raise a ValueErrror:
```
def _initialize_value(self):
  if self.measured_value and self.measured_value.is_value_set:
    raise ValueError('Cannot update a Measurement once a value is set.')
```

Overwriting deepcopy to sidestep ValueError.
