### PR TITLE
Add ordering to measurements

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -414,16 +414,15 @@ class PhaseState(mutablerecords.Record(
     Any UNSET measurements will cause the Phase to FAIL unless
     conf.allow_unset_measurements is set True.
     """
-    # Clear notification callbacks for later serialization.
-    for meas in self.measurements.values():
-      meas.set_notification_callback(None)
-
-    # Validate multi-dimensional measurements now that we have all values.
     for measurement in self.measurements.itervalues():
-      measurement.validate()
+      # Clear notification callbacks for later serialization.
+      measurement.set_notification_callback(None)
+      # Validate multi-dimensional measurements now that we have all values.
+      if measurement.outcome is measurements.Outcome.PARTIALLY_SET:
+        measurement.validate()
 
-    # Fill out final values for the PhaseRecord.
-    self.phase_record.measurements = self.measurements.copy()
+    # Set final values on the PhaseRecord.
+    self.phase_record.measurements = self.measurements
 
   def _measurements_pass(self):
     allowed_outcomes = {measurements.Outcome.PASS}

--- a/openhtf/output/callbacks/console_summary.py
+++ b/openhtf/output/callbacks/console_summary.py
@@ -44,22 +44,19 @@ class ConsoleSummary():
         new_phase = True
         phase_time_sec = (float(phase.end_time_millis)
                           - float(phase.start_time_millis)) / 1000.0
-        measured = phase.measured_values
-        measurements = phase.measurements
-        for key in measurements:
-          result = measurements[key]
-          if result.outcome == meas_module.Outcome.FAIL:
+        for name, measurement in phase.measurements.iteritems():
+          if measurement.outcome == meas_module.Outcome.FAIL:
             if new_phase:
               output_lines.append('failed phase: %s [ran for %.2f sec]' %
                                   (phase.name, phase_time_sec))
               new_phase = False
 
             output_lines.append('%sfailed_item: %s' %
-                                (self.indent, result.name))
+                                (self.indent, name))
             output_lines.append('%smeasured_value: %s' %
-                                (self.indent*2, str(measured[result.name])))
+                                (self.indent*2, measurement.measured_value))
             output_lines.append('%svalidators:' % (self.indent*2))
-            for validator in result.validators:
+            for validator in measurement.validators:
               output_lines.append('%svalidator: %s' %
                                   (self.indent*3, str(validator)))
 

--- a/test/core/measurements_test.py
+++ b/test/core/measurements_test.py
@@ -68,3 +68,13 @@ class TestMeasurements(htf_test.TestCase):
     self.assertMeasurementPass(record, 'replaced_min_only')
     self.assertMeasurementFail(record, 'replaced_max_only')
     self.assertMeasurementFail(record, 'replaced_min_max')
+
+  @htf_test.yields_phases
+  def test_measurement_order(self):
+    record = yield all_the_things.dimensions
+    self.assertEqual(record.measurements.keys(),
+                     ['unset_dims', 'dimensions', 'lots_of_dims'])
+    record = yield all_the_things.measures_with_args.with_args(min=2, max=4)
+    self.assertEqual(record.measurements.keys(),
+                     ['replaced_min_only', 'replaced_max_only',
+                      'replaced_min_max'])


### PR DESCRIPTION
Use OrderedDict instead of dict for measurements on PhaseState and PhaseRecord. This allows the test author to fix an ordering for measurements in console output.

The measurements will keep the order in which they were declared, e.g.

```
@htf.measures(
    htf.Measurement('first'),
    htf.Measurement('second'),
    htf.Measurement('third'),
)
```

(Also, fix `callbacks/console_summary.py`)