### PR TITLE
Add FAIL_AND_CONTINUE to just fail a phase.

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -344,6 +344,9 @@ PhaseResult = Enum('PhaseResult', [
     # Causes the framework to process the phase measurement outcomes and execute
     # the next phase.
     'CONTINUE',
+    # Causes the framework to mark the phase with a fail outcome and execute the
+    # next phase.
+    'FAIL_AND_CONTINUE',
     # Causes the framework to execute the same phase again, ignoring the
     # measurement outcomes for this instance. If returned more than the phase's
     # repeat_limit option, this will be treated as a STOP.

--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -99,6 +99,10 @@ class PhaseExecutionOutcome(collections.namedtuple(
     super(PhaseExecutionOutcome, self).__init__(phase_result)
 
   @property
+  def is_fail_and_continue(self):
+    return self.phase_result is openhtf.PhaseResult.FAIL_AND_CONTINUE
+
+  @property
   def is_repeat(self):
     return self.phase_result is openhtf.PhaseResult.REPEAT
 

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -79,7 +79,7 @@ class TestRecord(  # pylint: disable=no-init
 PhaseOutcome = Enum(  # pylint: disable=invalid-name
     'PhaseOutcome', [
         'PASS',  # CONTINUE with allowed measurement outcomes.
-        'FAIL',  # CONTINUE with failed measurements.
+        'FAIL',  # CONTINUE with failed measurements or FAIL_AND_CONTINUE.
         'SKIP',  # SKIP or REPEAT when under the phase's repeat limit.
         'ERROR',  # Any terminal result.
     ])

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -439,6 +439,8 @@ class PhaseState(mutablerecords.Record(
       outcome = test_record.PhaseOutcome.ERROR
     elif self.result.is_repeat or self.result.is_skip:
       outcome = test_record.PhaseOutcome.SKIP
+    elif self.result.is_fail_and_continue:
+      outcome = test_record.PhaseOutcome.FAIL
     else:
       outcome = (test_record.PhaseOutcome.PASS
                  if self._measurements_pass()

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -93,6 +93,12 @@ def phase_return_skip(test):
   return openhtf.PhaseResult.SKIP
 
 
+@openhtf.PhaseOptions()
+def phase_return_fail_and_continue(test):
+  del test  # Unused.
+  return openhtf.PhaseResult.FAIL_AND_CONTINUE
+
+
 class TestExecutor(unittest.TestCase):
 
   def setUp(self):
@@ -224,3 +230,7 @@ class TestPhaseExecutor(unittest.TestCase):
   def test_execute_phase_return_skip(self):
     result = self.phase_executor.execute_phase(phase_return_skip)
     self.assertEqual(PhaseResult.SKIP, result.phase_result)
+
+  def test_execute_phase_return_fail_and_continue(self):
+    result = self.phase_executor.execute_phase(phase_return_fail_and_continue)
+    self.assertEqual(PhaseResult.FAIL_AND_CONTINUE, result.phase_result)


### PR DESCRIPTION
Add FAIL_AND_CONTINUE to PhaseResult to indicate to the executor that
the phase should just be marked as a failure while continuing onto the
next phase.