### PR TITLE
Replace gflags with argv.

### DIFF
--- a/openhtf/plugs/usb/__init__.py
+++ b/openhtf/plugs/usb/__init__.py
@@ -27,24 +27,38 @@ To use these plugs:
   def MyPhase(test, adb):
     adb.Shell('ls')
 """
+import argparse
 import commands
 import logging
 import time
 
 import openhtf.plugs as plugs
+from openhtf.plugs import cambrionix
 from openhtf.plugs.usb import adb_device
+from openhtf.plugs.usb import adb_protocol
 from openhtf.plugs.usb import fastboot_device
+from openhtf.plugs.usb import fastboot_protocol
 from openhtf.plugs.usb import local_usb
 from openhtf.plugs.usb import usb_exceptions
-from openhtf.plugs import cambrionix
 from openhtf.plugs.user_input import prompt_for_test_start
 from openhtf.util import conf
+from openhtf.util import functions
 
 _LOG = logging.getLogger(__name__)
 
 conf.declare('libusb_rsa_key', 'A private key file for use by libusb auth.')
 conf.declare('remote_usb', 'ethersync or other')
 conf.declare('ethersync', 'ethersync configuration')
+
+
+@functions.call_once
+def init_dependent_flags():
+  parser = argparse.ArgumentParser(
+      'USB Plug flags', parents=[
+          adb_protocol.ARG_PARSER, fastboot_protocol.ARG_PARSER],
+      add_help=False)
+  parser.parse_known_args()
+
 
 def _open_usb_handle(**kwargs):
   """Open a UsbHandle subclass, based on configuration.
@@ -65,7 +79,7 @@ def _open_usb_handle(**kwargs):
   Returns:
     Instance of UsbHandle.
   """
-
+  init_dependent_flags()
   serial = None
   remote_usb = conf.remote_usb
   if remote_usb:

--- a/openhtf/plugs/usb/adb_message.py
+++ b/openhtf/plugs/usb/adb_message.py
@@ -46,15 +46,9 @@ import string
 import struct
 import threading
 
-import gflags
-
 from openhtf.plugs.usb import usb_exceptions
 from openhtf.util import timeouts
 
-gflags.DEFINE_boolean('adb_message_log', False,
-                      'Set to True to save all incoming and outgoing '
-                      'AdbMessages and print them on close().')
-FLAGS = gflags.FLAGS
 _LOG = logging.getLogger(__name__)
 
 def make_wire_commands(*ids):

--- a/openhtf/plugs/usb/adb_protocol.py
+++ b/openhtf/plugs/usb/adb_protocol.py
@@ -82,15 +82,24 @@ import logging
 import Queue
 import threading
 
-import gflags
 from enum import Enum
 
 from openhtf.plugs.usb import adb_message
 from openhtf.plugs.usb import usb_exceptions
+from openhtf.util import argv
 from openhtf.util import exceptions
 from openhtf.util import timeouts
 
-FLAGS = gflags.FLAGS
+
+ADB_MESSAGE_LOG = False
+
+ARG_PARSER = argv.ModuleParser()
+ARG_PARSER.add_argument('--adb_messsage_log',
+                        action=argv.StoreTrueInModule,
+                        target='%s.ADB_MESSAGE_LOG' % __name__,
+                        help='Set to True to save all incoming and outgoing '
+                        'AdbMessages and print them on Close().')
+
 _LOG = logging.getLogger(__name__)
 
 # Maximum amount of data in an ADB packet, we would like to raise this, but the
@@ -849,7 +858,7 @@ class AdbConnection(object):
         unexpected way, or fails to respond appropriately to our CNXN request.
     """
     timeout = timeouts.PolledTimeout.from_millis(timeout_ms)
-    if FLAGS.adb_message_log:
+    if ADB_MESSAGE_LOG:
       adb_transport = adb_message.DebugAdbTransportAdapter(transport)
     else:
       adb_transport = adb_message.AdbTransportAdapter(transport)

--- a/openhtf/plugs/usb/fastboot_protocol.py
+++ b/openhtf/plugs/usb/fastboot_protocol.py
@@ -22,13 +22,20 @@ import logging
 import os
 import struct
 
-import gflags
-
 from . import usb_exceptions
+from openhtf.util import argv
 
-FLAGS = gflags.FLAGS
-gflags.DEFINE_integer('fastboot_download_chunk_size_kb', 1024,
-                      'Size of chunks to send when downloading fastboot images')
+
+FASTBOOT_DOWNLOAD_CHUNK_SIZE_KB = 1024
+
+ARG_PARSER = argv.ModuleParser()
+ARG_PARSER.add_argument(
+    '--fastboot_download_chunk_size_kb',
+    default=FASTBOOT_DOWNLOAD_CHUNK_SIZE_KB,
+    action=argv.StoreInModule,
+    type=int,
+    target='%s.FASTBOOT_DOWNLOAD_CHUNK_SIZE_KB' % __name__,
+    help='Size of chunks to send when downloading fastboot images')
 
 _LOG = logging.getLogger(__name__)
 
@@ -170,7 +177,7 @@ class FastbootProtocol(object):
       progress = self._handle_progress(length, progress_callback)
       progress.next()
     while length:
-      tmp = data.read(FLAGS.fastboot_download_chunk_size_kb * 1024)
+      tmp = data.read(FASTBOOT_DOWNLOAD_CHUNK_SIZE_KB * 1024)
       length -= len(tmp)
       self.usb.write(tmp)
 

--- a/openhtf/util/argv.py
+++ b/openhtf/util/argv.py
@@ -3,7 +3,7 @@
 StoreInModule:
   Enables emulating a gflags-esque API (flag affects global value), but one
   doesn't necessarily need to use flags to set values.
-  
+
   Example usage:
     DEFAULT_VALUE = 0
     ARG_PARSER = argv.ModuleParser()
@@ -41,3 +41,30 @@ class StoreInModule(argparse.Action):
     else:
       module = __import__(self._tgt_mod)
     setattr(module, self._tgt_attr, values)
+
+
+class _StoreValueInModule(StoreInModule):
+  """Stores a value in a module level variable when set."""
+
+  def __init__(self, const, *args, **kwargs):
+    kwargs.update(nargs=0, const=const)
+    super(_StoreValueInModule, self).__init__(*args, **kwargs)
+
+  def __call__(self, parser, namespace, values, option_string=None):
+    del values  # Unused.
+    super(_StoreValueInModule, self).__call__(
+        parser, namespace, self.const, option_string=option_string)
+
+
+class StoreTrueInModule(_StoreValueInModule):
+  """Stores True in a module level variable when set."""
+
+  def __init__(self, *args, **kwargs):
+    super(StoreTrueInModule, self).__init__(True, *args, **kwargs)
+
+
+class StoreFalseInModule(_StoreValueInModule):
+  """Stores False in module level variable when set."""
+
+  def __init__(self, *args, **kwargs):
+    super(StoreFalseInModule, self).__init__(False, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,6 @@ setup(
         'usb_plugs': [
             'libusb1>=1.3.0,<2.0',
             'M2Crypto>=0.22.3,<1.0',
-            'python-gflags>=2.0,<3.0',
         ],
         'update_units': [
             'xlrd>=1.0.0,<2.0',


### PR DESCRIPTION
Make the usb module more portable by removing the gflags library.