### PR TITLE
Consume CLI flags when parsing them.

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -328,9 +328,10 @@ def create_arg_parser(add_help=False):
           'My args title', parents=[openhtf.create_arg_parser()])
   >>> parser.parse_args()
   """
-  return argparse.ArgumentParser('OpenHTF-based testing', parents=[
+  return util.argv.SysArgvConsumingParser('OpenHTF-based testing', parents=[
       conf.ARG_PARSER, phase_executor.ARG_PARSER, logs.ARG_PARSER],
-      add_help=add_help)
+      add_help=add_help,
+      consume=True)
 
 
 # Result of a phase.

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -319,7 +319,7 @@ class TestDescriptor(collections.namedtuple(
     return {plug.cls for phase in self.phases for plug in phase.plugs}
 
 
-def create_arg_parser(add_help=False):
+def create_arg_parser(add_help=False, consume=True):
   """Creates an argparse.ArgumentParser for parsing command line flags.
 
   If you want to add arguments, create your own with this as a parent:
@@ -331,7 +331,7 @@ def create_arg_parser(add_help=False):
   return util.argv.SysArgvConsumingParser('OpenHTF-based testing', parents=[
       conf.ARG_PARSER, phase_executor.ARG_PARSER, logs.ARG_PARSER],
       add_help=add_help,
-      consume=True)
+      consume=consume)
 
 
 # Result of a phase.

--- a/openhtf/util/argv.py
+++ b/openhtf/util/argv.py
@@ -3,7 +3,7 @@
 StoreInModule:
   Enables emulating a gflags-esque API (flag affects global value), but one
   doesn't necessarily need to use flags to set values.
-  
+
   Example usage:
     DEFAULT_VALUE = 0
     ARG_PARSER = argv.ModuleParser()
@@ -17,10 +17,39 @@ StoreInModule:
 """
 
 import argparse
+import sys
 
 
 def ModuleParser():
-  return argparse.ArgumentParser(add_help=False)
+  return SysArgvConsumingParser(add_help=False, consume=False)
+
+
+class SysArgvConsumingParser(argparse.ArgumentParser):
+  """ArgumentParser variant that can consume known arguments from sys.argv.
+
+  Args (in addition to the normal argparse.ArgumentParser args):
+    consume: If True, consumes known args from sys.argv upon parsing.
+  """
+  def __init__(self, *args, **kwargs):
+    self._consume = kwargs.pop('consume')
+    super(SysArgvConsumingParser, self).__init__(*args, **kwargs)
+
+  def parse_args(self):
+    self.parse_known_args()
+
+  def parse_known_args(self):
+    """Parse known args and remove them from sys.argv.
+
+    Returns: A 2-tuple of the namespace resulting from the parse, and the list
+        of args that were unknown and thus unconsumed. The script name
+        (sys.argv[0]) will be preserved along with any unparsed args.
+    """
+    leftover_args = [sys.argv[0]]
+    flags, unknown = super(SysArgvConsumingParser, self).parse_known_args()
+    leftover_args.extend(unknown)
+    if self._consume:
+      sys.argv = leftover_args
+    return flags, unknown
 
 
 class StoreInModule(argparse.Action):

--- a/openhtf/util/conf.py
+++ b/openhtf/util/conf.py
@@ -239,17 +239,17 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     self._modules = kwargs
     self._declarations = {}
     self.ARG_PARSER = parser
-    
+
     # Parse just the flags we care about, since this happens at import time.
     self._flags, _ = parser.parse_known_args()
     self._flag_values = {}
-    
+
     # Populate flag_values from flags now.
     self.load_flag_values()
 
     # Initialize self._loaded_values and load from --config-file if it's set.
     self.reset()
-  
+
   def load_flag_values(self, flags=None):
     """Load flag values given from command line flags.
 

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ class PyTestCommand(test):
 
 setup(
     name='openhtf',
-    version='1.1.0',
+    version='1.1.1',
     description='OpenHTF, the open hardware testing framework.',
     author='John Hawley',
     author_email='madsci@google.com',

--- a/test/util/conf_test.py
+++ b/test/util/conf_test.py
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 import sys
-
-_old_argv = list(sys.argv)
-sys.argv.extend([
-    '--config-value=flag_key=flag_value',
-    '--config-value', 'other_flag=other_value',
-    # You can specify arbitrary keys, but they'll get ignored if they aren't
-    # actually declared anywhere (included here to make sure of that).
-    '--config_value=undeclared_flag=who_cares',
-])
-
 import os.path
 import unittest
 
@@ -38,10 +28,6 @@ conf.declare('string_default', default_value='default')
 conf.declare('no_default')
 
 
-def tear_down_module():
-    sys.argv = _old_argv
-
-
 class TestConf(unittest.TestCase):
 
   YAML_FILENAME = os.path.join(os.path.dirname(__file__), 'test_config.yaml')
@@ -49,12 +35,21 @@ class TestConf(unittest.TestCase):
   NOT_A_DICT = os.path.join(os.path.dirname(__file__), 'bad_config.yaml')
 
   def setUp(self):
+    self._old_argv = list(sys.argv)
+    sys.argv.extend([
+        '--config-value=flag_key=flag_value',
+        '--config-value', 'other_flag=other_value',
+        # You can specify arbitrary keys, but they'll get ignored if they aren't
+        # actually declared anywhere (included here to make sure of that).
+        '--config_value=undeclared_flag=who_cares',
+    ])
     flags, _ = conf.ARG_PARSER.parse_known_args()
     conf.load_flag_values(flags)
 
   def tearDown(self):
     conf._flags.config_file = None
     conf.reset()
+    sys.argv = self._old_argv
 
   def test_yaml_config(self):
     with open(self.YAML_FILENAME, 'rb') as yamlfile:


### PR DESCRIPTION
Proposed solution to enable using 3rd party libraries that blow up when encountering unknown command line arguments.