### PR TITLE
Populate outcome_details when test_start fails.

### DIFF
--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -161,6 +161,8 @@ class TestExecutor(threads.KillableThread):
     self.test_state.plug_manager.initialize_plugs(
         (phase_plug.cls for phase_plug in self._test_start.plugs))
     outcome = phase_exec.execute_phase(self._test_start)
+    if outcome.is_terminal:
+      self.test_state.finalize_from_phase_outcome(outcome)
 
     if self.test_state.test_record.dut_id is None:
       _LOG.warning('Start trigger did not set DUT ID. A later phase will need'


### PR DESCRIPTION
Make sure `outcome_details` gets populated from a `test_start` phase, even if it aborts.

I don't know how to unit test this, but here's an end-to-end test:
```python
import openhtf as htf

@htf.PhaseOptions()
def phase(test):
    test.test_record.dut_id = '1'
    return htf.PhaseResult.STOP

def check_outcome(record):
    assert(record.outcome_details)

if __name__ == '__main__':
    test = htf.Test()
    test.add_output_callbacks(check_outcome)
    test.execute(test_start=phase)
```

Depends on #626. Fixes #635.