### PR TITLE
Special case for boolean equals() validator.

### DIFF
--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -173,7 +173,7 @@ register(in_range, name='in_range')
 
 @register
 def equals(value, type=None):
-  if isinstance(value, numbers.Number):
+  if isinstance(value, numbers.Number) and not isinstance(value, bool):
     return InRange(minimum=value, maximum=value, type=type)
   elif isinstance(value, basestring):
     assert type is None or issubclass(type, basestring), (


### PR DESCRIPTION
Bools can't use `InRange` because it calls `isnan` on them which is an
error.

Fixes #642.