### PR TITLE
Don't force DEBUG loglevel in test_record loggers.

### DIFF
--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -116,7 +116,6 @@ def initialize_record_logger(test_uid, test_record, notify_update):
   # All record loggers have a shared parent that's separately configured, so
   # we want to propagate to that logger.
   logger.propagate = True
-  logger.setLevel(logging.DEBUG)
   # Just in case, make sure we don't have any extra handlers hanging around.
   logger.handlers = [RecordHandler(test_record, notify_update)]
   return logger


### PR DESCRIPTION
Allow users to set log level for `test_record` and its children.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/648)
<!-- Reviewable:end -->
