### PR TITLE
Fix unicode logs

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -222,7 +222,7 @@ class TestState(util.SubscribableStateMixin):
       result = phase_execution_outcome.phase_result
       if isinstance(result, phase_executor.ExceptionInfo):
         code = result.exc_type.__name__
-        description = str(result.exc_val).decode('utf8', 'replace')
+        description = unicode(result.exc_val)
       else:
         # openhtf.util.threads.ThreadTerminationError gets str'd directly.
         code = str(type(phase_execution_outcome.phase_result).__name__)

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -23,6 +23,7 @@ prompt state should use the openhtf.prompts pseudomodule.
 
 import collections
 import functools
+import locale
 import logging
 import os
 import platform
@@ -92,7 +93,10 @@ class ConsolePrompt(threading.Thread):
         if sys.stdin.isatty():
           termios.tcflush(sys.stdin, termios.TCIFLUSH)
 
-        line = ''
+        # Although this isn't threadsafe with do_setlocale=True, it doesn't work without it.
+        encoding = locale.getpreferredencoding(do_setlocale=True)
+
+        line = u''
         while not self._stopped:
           inputs, _, _ = select.select([sys.stdin], [], [], 0.001)
           for stream in inputs:
@@ -111,7 +115,7 @@ class ConsolePrompt(threading.Thread):
                   # want to actually quit.
                   print "Hit ^C (Ctrl+c) to exit."
                   break
-              line += new
+              line += new.decode(encoding)
               if '\n' in line:
                 response = line[:line.find('\n')]
                 self._answered = True

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -143,7 +143,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
   def _create_prompt(self, message, text_input):
     """Sets the prompt."""
     prompt_id = uuid.uuid4()
-    _LOG.debug('Displaying prompt (%s): "%s"%s', prompt_id, message,
+    _LOG.debug(u'Displaying prompt (%s): "%s"%s', prompt_id, message,
                ', Expects text' if text_input else '')
 
     self._response = None
@@ -214,7 +214,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
     """
     if isinstance(prompt_id, basestring):
       prompt_id = uuid.UUID(prompt_id)
-    _LOG.debug('Responding to prompt (%s): "%s"', prompt_id.hex, response)
+    _LOG.debug(u'Responding to prompt (%s): "%s"', prompt_id.hex, response)
     with self._cond:
       if not (self._prompt and self._prompt.id == prompt_id):
         return False

--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -158,7 +158,7 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple):
     return float(obj)
 
   # Convert all other types to strings.
-  return unicode(obj)
+  return str(obj)
 
 
 def total_size(obj):

--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -158,7 +158,7 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple):
     return float(obj)
 
   # Convert all other types to strings.
-  return str(obj)
+  return unicode(obj)
 
 
 def total_size(obj):

--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -180,7 +180,6 @@ class RecordHandler(logging.Handler):
     if record.exc_info:
       message += '\n' + ''.join(traceback.format_exception(
           *record.exc_info))
-    message = message.decode('utf8', 'replace')
 
     log_record = LogRecord(
         record.levelno, record.name, os.path.basename(record.pathname),

--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -178,7 +178,7 @@ class RecordHandler(logging.Handler):
     """
     message = record.getMessage()
     if record.exc_info:
-      message += '\n' + ''.join(traceback.format_exception(
+      message += u'\n' + u''.join(traceback.format_exception(
           *record.exc_info))
 
     log_record = LogRecord(

--- a/test/util/data_test.py
+++ b/test/util/data_test.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # Copyright 2016 Google Inc. All Rights Reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +30,7 @@ class TestData(unittest.TestCase):
       'list': [10],
       'tuple': (10,),
       'str': '10',
-      'unicode': u'10',
+      'unicode': u'☃',
       'int': 2 ** 40,
       'float': 10.0,
       'long': 2 ** 80,
@@ -43,6 +45,7 @@ class TestData(unittest.TestCase):
     self.assertIs(type(converted['tuple']), tuple)
     self.assertIs(type(converted['str']), str)
     self.assertIs(type(converted['unicode']), unicode)
+    self.assertEqual(converted['unicode'], example_data['unicode'])
     self.assertIs(type(converted['int']), int)
     self.assertIs(type(converted['float']), float)
     self.assertIs(type(converted['long']), long)

--- a/test/util/data_test.py
+++ b/test/util/data_test.py
@@ -51,5 +51,5 @@ class TestData(unittest.TestCase):
     self.assertIs(type(converted['long']), long)
     self.assertIs(type(converted['bool']), bool)
     self.assertIs(converted['none'], None)
-    self.assertIs(type(converted['complex']), unicode)
+    self.assertIs(type(converted['complex']), str)
     self.assertIs(type(converted['float_subclass']), float)

--- a/test/util/data_test.py
+++ b/test/util/data_test.py
@@ -48,5 +48,5 @@ class TestData(unittest.TestCase):
     self.assertIs(type(converted['long']), long)
     self.assertIs(type(converted['bool']), bool)
     self.assertIs(converted['none'], None)
-    self.assertIs(type(converted['complex']), str)
+    self.assertIs(type(converted['complex']), unicode)
     self.assertIs(type(converted['float_subclass']), float)


### PR DESCRIPTION
Tested against the following code:

```python
# coding=utf-8
import openhtf
from openhtf.output.callbacks.json_factory import OutputToJSON
import sys
from openhtf.core.measurements import Measurement


@openhtf.measures(Measurement('val'))
def utf8(test):
    val = u'☹'
    test.logger.error('uh oh')
    test.logger.error(val)
    test.measurements.val = val
    raise Exception(val)

if __name__ == '__main__':
    test = openhtf.Test(utf8)
    test.add_output_callbacks(
        OutputToJSON('log_demo.json')
    )
    test.execute(test_start=lambda: 'fake_dut')
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/651)
<!-- Reviewable:end -->
