### PR TITLE
Give frontends access to plug inheritance info

### DIFF
--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -426,9 +426,10 @@ class PlugManager(object):
     self._plug_types.add(plug_type)
     if plug_type in self._plugs_by_type:
       self._plugs_by_type[plug_type].tearDown()
+    plug_name = self.get_plug_name(plug_type)
     self._plugs_by_type[plug_type] = plug_value
-    self._plugs_by_name[self.get_plug_name(plug_type)] = plug_value
-    self._plug_descriptors[plug_type] = self._make_plug_descriptor(plug_type)
+    self._plugs_by_name[plug_name] = plug_value
+    self._plug_descriptors[plug_name] = self._make_plug_descriptor(plug_type)
 
   def provide_plugs(self, plug_name_map):
     """Provide the requested plugs [(name, type),] as {name: plug instance}."""

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -338,10 +338,12 @@ class PlugManager(object):
         ['openhtf.plugs.user_input.UserInput',
          'my_module.advanced_user_input.AdvancedUserInput']
     """
-    return ','.join([
+    ignored_classes = (BasePlug, FrontendAwareBasePlug)
+    return [
         self.get_plug_name(base_class) for base_class in plug_type.mro()
-        if issubclass(base_class, BasePlug) and base_class is not BasePlug
-    ])
+        if (issubclass(base_class, BasePlug) and
+            base_class not in ignored_classes)
+    ]
 
   def get_plug_name(self, plug_type):
     """Returns the plug's name, which is the class name and module.

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -96,8 +96,8 @@ self._my_config having a value of 'my_config_value'.
 
 import collections
 import functools
-import json
 import inspect
+import json
 import logging
 import threading
 import time
@@ -161,6 +161,31 @@ class BasePlug(object):
     """Returns a PlugPlaceholder for calling class."""
     return PlugPlaceholder(cls)
 
+  @classmethod
+  def get_plug_name(cls):
+    """Returns the plug's name.
+    
+    The plug name is a class name, or, if the plug is a subclass of another
+    plug, a comma-separated list of class names.
+
+    For example:
+        `openhtf.plugs.user_input.UserInput`
+    Or:
+        `openhtf.plugs.user_input.UserInput,\
+            my_module.advanced_user_input.AdvancedUserInput`
+
+    This allows frontends to make use of base class information to render
+    subclassed plugs appropriately.
+    """
+    ignored_classes = {FrontendAwareBasePlug, util.SubscribableStateMixin,
+                       BasePlug, object}
+    mro = [
+        '%s.%s' % (base_cls.__module__, base_cls.__name__)
+        for base_cls in cls.mro()
+        if base_cls not in ignored_classes
+    ]
+    return ','.join(mro)
+  
   def _asdict(self):
     """Return a dictionary representation of this plug's state.
 
@@ -396,8 +421,7 @@ class PlugManager(object):
     if plug_type in self._plugs_by_type:
       self._plugs_by_type[plug_type].tearDown()
     self._plugs_by_type[plug_type] = plug_value
-    self._plugs_by_name[
-        '.'.join((plug_type.__module__, plug_type.__name__))] = plug_value
+    self._plugs_by_name[plug_type.get_plug_name()] = plug_value
 
   def provide_plugs(self, plug_name_map):
     """Provide the requested plugs [(name, type),] as {name: plug instance}."""

--- a/test/plugs_test.py
+++ b/test/plugs_test.py
@@ -87,9 +87,15 @@ class PlugsTest(test.TestCase):
         AdderPlug.LAST_INSTANCE,
         self.plug_manager.provide_plugs(
             (('adder_plug', AdderPlug),))['adder_plug'])
-    self.assertItemsEqual(
-        {'plug_states': {'plugs_test.AdderPlug': {'number': 0}},
-         'xmlrpc_port': None}, self.plug_manager._asdict())
+    self.assertItemsEqual(self.plug_manager._asdict(), {
+        'plug_descriptors': {
+            'plugs_test.AdderPlug': plugs.PlugDescriptor('plugs_test.AdderPlug'),
+        },
+        'plug_states': {
+            'plugs_test.AdderPlug': {'number': 0},
+        },
+        'xmlrpc_port': None,
+    })
     self.assertEquals('CREATED', AdderPlug.LAST_INSTANCE.state)
 
   @test.yields_phases


### PR DESCRIPTION
This PR adds the concept of a plug descriptor. Currently this contains one item of info, the MRO, which here is a list of class names, like `['openhtf.plugs.user_input.UserInput', 'my_module.advanced_user_input.AdvancedUserInput']`.

This allows frontends to make use of base class information to render subclassed plugs appropriately. For example, a frontend might use the same frontend component to render both the standard `openhtf.plugs.user_input.UserInput` and a custom `AdvancedUserInput`, leaving the test writer with the option of using either plug for operator input.