### PR TITLE
Minor fix to error handling of PlugPlaceholders

### DIFF
--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -264,9 +264,10 @@ class PlugManager(object):
 
   def __init__(self, plug_types=None, logger=None):
     self._plug_types = plug_types or set()
-    if any(isinstance(plug, PlugPlaceholder) for plug in self._plug_types):
-      raise InvalidPlugError('Plug %s is a placeholder, replace it using '
-                             'with_plugs()' % plug)
+    for plug in self._plug_types:
+      if isinstance(plug, PlugPlaceholder):
+        raise InvalidPlugError('Plug %s is a placeholder, replace it using '
+                               'with_plugs().' % plug)
     self._logger = logger
     self._plugs_by_type = {}
     self._plugs_by_name = {}


### PR DESCRIPTION
Because generator expressions do *not* leak their loop variable into the surrounding scope, this error message did not have the intended behavior. You would see

> InvalidPlugError: Plug <function plug at 0x102a776e0> is a placeholder

Because of the function `plug` defined elsewhere in this file.

--

Interestingly, list comprehensions *do* leak their loop variable into the surrounding scope in Python 2, but not in Python 3.