### PR TITLE
Neg value handling for within_percent validator.

### DIFF
--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -239,12 +239,16 @@ class WithinPercent(RangeValidatorBase):
     self.percent = percent
 
   @property
+  def _applied_percent(self):
+    return abs(self.expected * self.percent / 100.0)
+
+  @property
   def minimum(self):
-    return (1.0 - self.percent / 100.0) * self.expected
+    return self.expected - self._applied_percent
 
   @property
   def maximum(self):
-    return (1.0 + self.percent / 100.0) * self.expected
+    return self.expected + self._applied_percent
 
   def __call__(self, value):
     return self.minimum <= value <= self.maximum


### PR DESCRIPTION
The WithinPercent validator did not sufficiently handle the case of negative values (as might be encountered when measuring voltages).  This change uses the absolute value of expected and tested values to make accommodation for those cases.