### PR TITLE
Add json_safe option to convert_to_base_types

### DIFF
--- a/openhtf/output/callbacks/json_factory.py
+++ b/openhtf/output/callbacks/json_factory.py
@@ -30,13 +30,18 @@ class OutputToJSON(callbacks.OutputToFile):
   def __init__(self, filename_pattern=None, inline_attachments=True, **kwargs):
     super(OutputToJSON, self).__init__(filename_pattern)
     self.inline_attachments = inline_attachments
+
+    # Conform strictly to the JSON spec by default.
+    kwargs.setdefault('allow_nan', False)
+    self.allow_nan = kwargs['allow_nan']
     self.json_encoder = json.JSONEncoder(**kwargs)
 
   def serialize_test_record(self, test_record):
     return self.json_encoder.encode(self.convert_to_dict(test_record))
 
   def convert_to_dict(self, test_record):
-    as_dict = data.convert_to_base_types(test_record)
+    as_dict = data.convert_to_base_types(test_record,
+                                         json_safe=(not self.allow_nan))
     if self.inline_attachments:
       for phase, original_phase in zip(as_dict['phases'], test_record.phases):
         for name, attachment in phase['attachments'].iteritems():


### PR DESCRIPTION
Add `json_safe` option to `convert_to_base_types()` and enable it by default.

**Background:**
Running `json.dumps()` or `json.JSONEncoder().encode()` on an “out-of-range” float value (`nan`, `inf`, `-inf`) will, by default, produce invalid JSON. `NaN`, `Infinity`, and `-Infinity` are valid Javascript values but invalid in JSON, and they produce errors in JavaScript clients using `JSON.parse`. It's possible to run `json.dumps()` with the `allow_nan=False` option, which raises an error instead of producing invalid JSON, but this still leaves us with the problem of converting out-of-range floats before serialization.

I've reviewed the uses of `convert_to_base_types()` within OpenHTF and I suggest we enable `json_safe` by default. The only place it seemed useful not to enforce it is `json_factory.OutputToJSON`, where I've made it optional, but enabled by default.
