### PR TITLE
Fix missing test in get_attachment and get_measurement

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -173,7 +173,7 @@ class TestState(util.SubscribableStateMixin):
         return copy.deepcopy(attachment)
 
 
-    test.logger.warning('Could not find attachment: %s', attachment_name)
+    self.logger.warning('Could not find attachment: %s', attachment_name)
     return None
 
   def get_measurement(self, measurement_name):
@@ -204,7 +204,7 @@ class TestState(util.SubscribableStateMixin):
         measurement = phase_record.measurements[measurement_name]
         return ImmutableMeasurement.FromMeasurement(measurement)
 
-    test.logger.warning('Could not find measurement: %s', measurement_name)
+    self.logger.warning('Could not find measurement: %s', measurement_name)
     return None
 
   @contextlib.contextmanager


### PR DESCRIPTION
Fix bug introduced when backporting get_attachment and get_measurements.  Fixes traceback when the requested attachment or measurement is missing.