### PR TITLE
Add a 'config-help' CLI flag.

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -190,7 +190,10 @@ class Test(object):
     """Update test-wide configuration options. See TestOptions for docs."""
     # These internally ensure they are safe to call multiple times with no weird
     # side effects.
-    create_arg_parser(add_help=True).parse_known_args()
+    known_args, _ = create_arg_parser(add_help=True).parse_known_args()
+    if known_args.config_help:
+      sys.stdout.write(conf.help_text)
+      sys.exit(0)
     logs.setup_logger()
     for key, value in kwargs.items():
       setattr(self._test_options, key, value)
@@ -328,9 +331,14 @@ def create_arg_parser(add_help=False):
           'My args title', parents=[openhtf.create_arg_parser()])
   >>> parser.parse_args()
   """
-  return argparse.ArgumentParser('OpenHTF-based testing', parents=[
+  parser = argparse.ArgumentParser('OpenHTF-based testing', parents=[
       conf.ARG_PARSER, phase_executor.ARG_PARSER, logs.ARG_PARSER],
       add_help=add_help)
+  parser.add_argument(
+      '--config-help', action='store_true',
+      help='Instead of executing the test, simply print all available config '
+      'keys and their description strings.')
+  return parser
 
 
 # Result of a phase.

--- a/openhtf/util/conf.py
+++ b/openhtf/util/conf.py
@@ -467,7 +467,6 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
       result.append('')
     return '\n'.join(result)
 
-
   def save_and_restore(self, _func=None, **config_values):
     """Decorator for saving conf state and restoring it after a function.
 

--- a/openhtf/util/conf.py
+++ b/openhtf/util/conf.py
@@ -446,6 +446,22 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
         retval[key] = value
     return retval
 
+  @property
+  def help_text(self):
+    """Return a string with all config keys and their descriptions."""
+    result = []
+    for name in sorted(self._declarations.keys()):
+      result.append(name)
+      result.append('-' * len(name))
+      if self._declarations[name].description:
+        result.append(self._declarations[name].description.strip())
+      else:
+        result.append('(no description found)')
+      result.append('')
+      result.append('')
+    return '\n'.join(result)
+
+
   def save_and_restore(self, _func=None, **config_values):
     """Decorator for saving conf state and restoring it after a function.
 

--- a/openhtf/util/conf.py
+++ b/openhtf/util/conf.py
@@ -239,17 +239,17 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     self._modules = kwargs
     self._declarations = {}
     self.ARG_PARSER = parser
-    
+
     # Parse just the flags we care about, since this happens at import time.
     self._flags, _ = parser.parse_known_args()
     self._flag_values = {}
-    
+
     # Populate flag_values from flags now.
     self.load_flag_values()
 
     # Initialize self._loaded_values and load from --config-file if it's set.
     self.reset()
-  
+
   def load_flag_values(self, flags=None):
     """Load flag values given from command line flags.
 
@@ -453,10 +453,16 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     for name in sorted(self._declarations.keys()):
       result.append(name)
       result.append('-' * len(name))
-      if self._declarations[name].description:
-        result.append(self._declarations[name].description.strip())
+      decl = self._declarations[name]
+      if decl.description:
+        result.append(decl.description.strip())
       else:
         result.append('(no description found)')
+      if decl.has_default:
+        result.append('')
+        quotes = '"' if type(decl.default_value) is str else ''
+        result.append('  default_value={quotes}{val}{quotes}'.format(
+            quotes=quotes, val=decl.default_value))
       result.append('')
       result.append('')
     return '\n'.join(result)


### PR DESCRIPTION
If enabled, this flag will cause the framework to print all config
keys and their descriptions and exit rather than executing the test.

Example output:
```
  ble_sniffer_download_port
  -------------------------
  Port for HTTP server for downloading sniffer logs.

  ble_sniffer_enable
  ------------------
  (no description found)

  ble_sniffer_host
  ----------------
  Host running BLE sniffer software.

  ble_sniffer_local_path
  ----------------------
  Local path to access BLE Sniffer logs.

  ble_sniffer_port
  ----------------
  Port the BLE sniffer is running on.

  ble_sniffer_usb_hub_channel
  ---------------------------
  If the acroname_usb_hub_serial exists and can be commanded, this config
  key specifies the channel that the BLE Sniffer is connected to.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/717)
<!-- Reviewable:end -->
