### PR TITLE
Fix 'cannot marshall PlugDescriptor' in web_gui

### DIFF
--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -103,8 +103,6 @@ import threading
 import time
 import types
 
-import mutablerecords
-
 import openhtf
 from openhtf import util
 from openhtf.util import classproperty
@@ -305,9 +303,14 @@ class PlugManager(object):
 
   def _asdict(self):
     return {
-        'plug_descriptors': self._plug_descriptors,
-        'plug_states': {name: plug._asdict()
-                        for name, plug in self._plugs_by_name.items()},
+        'plug_descriptors': {
+            name: dict(descriptor._asdict())  # Convert OrderedDict to dict.
+            for name, descriptor in self._plug_descriptors.items()
+        },
+        'plug_states': {
+            name: plug._asdict()
+            for name, plug in self._plugs_by_name.items()
+        },
         'xmlrpc_port': self._xmlrpc_server and
                        self._xmlrpc_server.socket.getsockname()[1]
     }

--- a/test/plugs_test.py
+++ b/test/plugs_test.py
@@ -88,7 +88,7 @@ class PlugsTest(test.TestCase):
         self.plug_manager.provide_plugs(
             (('adder_plug', AdderPlug),))['adder_plug'])
     self.assertEqual(self.plug_manager._asdict()['plug_descriptors'], {
-            'plugs_test.AdderPlug': plugs.PlugDescriptor(['plugs_test.AdderPlug']),
+            'plugs_test.AdderPlug': {'mro': ['plugs_test.AdderPlug']},
         })
     self.assertEqual(self.plug_manager._asdict()['plug_states'], {
             'plugs_test.AdderPlug': {'number': 0},


### PR DESCRIPTION
This should fix the web GUI. (#704, #715)

Test with:

```
python -m openhtf.output.web_gui
```

In another tab:

```
python hello_world.py
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/721)
<!-- Reviewable:end -->
