### PR TITLE
update test executor timeout threading.MAX_TIMEOUT for >= python 3.2

### DIFF
--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -109,8 +109,12 @@ class TestExecutor(threads.KillableThread):
   def wait(self):
     """Waits until death."""
     try:
-      # Timeout needed for SIGINT handling. Set to a year.
-      self.join(31557600)
+      # Timeout needed for SIGINT handling.
+      if (sys.version_info >= (3, 2)):
+        self.join(threading.TIMEOUT_MAX)
+      else:
+        # Seconds in a year.
+        self.join(31557600)
     except KeyboardInterrupt:
       self.test_state.logger.info('KeyboardInterrupt caught, aborting test.')
       raise


### PR DESCRIPTION
encountered overflow error with windows + python3.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/724)
<!-- Reviewable:end -->
