### PR TITLE
Make logger handle UTF-8 input.

### DIFF
--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -205,7 +205,7 @@ def setup_logger():
 
   # TODO: make printed timestamp optional?
   record_console_handler_formatter = logging.Formatter(
-    '[%(asctime)s]    %(message)s', '%H:%M:%S')
+    u'[%(asctime)s]    %(message)s', '%H:%M:%S')
   record_console_handler = logging.StreamHandler(stream=sys.stdout)
   record_console_handler.setFormatter(record_console_handler_formatter)
   record_console_handler.setLevel(DEFAULT_RECORD_VERBOSITY.upper())
@@ -214,7 +214,7 @@ def setup_logger():
   logger = logging.getLogger(LOGGER_PREFIX)
   logger.propagate = False
   logger.setLevel(logging.DEBUG)
-  formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+  formatter = logging.Formatter(u'%(asctime)s - %(levelname)s - %(message)s')
   if LOGFILE:
     try:
       cur_time = str(util.time_millis())

--- a/test/util/logs_test.py
+++ b/test/util/logs_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Copyright 2016 Google Inc. All Rights Reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,3 +28,11 @@ class TestLogs(unittest.TestCase):
       logs.log_once(mock_log, 'Message 1', 'arg1')
 
     assert mock_log.call_count == 1
+
+  def test_log_once_utf8(self):
+    mock_log = mock.Mock()
+    for _ in range(10):
+      logs.log_once(mock_log, u'状态是', 'arg1')
+
+    assert mock_log.call_count == 1
+


### PR DESCRIPTION
python logging explodes when encountering UTF-8 characters without this change.

Followed the instructions at https://stackoverflow.com/questions/1545263/utf-8-in-python-logging-how

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/730)
<!-- Reviewable:end -->
