### PR TITLE
minor improvements for DeviceWrappingPlug

### DIFF
--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -68,6 +68,9 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
     openhtf.plugs.InvalidPlugError: The _device attribute has the value None
         when attribute access is attempted.
   """
+
+  verbose = True # overwrite on subclass to disable loggging_wrapper.
+
   def __init__(self, device):
     super(DeviceWrappingPlug, self).__init__()
     self._device = device
@@ -79,7 +82,7 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
 
     attribute = getattr(self._device, attr)
 
-    if not callable(attribute):
+    if not verbose or not callable(attribute):
       return attribute
 
     # Attribute callable; return a wrapper that logs calls with args and kwargs.

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -131,6 +131,7 @@ from openhtf.core import phase_executor
 from openhtf.core import station_api
 from openhtf.core import test_record
 from openhtf.core import test_state
+from openhtf.plugs import device_wrapping
 from openhtf.util import conf
 
 

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -224,7 +224,7 @@ class PhaseOrTestIterator(collections.Iterator):
       self.last_result = self._handle_phase(
           openhtf.PhaseDescriptor.wrap_or_copy(phase_or_test))
     return phase_or_test, self.last_result
-  
+
   def next(self):
     phase_or_test = self.iterator.send(self.last_result)
     if isinstance(phase_or_test, openhtf.Test):
@@ -313,7 +313,13 @@ def patch_plugs(**mock_plugs):
       else:
         raise ValueError('Invalid plug type specification %s="%s"' % (
             plug_arg_name, plug_fullname))
-      plug_mock = mock.create_autospec(plug_type, spec_set=True, instance=True)
+      if issubclass(plug_type, device_wrapping.DeviceWrappingPlug):
+        # We can't strictly spec because calls to attributes are proxied to the
+        # underlying device.
+        plug_mock = mock.MagicMock()
+      else:
+        plug_mock = mock.create_autospec(plug_type, spec_set=True,
+                                         instance=True)
       plug_typemap[plug_type] = plug_mock
       plug_kwargs[plug_arg_name] = plug_mock
 
@@ -336,7 +342,7 @@ class TestCase(unittest.TestCase):
     if inspect.isgeneratorfunction(test_method):
       raise ValueError(
           "%s yields without @openhtf.util.test.yields_phases" % methodName)
-    
+
     # Mock the station api server.
     station_api_server_patcher = mock.patch.object(station_api, 'ApiServer')
     self.mock_api_server = station_api_server_patcher.start()


### PR DESCRIPTION
* Making DeviceWrappingPlug compatible with @test.patch_plugs.  We can't use a strict mock spec, because a DeviceWrappingPlug instance proxies calls to getattr to the underlying device.
* Adding option to disable logging_wrapper on subclasses of DeviceWrappingPlug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/732)
<!-- Reviewable:end -->
