### PR TITLE
Fix issue with casting a multi-dim to an ImmutableMeasurement

### DIFF
--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -133,6 +133,8 @@ def analysis(test):
       (3, 23, 103, 129),
       (4, 24, 104, 132)
   ]
+  test.logger.info('Pandas datafram of lots_of_dims \n:%s',
+                   lots_of_dims.value.to_dataframe())
 
 
 def teardown(test):

--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -127,7 +127,7 @@ def analysis(test):
   test_attachment = test.get_attachment('test_attachment')
   assert test_attachment.data == 'This is test attachment data.'
   lots_of_dims = test.get_measurement('lots_of_dims')
-  assert lots_of_dims.value == [
+  assert lots_of_dims.value.value == [
       (1, 21, 101, 123),
       (2, 22, 102, 126),
       (3, 23, 103, 129),
@@ -141,7 +141,8 @@ def teardown(test):
 
 if __name__ == '__main__':
   test = htf.Test(
-      hello_world, set_measurements, dimensions, attachments, skip_phase,
+      hello_world,
+      set_measurements, dimensions, attachments, skip_phase,
       measures_with_args.with_args(min=2, max=4), analysis,
       # Some metadata fields, these in particular are used by mfg-inspector,
       # but you can include any metadata fields.

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -29,6 +29,7 @@ import contextlib
 import copy
 import logging
 import mimetypes
+import mutablerecords
 import os
 import socket
 
@@ -77,8 +78,10 @@ class ImmutableMeasurement(collections.namedtuple(
   def FromMeasurement(cls, measurement):
     measured_value = measurement.measured_value
     if isinstance(measured_value, measurements.DimensionedMeasuredValue):
-      value = measured_value.CopyRecord(
-        value_dict=copy.deepcopy(measured_value.value))
+      value = mutablerecords.CopyRecord(
+          measured_value,
+          value_dict=copy.deepcopy(measured_value.value_dict)
+      )
     else:
       value = (copy.deepcopy(measured_value.value)
                if measured_value.is_value_set else None)

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -79,7 +79,7 @@ class ImmutableMeasurement(collections.namedtuple(
     if isinstance(measured_value, measurements.DimensionedMeasuredValue):
       value = measured_value.CopyRecord(
         value_dict=copy.deepcopy(measured_value.value))
-    else
+    else:
       value = (copy.deepcopy(measured_value.value)
                if measured_value.is_value_set else None)
 

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -76,10 +76,16 @@ class ImmutableMeasurement(collections.namedtuple(
   @classmethod
   def FromMeasurement(cls, measurement):
     measured_value = measurement.measured_value
-    value = measured_value.value if measured_value.is_value_set else None
+    if isinstance(measured_value, measurements.DimensionedMeasuredValue):
+      value = measured_value.CopyRecord(
+        value_dict=copy.deepcopy(measured_value.value))
+    else
+      value = (copy.deepcopy(measured_value.value)
+               if measured_value.is_value_set else None)
+
     return cls(
         measurement.name,
-        copy.deepcopy(value),
+        value,
         measurement.units,
         measurement.dimensions,
         measurement.outcome)


### PR DESCRIPTION
Fix issue where a multi-dim measurement was flattened to a list by use of the @property DimensionedMeasuredValue.value.  This data loss meant the to_dataframe method did not function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/733)
<!-- Reviewable:end -->
