### PR TITLE
Make killable threads more robust to race condition

### DIFF
--- a/openhtf/util/threads.py
+++ b/openhtf/util/threads.py
@@ -95,7 +95,7 @@ class KillableThread(ExceptionSafeThread):
     assert self.is_alive(), 'Only running threads have a thread identity'
     result = ctypes.pythonapi.PyThreadState_SetAsyncExc(
         ctypes.c_long(self.ident), ctypes.py_object(exc_type))
-    if result == 0:
+    if result == 0 and self.is_alive():
       raise ValueError('Thread ID was invalid.', self.ident)
     elif result != 1:
       # Something bad happened, call with a NULL exception to undo.

--- a/openhtf/util/threads.py
+++ b/openhtf/util/threads.py
@@ -83,6 +83,17 @@ class KillableThread(ExceptionSafeThread):
   """Killable thread raises an internal exception when killed.
 
   Based on recipe available at http://tomerfiliba.com/recipes/Thread2/
+
+  Important Note:
+    From PyThreadState_SetAsyncExc documentation:  "To prevent naive misuse,
+    you must write your own C extension to call this. Must be called with the
+    GIL held."
+
+    We do not implement C extension and are not holding GIL so are susceptible
+    to race condition, we've tried to make KillabelThread robust to those race
+    conditions.
+
+
   """
 
   def kill(self):


### PR DESCRIPTION
There is a very small chance that a killable thread will end on it's own before it is killed.  Make us robust to this race condition by not raising an error if the thread is no longer alive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/740)
<!-- Reviewable:end -->
