### PR TITLE
Use six.string_types where there was basestring before

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -570,7 +570,7 @@ def measures(*measurements, **kwargs):
     """Turn strings into Measurement objects if necessary."""
     if isinstance(meas, Measurement):
       return meas
-    elif isinstance(meas, str):
+    elif isinstance(meas, six.string_types):
       return Measurement(meas, **kwargs)
     raise InvalidMeasurementType('Expected Measurement or string', meas)
 

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -32,6 +32,7 @@ import tempfile
 
 from openhtf import util
 from openhtf.util import data
+import six
 
 
 # TODO(wallacbe): Switch to util
@@ -86,7 +87,7 @@ class OutputToFile(object):
     record_dict = data.convert_to_base_types(
         test_record, ignore_keys=('code_info', 'phases', 'log_records'))
     pattern = self.filename_pattern
-    if isinstance(pattern, str) or callable(pattern):
+    if isinstance(pattern, six.string_types) or callable(pattern):
       output_file = self.open_file(util.format_string(pattern, record_dict))
       try:
         yield output_file

--- a/openhtf/plugs/usb/adb_device.py
+++ b/openhtf/plugs/usb/adb_device.py
@@ -142,7 +142,7 @@ class AdbDevice(object):
       timeout_ms: Expected timeout for any part of the push.
     """
     mtime = 0
-    if isinstance(source_file, str):
+    if isinstance(source_file, six.string_types):
       mtime = os.path.getmtime(source_file)
       source_file = open(source_file)
 
@@ -162,7 +162,7 @@ class AdbDevice(object):
       The file data if dest_file is not set, None otherwise.
     """
     should_return_data = dest_file is None
-    if isinstance(dest_file, str):
+    if isinstance(dest_file, six.string_types):
       dest_file = open(dest_file, 'w')
     elif dest_file is None:
       dest_file = six.StringIO()

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -214,7 +214,7 @@ class UserInput(plugs.FrontendAwareBasePlug):
     Returns:
       True if the prompt was used, otherwise False.
     """
-    if isinstance(prompt_id, str):
+    if isinstance(prompt_id, six.string_types):
       prompt_id = uuid.UUID(prompt_id)
     _LOG.debug('Responding to prompt (%s): "%s"', prompt_id.hex, response)
     with self._cond:

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -36,6 +36,7 @@ import uuid
 from openhtf import PhaseOptions
 from openhtf import plugs
 from openhtf.util import argv
+import six
 from six.moves import input
 
 

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -147,7 +147,7 @@ def format_string(target, kwargs):
     return target
   if callable(target):
     return target(**kwargs)
-  if not isinstance(target, str):
+  if not isinstance(target, six.string_types):
     return target
   if '{' in target:
     return partial_format(target, **kwargs)

--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -119,7 +119,7 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple,
       skipped.
     - Enum instances are converted to strings via their .name attribute.
     - Real and integral numbers are converted to built-in types.
-    - Byte and unicode strings are left alone (instances of basestring).
+    - Byte and unicode strings are left alone (instances of six.string_types).
     - Other non-None values are converted to strings via str().
 
   The return value contains only the Python built-in types: dict, list, tuple,
@@ -134,7 +134,7 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple,
   such as NaN which are not valid JSON.
   """
   # Because it's *really* annoying to pass a single string accidentally.
-  assert not isinstance(ignore_keys, str), 'Pass a real iterable!'
+  assert not isinstance(ignore_keys, six.string_types), 'Pass a real iterable!'
 
   if type(obj) in PASSTHROUGH_TYPES:
     return obj
@@ -197,7 +197,7 @@ def total_size(obj):
       size += sum(map(sizeof, itertools.chain.from_iterable(
           six.iteritems(current_obj))))
     elif (isinstance(current_obj, collections.Iterable) and
-          not isinstance(current_obj, str)):
+          not isinstance(current_obj, six.string_types)):
       size += sum(sizeof(item) for item in current_obj)
     elif isinstance(current_obj, records.RecordClass):
       size += sum(sizeof(getattr(current_obj, attr))

--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -63,7 +63,6 @@ Test record logs are by default output to stdout at a debug level.  Use the
 --test-record-verbosity flag to select a different level of chatter.
 """
 
-from past.builtins import basestring
 import argparse
 import collections
 import logging
@@ -75,6 +74,7 @@ import traceback
 from openhtf import util
 from openhtf.util import argv
 from openhtf.util import functions
+import six
 
 
 DEFAULT_LEVEL = 'warning'
@@ -155,7 +155,7 @@ class MacAddressLogFilter(logging.Filter):
       record.msg = self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, record.msg)
       record.args = tuple([
           self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, str(arg))
-          if isinstance(arg, basestring)
+          if isinstance(arg, six.string_types)
           else arg for arg in record.args])
     return True
 

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -112,7 +112,6 @@ List of assertions that can be used with either PhaseRecords or TestRecords:
   assertMeasurementFail(phase_or_test_rec, measurement)
 """
 
-from past.builtins import basestring
 import collections
 import functools
 import inspect
@@ -302,7 +301,7 @@ def patch_plugs(**mock_plugs):
     plug_kwargs = {}  # kwargs to pass to test func.
     plug_typemap = {}  # typemap for PlugManager, maps type to instance.
     for plug_arg_name, plug_fullname in six.iteritems(mock_plugs):
-      if isinstance(plug_fullname, basestring):
+      if isinstance(plug_fullname, six.string_types):
         try:
           plug_module, plug_typename = plug_fullname.rsplit('.', 1)
           plug_type = getattr(sys.modules[plug_module], plug_typename)

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -58,9 +58,9 @@ import abc
 import numbers
 import re
 import sys
-from past.builtins import basestring
 from future.utils import with_metaclass
 from openhtf import util
+import six
 
 _VALIDATORS = {}
 
@@ -173,8 +173,8 @@ register(in_range, name='in_range')
 def equals(value, type=None):
   if isinstance(value, numbers.Number):
     return InRange(minimum=value, maximum=value, type=type)
-  elif isinstance(value, basestring):
-    assert type is None or issubclass(type, basestring), (
+  elif isinstance(value, six.string_types):
+    assert type is None or issubclass(type, six.string_types), (
         'Cannot use a non-string type when matching a string')
     return matches_regex('^{}$'.format(re.escape(value)))
   else:


### PR DESCRIPTION
@kdsudac ran into this since it broke the UserInput plug.

Used diff of #679 as reference. `fastboot_protocol.py` was fixed previously in #739.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/743)
<!-- Reviewable:end -->
