### PR TITLE
Fix extra exception when plug init fails.

### DIFF
--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -253,11 +253,12 @@ class PhaseExecutor(object):
     Args:
       timeout_s: int or None, timeout in seconds to wait for the phase to stop.
     """
-    self._stopping.set()
     phase_thread = self._current_phase_thread
 
     if not phase_thread:
       return
+
+    self._stopping.set()
 
     if phase_thread.is_alive():
       phase_thread.kill()
@@ -271,5 +272,5 @@ class PhaseExecutor(object):
     # Clear the currently running phase, whether it finished or timed out.
     self.test_state.stop_running_phase()
 
-    # Clear stopping once we're done, in case we're used againu
+    # Clear stopping once we're done, in case we're used again.
     self._stopping.clear()


### PR DESCRIPTION
If there is an exception during plug initialization, the test record
outcome is never set for the console printing code in
_excecute_test_teardown to be called properly.

This required a few other changes:
* In Phase Executor, don't set the stopping event if there is no
current phase running.
* In Test State, make sure _finalize always sets the test record
outcome.
* Add unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/745)
<!-- Reviewable:end -->
