### PR TITLE
MacAddressLogFilter use record.getMessage() if not string

### DIFF
--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -152,11 +152,14 @@ class MacAddressLogFilter(logging.Filter):
   def filter(self, record):
     if self.MAC_REPLACE_RE.search(record.getMessage()):
       # Update all the things to have no mac address in them
-      record.msg = self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, record.msg)
-      record.args = tuple([
-          self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, str(arg))
-          if isinstance(arg, six.string_types)
-          else arg for arg in record.args])
+      if isinstance(record.msg, six.string_types:
+        record.msg = self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, record.msg)
+        record.args = tuple([
+            self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, str(arg))
+            if isinstance(arg, six.string_types)
+            else arg for arg in record.args])
+      else:
+        record.msg = self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, record.getMessage())
     return True
 
 

--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -152,7 +152,7 @@ class MacAddressLogFilter(logging.Filter):
   def filter(self, record):
     if self.MAC_REPLACE_RE.search(record.getMessage()):
       # Update all the things to have no mac address in them
-      if isinstance(record.msg, six.string_types:
+      if isinstance(record.msg, six.string_types):
         record.msg = self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, record.msg)
         record.args = tuple([
             self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, str(arg))


### PR DESCRIPTION
record.msg is not necessarily a string and python logging api does support arbitrary objects (as long as they have __str__ implemented) being passed into logging.  Calling record.getMessage() 

https://docs.python.org/2/library/logging.html#logging.LogRecord.getMessage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/746)
<!-- Reviewable:end -->
