### PR TITLE
Fix Phase Executor stop race condition.

### DIFF
--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -196,6 +196,7 @@ class TestExecutor(threads.KillableThread):
 
   def _execute_test_teardown(self, phase_exec):
     phase_exec.stop(timeout_s=conf.cancel_timeout_s)
+    phase_exec.reset_stop()
     if self._do_teardown_function and self._teardown_function:
       phase_exec.execute_phase(self._teardown_function)
     self.test_state.plug_manager.tear_down_plugs()


### PR DESCRIPTION
The Phase Executor has a race condition where a stop() call issued after
execute_phase() checks the _stopping event, but before the internal
functions actually set the current phase thread.  When this occurs, the
phase will start unexpectedly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/747)
<!-- Reviewable:end -->
