### PR TITLE
Restructure test state finalization.

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -335,17 +335,6 @@ class TestState(util.SubscribableStateMixin):
                                            'A phase stopped the test run.')
       self._finalize(test_record.Outcome.FAIL)
 
-  def finalize_on_failed_plug_initialization(self, except_info):
-    if self._is_aborted():
-      return
-
-    self.logger.error('Finishing test execution early due to failed plug '
-                      'initialization.')
-    code = except_info.exc_type.__name__
-    description = str(except_info.exc_val)
-    self.test_record.add_outcome_details(code, description)
-    self._finalize(test_record.Outcome.ERROR)
-
   def finalize_normally(self):
     """Mark the state as finished.
 


### PR DESCRIPTION
Finalizing the test state causes the loggers to be reset.  This also
meant that a failure during the teardown phase does not affect the test
outcome.

Changing this so the finalization always occurs after the teardown phase
and plug teardowns to gather their logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/749)
<!-- Reviewable:end -->
