### PR TITLE
cleaning up formatting, adding trailing newline for copybara

### DIFF
--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -73,4 +73,3 @@ class TestConsoleSummary(test.TestCase):
     instance = console_summary.ConsoleSummary()
     for outcome in htf.test_record.Outcome:
         self.assertIn(outcome, instance.color_table)
-

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -68,8 +68,9 @@ class TestOutput(test.TestCase):
 
 class TestConsoleSummary(test.TestCase):
 
-    def test_outcome_colors(self):
-        """Ensure there is an output color for each outcome."""
-        instance = console_summary.ConsoleSummary()
-        for outcome in htf.test_record.Outcome:
-            self.assertIn(outcome, instance.color_table)
+  def test_outcome_colors(self):
+    """Ensure there is an output color for each outcome."""
+    instance = console_summary.ConsoleSummary()
+    for outcome in htf.test_record.Outcome:
+        self.assertIn(outcome, instance.color_table)
+


### PR DESCRIPTION
Our sync to internal repo checks for trailing newline character in unit tests files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/751)
<!-- Reviewable:end -->
