### PR TITLE
Update web_gui imports

### DIFF
--- a/openhtf/output/web_gui/src/app/station.service.ts
+++ b/openhtf/output/web_gui/src/app/station.service.ts
@@ -17,7 +17,7 @@ declare var jsonpatch; // Global provided by the fast-json-patch package.
 
 import {Injectable} from 'angular2/core';
 import {Headers, Http, RequestOptions} from 'angular2/http';
-import {Observable} from 'rxjs/Observable';
+import {Observable} from 'rxjs';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/catch';
 

--- a/openhtf/output/web_gui/src/other_modules/get_other_modules.py
+++ b/openhtf/output/web_gui/src/other_modules/get_other_modules.py
@@ -18,7 +18,7 @@
 
 import argparse
 import os
-import urllib.request, urllib.parse, urllib.error
+from six.moves.urllib import request
 
 TARGETS = [
     'http://cdn.jsdelivr.net/sockjs/1/sockjs.min.js',  # sockjs
@@ -38,7 +38,7 @@ def main():
     filename = src.split('/')[-1].split('#')[0].split('?')[0]
     dst = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
     if args.force or not os.path.exists(dst):
-      urllib.request.urlretrieve(src, dst)
+      request.urlretrieve(src, dst)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix `get_other_modules.py` for Python 2 and update rxjs import style in `station.service.ts`.

Tested by building and running the web_gui

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/752)
<!-- Reviewable:end -->
