### PR TITLE
Make Equals.expected, InRange.minimum and InRange.maximum consistent with the value used for valiation

### DIFF
--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -118,16 +118,18 @@ class InRange(RangeValidatorBase):
 
   @property
   def minimum(self):
-    return self._minimum
+    converter = self._type or _identity
+    return converter(self._minimum)
 
   @property
   def maximum(self):
-    return self._maximum
+    converter = self._type or _identity
+    return converter(self._maximum)
 
   def with_args(self, **kwargs):
     return type(self)(
-        minimum=util.format_string(self.minimum, kwargs),
-        maximum=util.format_string(self.maximum, kwargs),
+        minimum=util.format_string(self._minimum, kwargs),
+        maximum=util.format_string(self._maximum, kwargs),
         type=self._type,
     )
 
@@ -138,12 +140,9 @@ class InRange(RangeValidatorBase):
     # Check for nan
     if math.isnan(value):
       return False
-    converter = self._type or _identity
-    minimum = converter(self.minimum)
-    maximum = converter(self.maximum)
-    if minimum is not None and value < minimum:
+    if self.minimum is not None and value < self.minimum:
       return False
-    if maximum is not None and value > maximum:
+    if self.maximum is not None and value > self.maximum:
       return False
     return True
 
@@ -185,12 +184,16 @@ class Equals(object):
   """Validator to verify an object is equal to the expected value."""
 
   def __init__(self, expected, type=None):
-    self.expected = expected
+    self._expected = expected
     self._type = type
 
-  def __call__(self, value):
+  @property
+  def expected(self):
     converter = self._type or _identity
-    return value == converter(self.expected)
+    return converter(self._expected)
+
+  def __call__(self, value):
+    return value == self.expected
 
   def __str__(self):
     return "'x' is equal to '%s'" % self.expected

--- a/test/util/validators_test.py
+++ b/test/util/validators_test.py
@@ -56,6 +56,14 @@ class TestInRange(unittest.TestCase):
     validator_c = validators.InRange(maximum=10)
     self.assertNotEqual(validator_a, validator_c)
 
+  def test_with_custom_type(self):
+    hex_int = lambda x: int(x, 16)
+    test_validator = validators.InRange('0x10', '0x12', type=hex_int)
+    self.assertTrue(test_validator(0x11))
+    self.assertFalse(test_validator(0x9))
+    self.assertEqual(test_validator.minimum, 0x10)
+    self.assertEqual(test_validator.maximum, 0x12)
+
 
 class TestEqualsValidator(unittest.TestCase):
 
@@ -68,6 +76,11 @@ class TestEqualsValidator(unittest.TestCase):
       A = 10
     my_type = MyType()
     self.assertTrue(validators.Equals(my_type)(my_type))
+
+  def test_with_custom_type(self):
+    hex_int = lambda x: int(x, 16)
+    self.assertTrue(validators.Equals('0x12', type=hex_int)(0x12))
+    self.assertEqual(validators.Equals('0x12', type=hex_int).expected, 0x12)
 
   def test_str_does_not_raise(self):
     equality_validator = validators.Equals(1)


### PR DESCRIPTION
`Equals.expected`, `InRange.minimum` and `InRange.maximum` should return the same value that has been used in validation, even when a customized `type` has been specifed. This helps the third party test recording tool such as [steam_engine](http://google3/third_party/car/hw/testing/output/steam_engine.py) to correctly interpret the validator's expectations.