### PR TITLE
Handle dimensioned measurement validation errors

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -251,11 +251,17 @@ class Measurement(  # pylint: disable=no-init
   def validate(self):
     """Validate this measurement and update its 'outcome' field."""
     # PASS if all our validators return True, otherwise FAIL.
-    if all(v(self.measured_value.value) for v in self.validators):
-      self.outcome = Outcome.PASS
-    else:
+    try:
+      if all(v(self.measured_value.value) for v in self.validators):
+        self.outcome = Outcome.PASS
+      else:
+        self.outcome = Outcome.FAIL
+      return self
+    except Exception as e:  # pylint: disable=bare-except
+      _LOG.error('Validation for measurement %s raised an exception %s.',
+                 self.name, e)
       self.outcome = Outcome.FAIL
-    return self
+      raise
 
   def _asdict(self):
     """Convert this measurement to a dict of basic types."""


### PR DESCRIPTION
Exceptions in dimensioned measurement validations occur in the Test
Executor thread, which measn they are not caught by the normal flow of
tests.  When those occur, the test will end and will be reported as a
PASS.

This commit changes that.  Now, an exception during a dimensioned
validation measurement validator function will set the phase result to
the raise exception if the phase result is not terminal.  The existing
result will be left in place if it is terminal; in this case, the
validator exception is logged with its stack dump to ensure that there
is still a record.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/770)
<!-- Reviewable:end -->
