### PR TITLE
Refactoring test_executor to have access to test_options

### DIFF
--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -30,7 +30,6 @@ from types import LambdaType
 import uuid
 import weakref
 
-from enum import Enum
 import colorama
 import mutablerecords
 
@@ -77,6 +76,13 @@ def create_arg_parser(add_help=False):
   >>> parser = argparse.ArgumentParser(
           'My args title', parents=[openhtf.create_arg_parser()])
   >>> parser.parse_args()
+
+  Args:
+    add_help: boolean option passed through to arg parser.
+
+  Returns:
+    an `argparse.ArgumentParser`
+
   """
   parser = argparse.ArgumentParser(
       'OpenHTF-based testing',
@@ -272,10 +278,8 @@ class Test(object):
         trigger.code_info = test_record.CodeInfo.for_function(trigger.func)
 
       self._executor = test_executor.TestExecutor(
-          self._test_desc, self.make_uid(), trigger,
-          self._test_options.default_dut_id,
-          self._test_options.teardown_function,
-          self._test_options.failure_exceptions)
+          self._test_desc, self.make_uid(), trigger, self._test_options)
+
       _LOG.info('Executing test: %s', self.descriptor.code_info.name)
       self.TEST_INSTANCES[self.uid] = self
       self._executor.start()
@@ -305,7 +309,7 @@ class Test(object):
                                                       colorama.Fore.GREEN))
           colors[test_record.Outcome.FAIL] = ''.join((colorama.Style.BRIGHT,
                                                       colorama.Fore.RED))
-          msg_template = "test: {name}  outcome: {color}{outcome}{rst}"
+          msg_template = 'test: {name}  outcome: {color}{outcome}{rst}'
           console_output.banner_print(msg_template.format(
               name=final_state.test_record.metadata['test_name'],
               color=colors[final_state.test_record.outcome],

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -127,10 +127,10 @@ from openhtf import plugs
 from openhtf import util
 from openhtf.core import measurements
 from openhtf.core import phase_executor
+from openhtf.core import test_descriptor
 from openhtf.core import test_record
 from openhtf.core import test_state
 from openhtf.plugs import device_wrapping
-from openhtf.util import conf
 import six
 
 
@@ -180,10 +180,14 @@ class PhaseOrTestIterator(collections.Iterator):
     self._initialize_plugs(phase_plug.cls for phase_plug in phase_desc.plugs)
 
     # Cobble together a fake TestState to pass to the test phase.
+    test_options = test_descriptor.TestOptions()
     with mock.patch(
         'openhtf.plugs.PlugManager', new=lambda _, __: self.plug_manager):
-      test_state_ = test_state.TestState(openhtf.TestDescriptor(
-          (phase_desc,), phase_desc.code_info, {}), 'Unittest:StubTest:UID')
+      test_state_ = test_state.TestState(
+          openhtf.TestDescriptor((phase_desc,), phase_desc.code_info, {}),
+          'Unittest:StubTest:UID',
+          test_options
+      )
       test_state_.mark_test_started()
 
     # Actually execute the phase, saving the result in our return value.

--- a/test/test_state_test.py
+++ b/test/test_state_test.py
@@ -17,8 +17,9 @@ import unittest
 import mock
 
 import openhtf
-from openhtf import plugs
 from openhtf.core import test_state
+from openhtf.core import test_descriptor
+
 
 @openhtf.measures('test_measurement')
 @openhtf.PhaseOptions(name='test_phase')
@@ -26,11 +27,13 @@ def test_phase():
   """Test docstring."""
   pass
 
+
 class TestTestApi(unittest.TestCase):
 
   def setUp(self):
-    test_descriptor = mock.MagicMock()
-    self.test_state = test_state.TestState(test_descriptor, 'testing-123')
+    mock_test_descriptor = mock.MagicMock()
+    self.test_state = test_state.TestState(mock_test_descriptor, 'testing-123',
+                                           test_descriptor.TestOptions())
     self.running_phase_state = test_state.PhaseState.from_descriptor(
         test_phase, lambda *args: None)
     self.test_state.running_phase_state = self.running_phase_state
@@ -39,7 +42,7 @@ class TestTestApi(unittest.TestCase):
   def test_get_attachment(self):
     attachment_name = 'attachment.txt'
     input_contents = 'This is some attachment text!'
-    mimetype='text/plain'
+    mimetype = 'text/plain'
     self.test_api.attach(attachment_name, input_contents, mimetype)
 
     output_attachment = self.test_api.get_attachment(attachment_name)


### PR DESCRIPTION
Refactoring test_executor to have access to test_options to avoid unpacking test options to pass into test executor.

Cleaned up linting errors where practical.

PiperOrigin-RevId: 195146959

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/771)
<!-- Reviewable:end -->
