### PR TITLE
Guess mimetype from attachment name

### DIFF
--- a/test/test_state_test.py
+++ b/test/test_state_test.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
 import unittest
 
 import mock
 
 import openhtf
-from openhtf.core import test_state
 from openhtf.core import test_descriptor
+from openhtf.core import test_state
 
 
 @openhtf.measures('test_measurement')
@@ -67,3 +68,21 @@ class TestTestApi(unittest.TestCase):
 
     measurement.value.append(4)
     self.assertNotEqual(measurement_val, measurement.value)
+
+  def test_infer_mime_type_from_file_name(self):
+    with tempfile.NamedTemporaryFile(suffix='.txt') as f:
+      f.write(b'Mock text contents.')
+      f.flush()
+      file_name = f.name
+      self.test_api.attach_from_file(file_name, 'attachment')
+    attachment = self.test_api.get_attachment('attachment')
+    self.assertEqual(attachment.mimetype, 'text/plain')
+
+  def test_infer_mime_type_from_attachment_name(self):
+    with tempfile.NamedTemporaryFile() as f:
+      f.write(b'Mock text contents.')
+      f.flush()
+      file_name = f.name
+      self.test_api.attach_from_file(file_name, 'attachment.png')
+    attachment = self.test_api.get_attachment('attachment.png')
+    self.assertEqual(attachment.mimetype, 'image/png')


### PR DESCRIPTION
Rationale: In attach_from_file() we try to guess mimetype from the source filename. It has sometimes surprised users that the mimetype is not inferred from the attachment name as well.

(Reviewed internally by @arsharma1 and @grybmadsci)

PiperOrigin-RevId: 196022999

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/783)
<!-- Reviewable:end -->
