### PR TITLE
Add color support to CLI prompts

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -69,6 +69,13 @@ class ConsolePrompt(threading.Thread):
   """Thread that displays a prompt to the console and waits for a response."""
 
   def __init__(self, message, callback, color=''):
+    """Initializes a ConsolePrompt.
+
+    Args:
+      message: A string to be presented to the user.
+      callback: A function to be called with the response string.
+      color: An ANSI color code, or the empty string.
+    """
     super(ConsolePrompt, self).__init__()
     self.daemon = True
     self._message = message
@@ -154,7 +161,15 @@ class UserInput(plugs.FrontendAwareBasePlug):
               'text-input': self._prompt.text_input}
 
   def _create_prompt(self, message, text_input, cli_color):
-    """Sets the prompt."""
+    """Set the prompt.
+
+    Called internally by start_prompt().
+
+    Args:
+      message: A string to be presented to the user.
+      text_input: A boolean indicating whether the user must respond with text.
+      cli_color: An ANSI color code, or the empty string.
+    """
     prompt_id = uuid.uuid4()
     _LOG.debug('Displaying prompt (%s): "%s"%s', prompt_id, message,
                ', Expects text' if text_input else '')
@@ -169,22 +184,23 @@ class UserInput(plugs.FrontendAwareBasePlug):
     return prompt_id
 
   def remove_prompt(self):
-    """Ends the prompt."""
+    """Remove the prompt."""
     self._prompt = None
     self._console_prompt.Stop()
     self._console_prompt = None
     self.notify_update()
 
   def prompt(self, message, text_input=False, timeout_s=None, cli_color=''):
-    """Prompt and wait for a user response to the given message.
+    """Set the prompt and wait for the user to respond.
 
     Args:
-      message: The message to display to the user.
-      text_input: True iff the user needs to provide a string back.
+      message: A string to be presented to the user.
+      text_input: A boolean indicating whether the user must respond with text.
       timeout_s: Seconds to wait before raising a PromptUnansweredError.
+      cli_color: An ANSI color code, or the empty string.
 
     Returns:
-      The response from the user, or the empty string if text_input was False.
+      A string response, or the empty string if text_input was False.
 
     Raises:
       MultiplePromptsError: There was already an existing prompt.
@@ -194,14 +210,36 @@ class UserInput(plugs.FrontendAwareBasePlug):
     return self.wait_for_prompt(timeout_s)
 
   def start_prompt(self, message, text_input=False, cli_color=''):
-    """Creates a prompt without blocking on the user's response."""
+    """Set the prompt.
+
+    This can be used in conjunction with remove_prompt() to prompt the user in
+    a non-blocking manner.
+
+    Args:
+      message: A string to be presented to the user.
+      text_input: A boolean indicating whether the user must respond with text.
+      cli_color: An ANSI color code, or the empty string.
+
+    Raises:
+      MultiplePromptsError: There was already an existing prompt.
+    """
     with self._cond:
       if self._prompt:
         raise MultiplePromptsError
       return self._create_prompt(message, text_input, cli_color)
 
   def wait_for_prompt(self, timeout_s=None):
-    """Waits for and returns the user's response to the last prompt."""
+    """Wait for and return the user's response to the current prompt.
+
+    Args:
+      timeout_s: Seconds to wait before raising a PromptUnansweredError.
+
+    Returns:
+      A string response, or the empty string if text_input was False.
+
+    Raises:
+      PromptUnansweredError: Timed out waiting for the user to respond.
+    """
     with self._cond:
       if self._prompt:
         if timeout_s is None:
@@ -213,17 +251,17 @@ class UserInput(plugs.FrontendAwareBasePlug):
       return self._response
 
   def respond(self, prompt_id, response):
-    """Respond to the prompt that has the given ID.
+    """Respond to the prompt with the given ID.
 
-    If there is no active prompt or the prompt id being responded to doesn't
-    match the active prompt, do nothing.
+    If there is no active prompt or the given ID doesn't match the active
+    prompt, do nothing.
 
     Args:
       prompt_id: Either a UUID instance, or a string representing a UUID.
       response: A string response to the given prompt.
 
     Returns:
-      True if the prompt was used, otherwise False.
+      True if the prompt with the given ID was active, otherwise False.
     """
     if isinstance(prompt_id, six.string_types):
       prompt_id = uuid.UUID(prompt_id)
@@ -252,7 +290,6 @@ def prompt_for_test_start(
   @plugs.plug(prompts=UserInput)
   def trigger_phase(test, prompts):
     """Test start trigger that prompts the user for a DUT ID."""
-
     dut_id = prompts.prompt(message=message, text_input=True,
                             timeout_s=timeout_s)
     test.test_record.dut_id = validator(dut_id)


### PR DESCRIPTION
Addresses #781. Depends on #784. Relevant code is in the last commit.

Example:

![screen shot 2018-05-16 at 4 56 15 pm](https://user-images.githubusercontent.com/3301218/40149808-afdfb156-592a-11e8-883a-7ffd64a5ed3d.png)

(After modifying `prompt_for_test_start` as follows:)

```python
    import colorama
    dut_id = prompts.prompt(message=message, text_input=True,
                            timeout_s=timeout_s, cli_color=colorama.Fore.RED)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/785)
<!-- Reviewable:end -->
