### PR TITLE
Map TIMEOUT and ABORTED test outcome to their respective status code

### DIFF
--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -108,12 +108,13 @@ def measures_with_args(test, min, max):
 
 
 def attachments(test):
-  test.attach('test_attachment', 'This is test attachment data.'.encode('utf-8'))
+  attachment_data = 'This is test attachment data.'.encode('utf-8')
+  test.attach('test_attachment', attachment_data)
   test.attach_from_file(
       os.path.join(os.path.dirname(__file__), 'example_attachment.txt'))
 
   test_attachment = test.get_attachment('test_attachment')
-  assert test_attachment.data == 'This is test attachment data.'
+  assert test_attachment.data == attachment_data
 
 
 @htf.TestPhase(run_if=lambda: False)

--- a/openhtf/output/callbacks/mfg_inspector.py
+++ b/openhtf/output/callbacks/mfg_inspector.py
@@ -63,8 +63,8 @@ OUTCOME_MAP = {
     test_record.Outcome.ERROR: test_runs_pb2.ERROR,
     test_record.Outcome.FAIL: test_runs_pb2.FAIL,
     test_record.Outcome.PASS: test_runs_pb2.PASS,
-    test_record.Outcome.TIMEOUT: test_runs_pb2.ERROR,
-    test_record.Outcome.ABORTED: test_runs_pb2.ERROR,
+    test_record.Outcome.TIMEOUT: test_runs_pb2.TIMEOUT,
+    test_record.Outcome.ABORTED: test_runs_pb2.ABORTED,
 }
 
 UOM_CODE_MAP = {


### PR DESCRIPTION
openhtf used to mapping both TIMEOUT and ABORTED test outcome to ERROR test run status code. This change maps them to their respective test run status code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/789)
<!-- Reviewable:end -->
