### PR TITLE
Enable console logging in the util.test library.

### DIFF
--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -131,7 +131,10 @@ from openhtf.core import test_descriptor
 from openhtf.core import test_record
 from openhtf.core import test_state
 from openhtf.plugs import device_wrapping
+from openhtf.util import logs
 import six
+
+logs.CLI_LOGGING_VERBOSITY = 2
 
 
 class InvalidTestError(Exception):
@@ -177,6 +180,7 @@ class PhaseOrTestIterator(collections.Iterator):
 
   def _handle_phase(self, phase_desc):
     """Handle execution of a single test phase."""
+    logs.configure_cli_logging()
     self._initialize_plugs(phase_plug.cls for phase_plug in phase_desc.plugs)
 
     # Cobble together a fake TestState to pass to the test phase.


### PR DESCRIPTION
From arsharma@: “The OpenHTF unit test library should default to verbose logging and ensure the console logging is enabled for phase unit tests.”

This was previously reviewed internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/797)
<!-- Reviewable:end -->
