### PR TITLE
Silence multicast logs by default

### DIFF
--- a/openhtf/util/multicast.py
+++ b/openhtf/util/multicast.py
@@ -29,6 +29,10 @@ from six.moves import queue
 
 _LOG = logging.getLogger(__name__)
 
+# The multicast logs can occur frequently, e.g. every couple seconds. Prevent
+# most logs from ending up in the test record by default.
+_LOG.setLevel(logging.WARNING)
+
 DEFAULT_ADDRESS = '239.1.1.1'
 DEFAULT_PORT = 10000
 DEFAULT_TTL = 1


### PR DESCRIPTION
See #788 for repro steps.

**Before:**

![screen shot 2018-06-15 at 10 27 25 am](https://user-images.githubusercontent.com/3301218/41481520-26a07000-7087-11e8-8002-85ef1dabd35c.png)

**After:** No multicast log spam.

See also #799.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/800)
<!-- Reviewable:end -->
