### PR TITLE
If a callback fails you should print the traceback

### DIFF
--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -301,7 +301,7 @@ class Test(object):
           try:
             output_cb(final_state.test_record)
           except Exception:  # pylint: disable=broad-except
-            _LOG.error(
+            _LOG.exception(
                 'Output callback %s raised; continuing anyway', output_cb)
         # Make sure the final outcome of the test is printed last and in a
         # noticeable color so it doesn't get scrolled off the screen or missed.


### PR DESCRIPTION
If a callback fails you can continue but should print the traceback, not suppress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/803)
<!-- Reviewable:end -->
