### PR TITLE
Adding uses_base_tear_down functionality and having thread name refle…

### DIFF
--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -198,7 +198,7 @@ class BasePlug(object):
     """Checks whether the tearDown method is the BasePlug implementation."""
     this_tear_down = getattr(self, 'tearDown')
     base_tear_down = getattr(BasePlug, 'tearDown')
-    return this_tear_down.__func__ is base_tear_down.__func__
+    return this_tear_down.__code__ is base_tear_down.__code__
 
 
 class FrontendAwareBasePlug(BasePlug, util.SubscribableStateMixin):

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -458,9 +458,9 @@ class PlugManager(object):
     _LOG.debug('Tearing down all plugs.')
     for plug_type, plug_instance in six.iteritems(self._plugs_by_type):
       if plug_instance.uses_base_tear_down():
-        name = '<PlugTearDownThread: %s>' % plug_type
-      else:
         name = '<PlugTearDownThread: BasePlug No-Op for %s>' % plug_type
+      else:
+        name = '<PlugTearDownThread: %s>' % plug_type
       thread = _PlugTearDownThread(plug_instance, name=name)
       thread.start()
       timeout_s = (conf.plug_teardown_timeout_s

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -194,10 +194,9 @@ class BasePlug(object):
     pass
 
 
-  @classmethod
-  def uses_base_tear_down(cls):
+  def uses_base_tear_down(self):
     """Checks whether the tearDown method is the BasePlug implementation."""
-    this_tear_down = getattr(cls, 'tearDown')
+    this_tear_down = getattr(self, 'tearDown')
     base_tear_down = getattr(BasePlug, 'tearDown')
     return this_tear_down.__func__ is base_tear_down.__func__
 

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -194,6 +194,14 @@ class BasePlug(object):
     pass
 
 
+  @classmethod
+  def uses_base_tear_down(cls):
+    """Checks whether the tearDown method is the BasePlug implementation."""
+    this_tear_down = getattr(cls, 'tearDown')
+    base_tear_down = getattr(BasePlug, 'tearDown')
+    return this_tear_down.__func__ is base_tear_down.__func__
+
+
 class FrontendAwareBasePlug(BasePlug, util.SubscribableStateMixin):
   """A plug that notifies of any state updates.
 
@@ -450,8 +458,11 @@ class PlugManager(object):
     """
     _LOG.debug('Tearing down all plugs.')
     for plug_type, plug_instance in six.iteritems(self._plugs_by_type):
-      thread = _PlugTearDownThread(plug_instance,
-                                   name='<PlugTearDownThread: %s>' % plug_type)
+      if plug_instance.uses_base_tear_down():
+        name = '<PlugTearDownThread: %s>' % plug_type
+      else:
+        name = '<PlugTearDownThread: BasePlug No-Op for %s>' % plug_type
+      thread = _PlugTearDownThread(plug_instance, name=name)
       thread.start()
       timeout_s = (conf.plug_teardown_timeout_s
                    if conf.plug_teardown_timeout_s

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -194,9 +194,10 @@ class BasePlug(object):
     pass
 
 
-  def uses_base_tear_down(self):
+  @classmethod
+  def uses_base_tear_down(cls):
     """Checks whether the tearDown method is the BasePlug implementation."""
-    this_tear_down = getattr(self, 'tearDown')
+    this_tear_down = getattr(cls, 'tearDown')
     base_tear_down = getattr(BasePlug, 'tearDown')
     return this_tear_down.__code__ is base_tear_down.__code__
 

--- a/test/plugs_test.py
+++ b/test/plugs_test.py
@@ -46,6 +46,14 @@ class AdderPlug(plugs.FrontendAwareBasePlug):
     self.state = 'TORN DOWN'
 
 
+class AdderSubclassPlug(AdderPlug):
+  pass
+
+
+class DummyPlug(plugs.BasePlug):
+  pass
+
+
 class TearDownRaisesPlug1(plugs.BasePlug):
   TORN_DOWN = False
   def tearDown(self):
@@ -178,3 +186,10 @@ class PlugsTest(test.TestCase):
       @plugs.plug(adder_plug=AdderPlug)
       def dummy_phase(test, adder_plug):
         pass
+
+  def test_uses_base_tear_down(self):
+    self.assertTrue(plugs.BasePlug().uses_base_tear_down())
+    self.assertTrue(DummyPlug().uses_base_tear_down())
+    self.assertFalse(AdderPlug().uses_base_tear_down())
+    self.assertFalse(AdderSubclassPlug().uses_base_tear_down())
+    self.assertFalse(TearDownRaisesPlug1().uses_base_tear_down())


### PR DESCRIPTION
…ct if the tearDown is the BasePlug no-op.  The thread name is logged via KillableThread so this should give test author clear indicator that the tearDown run for that plug is a no-op.

PiperOrigin-RevId: 201715393

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/804)
<!-- Reviewable:end -->
