### PR TITLE
Indicate when history from disk is disabled.

### DIFF
--- a/openhtf/output/web_gui/src/app/stations/station-list/station-list.component.spec.ts
+++ b/openhtf/output/web_gui/src/app/stations/station-list/station-list.component.spec.ts
@@ -58,7 +58,7 @@ class MockDashboardService {
 
   registerMockStation(station) {
     this.stations.push(station);
-    this.messages.next();
+    this.messages.next({});
   }
 }
 

--- a/openhtf/output/web_gui/src/app/stations/station/history.component.html
+++ b/openhtf/output/web_gui/src/app/stations/station/history.component.html
@@ -62,8 +62,13 @@
     <li *ngIf="isLoading" class="status-text">
       Loading history from the server...
     </li>
-    <li *ngIf="hasError" class="status-text u-text-color-error">
-      Could not retrieve test history from the server.
+    <li *ngIf="hasError && !historyFromDiskEnabled" class="status-text">
+      History from disk is disabled.
+    </li>
+    <li *ngIf="hasError && historyFromDiskEnabled" class="status-text">
+      <span class="u-text-color-error">
+        Could not retrieve test history from the server.
+      </span>
     </li>
   </ul>
 

--- a/openhtf/output/web_gui/src/app/stations/station/history.component.ts
+++ b/openhtf/output/web_gui/src/app/stations/station/history.component.ts
@@ -38,6 +38,7 @@ export class HistoryComponent implements OnChanges {
   expanded = false;
   hasError = false;
   history: HistoryItem[] = [];
+  historyFromDiskEnabled = false;
   isLoading = false;
 
   private lastClickedItem: HistoryItem|null = null;
@@ -85,8 +86,8 @@ export class HistoryComponent implements OnChanges {
         // attachments until we know the file name, so try to retrieve it now.
         if (historyItem.testState.fileName === null) {
           this.historyService.retrieveFileName(this.station, historyItem)
-              .catch(error => {
-                if (error.status !== 404) {
+              .catch(() => {
+                if (this.historyFromDiskEnabled) {
                   this.flashMessage.warn(
                       'Could not retrieve history from disk, so attachments ' +
                       'are not available. You may try again later.');
@@ -115,16 +116,19 @@ export class HistoryComponent implements OnChanges {
   }
 
   private loadHistory() {
-    this.isLoading = true;
     this.hasError = false;
+    this.isLoading = true;
+    this.historyFromDiskEnabled = false;
 
     this.historyService.refreshList(this.station)
         .then(() => {
           this.isLoading = false;
+          this.historyFromDiskEnabled = true;
         })
-        .catch(() => {
+        .catch(error => {
           this.isLoading = false;
           this.hasError = true;
+          this.historyFromDiskEnabled = error.status !== 404;
         });
   }
 

--- a/openhtf/output/web_gui/tsconfig.json
+++ b/openhtf/output/web_gui/tsconfig.json
@@ -8,7 +8,8 @@
     "noEmitHelpers": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    "skipLibCheck": true
   },
   "compileOnSave": false,
   "buildOnSave": false,


### PR DESCRIPTION
Partially address #780 by providing more specific status messages.

TODO before merge: Update `dist/`. Having trouble since RXJS has errors when building.

### Before:

![screen shot 2018-06-25 at 7 42 49 pm](https://user-images.githubusercontent.com/3301218/41886507-7df83a40-78b1-11e8-8cc5-2f4997f95416.png)

### After, when history is disabled:

![screen shot 2018-06-25 at 7 37 48 pm](https://user-images.githubusercontent.com/3301218/41886511-826b0648-78b1-11e8-8e93-f469dd9063f2.png)

### After, when history is enabled:

For example, enable history with `station_server.StationServer(history_path='/history')`.

![screen shot 2018-06-25 at 7 40 02 pm](https://user-images.githubusercontent.com/3301218/41886541-9ff352d8-78b1-11e8-9a8a-811f8f910a60.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/806)
<!-- Reviewable:end -->
