### PR TITLE
Implement PhaseGroups.

### DIFF
--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -143,9 +143,11 @@ def teardown(test):
 
 if __name__ == '__main__':
   test = htf.Test(
-      hello_world,
-      set_measurements, dimensions, attachments, skip_phase,
-      measures_with_args.with_args(min=2, max=4), analysis,
+      htf.PhaseGroup.with_teardown(teardown)(
+          hello_world,
+          set_measurements, dimensions, attachments, skip_phase,
+          measures_with_args.with_args(min=2, max=4), analysis,
+      ),
       # Some metadata fields, these in particular are used by mfg-inspector,
       # but you can include any metadata fields.
       test_name='MyTest', test_description='OpenHTF Example Test',
@@ -168,5 +170,4 @@ if __name__ == '__main__':
   #    test.add_output_callbacks(mfg_inspector.UploadToMfgInspector.from_json(
   #        json.load(json_file)))
 
-  test.configure(teardown_function=teardown)
   test.execute(test_start=user_input.prompt_for_test_start())

--- a/examples/phase_groups.py
+++ b/examples/phase_groups.py
@@ -1,0 +1,166 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example OpenHTF Phase Groups.
+
+PhaseGroups are used to control phase shortcutting due to terminal errors to
+better guarentee when teardown phases run.
+"""
+
+import openhtf as htf
+
+
+def setup_phase(test):
+  test.logger.info('Setup in a group.')
+
+
+def main_phase(test):
+  test.logger.info('This is a main phase.')
+
+
+def teardown_phase(test):
+  test.logger.info('Teardown phase.')
+
+
+def inner_main_phase(test):
+  test.logger.info('Inner main phase.')
+
+
+def inner_teardown_phase(test):
+  test.logger.info('Inner teardown phase.')
+
+
+def error_setup_phase(test):
+  test.logger.info('Error in setup phase.')
+  return htf.PhaseResult.STOP
+
+
+def error_main_phase(test):
+  test.logger.info('Error in main phase.')
+  return htf.PhaseResult.STOP
+
+
+def run_basic_group():
+  """Run the basic phase group example.
+
+  In this example, there are no terminal phases; all phases are run.
+  """
+  test = htf.Test(htf.PhaseGroup(
+      setup=[setup_phase],
+      main=[main_phase],
+      teardown=[teardown_phase],
+  ))
+  test.execute()
+
+
+def run_setup_error_group():
+  """Run the phase group example where an error occurs in a setup phase.
+
+  The terminal setup phase shortcuts the test.  The main phases are
+  skipped.  The PhaseGroup is not entered, so the teardown phases are also
+  skipped.
+  """
+  test = htf.Test(htf.PhaseGroup(
+      setup=[error_setup_phase],
+      main=[main_phase],
+      teardown=[teardown_phase],
+  ))
+  test.execute()
+
+
+def run_main_error_group():
+  """Run the phase group example where an error occurs in a main phase.
+
+  The main phase in this example is terminal.  The PhaseGroup was entered
+  because the setup phases ran without error, so the teardown phases are run.
+  The other main phase is skipped.
+  """
+  test = htf.Test(htf.PhaseGroup(
+      setup=[setup_phase],
+      main=[error_main_phase, main_phase],
+      teardown=[teardown_phase],
+  ))
+  test.execute()
+
+
+def run_nested_groups():
+  """Run the nested groups example.
+
+  This example shows a PhaseGroup in a PhaseGroup.  No phase is terminal, so all
+  are run in the order;
+    main_phase
+    inner_main_phase
+    inner_teardown_phase
+    teardown_phase
+  """
+  test = htf.Test(
+      htf.PhaseGroup(
+          main=[
+              main_phase,
+              htf.PhaseGroup.with_teardown(inner_teardown_phase)(
+                  inner_main_phase),
+          ],
+          teardown=[teardown_phase]
+      )
+  )
+  test.execute()
+
+
+def run_nested_error_groups():
+  """Run nested groups example where an error occurs in nested main phase.
+
+  In this example, the first main phase in the nested PhaseGroup errors out.
+  The other inner main phase is skipped, as is the outer main phase.  Both
+  PhaseGroups were entered, so both teardown phases are run.
+  """
+  test = htf.Test(
+      htf.PhaseGroup(
+          main=[
+              htf.PhaseGroup.with_teardown(inner_teardown_phase)(
+                  error_main_phase, main_phase),
+              main_phase,
+          ],
+          teardown=[teardown_phase],
+      )
+  )
+  test.execute()
+
+
+def run_nested_error_skip_unentered_groups():
+  """Run nested groups example where an error occurs in outer main phase.
+
+  Lastly, the first main phase in the outer PhaseGroup errors out.  This skips
+  the nested PhaseGroup and the other outer main phase.  The outer PhaseGroup
+  was entered, so its teardown phase runs.
+  """
+  test = htf.Test(
+      htf.PhaseGroup(
+          main=[
+              error_main_phase,
+              htf.PhaseGroup.with_teardown(inner_teardown_phase)(main_phase),
+              main_phase,
+          ],
+          teardown=[teardown_phase],
+      )
+  )
+  test.execute()
+
+
+if __name__ == '__main__':
+  run_basic_group()
+  run_setup_error_group()
+  run_main_error_group()
+  run_nested_groups()
+  run_nested_error_groups()
+  run_nested_error_skip_unentered_groups()

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -43,6 +43,7 @@ from openhtf.core.monitors import monitors
 from openhtf.core.phase_descriptor import PhaseDescriptor
 from openhtf.core.phase_descriptor import PhaseOptions
 from openhtf.core.phase_descriptor import PhaseResult
+from openhtf.core.phase_group import PhaseGroup
 from openhtf.core.test_descriptor import Test
 from openhtf.core.test_descriptor import TestApi
 from openhtf.core.test_descriptor import TestDescriptor
@@ -60,7 +61,7 @@ TestPhase = PhaseOptions  # pylint: disable=invalid-name
 
 
 def get_version():
-  """Return the version string of the 'openhtf' package.
+  """Returns the version string of the 'openhtf' package.
 
   Note: the version number doesn't seem to get properly set when using ipython.
   """

--- a/openhtf/core/phase_group.py
+++ b/openhtf/core/phase_group.py
@@ -1,0 +1,272 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phase Groups in OpenHTF.
+
+Phase Groups are collections of Phases that are used to control phase
+shortcutting due to terminal errors to better guarentee when teardown phases
+run.
+
+PhaseGroup instances have three primary member fields:
+  `setup`: a list of phases, run first.  If these phases are all non-terminal,
+      the PhaseGroup is entered.
+  `main`: a list of phases, run after the setup phases as long as those are
+      non-terminal.  If any of these phases are terminal, then the rest of the
+      main phases will be skipped.
+  `teardown`: a list of phases, guarenteed to run after the main phases as long
+      as the PhaseGroup was entered.  If any are terminal, other teardown phases
+      will continue to be run.  One exception is that a second CTRL-C sent to
+      the main thread will abort all teardown phases.
+There is one optional field:
+  `name`: str, an arbitrary description used for logging.
+
+PhaseGroup instances can be nested inside of each other.  A PhaseGroup is
+terminal if any of its Phases or further nested PhaseGroups are also terminal.
+"""
+
+import collections
+import functools
+
+import mutablerecords
+
+from openhtf.core import phase_descriptor
+from openhtf.core import test_record
+
+
+class PhaseGroup(mutablerecords.Record(
+    'PhaseGroup', [], {
+        'setup': tuple,
+        'main': tuple,
+        'teardown': tuple,
+        'name': None,
+    })):
+  """Phase group with guaranteed end phase running.
+
+  If the setup phases all continue, then the main phases and teardown phases are
+  run. Even if any main phase or teardown phases has a terminal error, all the
+  teardown phases are guaranteed to be run.
+  """
+
+  def __init__(self, setup=None, main=None, teardown=None, name=None):
+    if not setup:
+      setup = ()
+    elif isinstance(setup, PhaseGroup):
+      setup = (setup,)
+    if not main:
+      main = ()
+    elif isinstance(main, PhaseGroup):
+      main = (main,)
+    if not teardown:
+      teardown = ()
+    elif isinstance(teardown, PhaseGroup):
+      teardown = (teardown,)
+    super(PhaseGroup, self).__init__(
+        setup=tuple(setup), main=tuple(main), teardown=tuple(teardown),
+        name=name)
+
+  @classmethod
+  def convert_if_not(cls, phases_or_groups):
+    """Convert list of phases or groups into a new PhaseGroup if not already."""
+    if isinstance(phases_or_groups, PhaseGroup):
+      return mutablerecords.CopyRecord(phases_or_groups)
+
+    flattened = flatten_phases_and_groups(phases_or_groups)
+    return cls(main=flattened)
+
+  @classmethod
+  def with_context(cls, setup_phases, teardown_phases):
+    """Create PhaseGroup creator function with setup and teardown phases.
+
+    Args:
+      setup_phases: list of phase_descriptor.PhaseDescriptors/PhaseGroups/
+          callables/iterables, phases to run during the setup for the PhaseGroup
+          returned from the created function.
+      teardown_phases: list of phase_descriptor.PhaseDescriptors/PhaseGroups/
+          callables/iterables, phases to run during the teardown for the
+          PhaseGroup returned from the created function.
+
+    Returns:
+      Function that takes *phases and returns a PhaseGroup with the predefined
+      setup and teardown phases, with *phases as the main phases.
+    """
+    setup = flatten_phases_and_groups(setup_phases)
+    teardown = flatten_phases_and_groups(teardown_phases)
+
+    def _context_wrapper(*phases):
+      return cls(setup=setup,
+                 main=flatten_phases_and_groups(phases),
+                 teardown=teardown)
+    return _context_wrapper
+
+  @classmethod
+  def with_setup(cls, *setup_phases):
+    """Create PhaseGroup creator function with predefined setup phases."""
+    return cls.with_context(setup_phases, [])
+
+  @classmethod
+  def with_teardown(cls, *teardown_phases):
+    """Create PhaseGroup creator function with predefined teardown phases."""
+    return cls.with_context([], teardown_phases)
+
+  def combine(self, other, name=None):
+    """Combine with another PhaseGroup and return the result."""
+    return PhaseGroup(
+        setup=self.setup + other.setup,
+        main=self.main + other.main,
+        teardown=self.teardown + other.teardown,
+        name=name)
+
+  def wrap(self, main_phases, name=None):
+    """Returns PhaseGroup with additional main phases."""
+    new_main = list(self.main)
+    new_main.extend(main_phases)
+    return PhaseGroup(
+        setup=self.setup,
+        main=new_main,
+        teardown=self.teardown,
+        name=name)
+
+  def transform(self, transform_fn):
+    return PhaseGroup(
+        setup=[transform_fn(p) for p in self.setup],
+        main=[transform_fn(p) for p in self.main],
+        teardown=[transform_fn(p) for p in self.teardown],
+        name=self.name)
+
+  def with_args(self, **kwargs):
+    """Send known keyword-arguments to each contained phase the when called."""
+    return self.transform(functools.partial(optionally_with_args, **kwargs))
+
+  def with_plugs(self, **subplugs):
+    """Substitute only known plugs for placeholders for each contained phase."""
+    return self.transform(functools.partial(optionally_with_plugs, **subplugs))
+
+  def _iterate(self, phases):
+    for phase in phases:
+      if isinstance(phase, PhaseGroup):
+        for p in phase:
+          yield p
+      else:
+        yield phase
+
+  def __iter__(self):
+    """Iterate directly over the phases."""
+    for phase in self._iterate(self.setup):
+      yield phase
+    for phase in self._iterate(self.main):
+      yield phase
+    for phase in self._iterate(self.teardown):
+      yield phase
+
+  def flatten(self):
+    """Internally flatten out nested iterables."""
+    return PhaseGroup(
+        setup=flatten_phases_and_groups(self.setup),
+        main=flatten_phases_and_groups(self.main),
+        teardown=flatten_phases_and_groups(self.teardown),
+        name=self.name)
+
+  def load_code_info(self):
+    """Load coded info for all contained phases."""
+    return PhaseGroup(
+        setup=load_code_info(self.setup),
+        main=load_code_info(self.main),
+        teardown=load_code_info(self.teardown),
+        name=self.name)
+
+
+def load_code_info(phases_or_groups):
+  """Recursively load code info for a PhaseGroup or list of phases or groups."""
+  if isinstance(phases_or_groups, PhaseGroup):
+    return phases_or_groups.load_code_info()
+  ret = []
+  for phase in phases_or_groups:
+    if isinstance(phase, PhaseGroup):
+      ret.append(phase.load_code_info())
+    else:
+      ret.append(
+          mutablerecords.CopyRecord(
+              phase, code_info=test_record.CodeInfo.for_function(phase.func)))
+  return ret
+
+
+def flatten_phases_and_groups(phases_or_groups):
+  """Recursively flatten nested lists for the list of phases or groups."""
+  if isinstance(phases_or_groups, PhaseGroup):
+    phases_or_groups = [phases_or_groups]
+  ret = []
+  for phase in phases_or_groups:
+    if isinstance(phase, PhaseGroup):
+      ret.append(phase.flatten())
+    elif isinstance(phase, collections.Iterable):
+      ret.extend(flatten_phases_and_groups(phase))
+    else:
+      ret.append(phase_descriptor.PhaseDescriptor.wrap_or_copy(phase))
+  return ret
+
+
+def optionally_with_args(phase, **kwargs):
+  """Apply only the args that the phase knows.
+
+  If the phase has a **kwargs-style argument, it counts as knowing all args.
+
+  Args:
+    phase: phase_descriptor.PhaseDescriptor or PhaseGroup or callable, or
+        iterable of those, the phase or phase group (or iterable) to apply
+        with_args to.
+    **kwargs: arguments to apply to the phase.
+
+  Returns:
+    phase_descriptor.PhaseDescriptor or PhaseGroup or iterable with the updated
+    args.
+  """
+  if isinstance(phase, PhaseGroup):
+    return phase.with_args(**kwargs)
+  if isinstance(phase, collections.Iterable):
+    return [optionally_with_args(p, **kwargs) for p in phase]
+
+  if not isinstance(phase, phase_descriptor.PhaseDescriptor):
+    phase = phase_descriptor.PhaseDescriptor.wrap_or_copy(phase)
+  return phase.with_known_args(**kwargs)
+
+
+def optionally_with_plugs(phase, **subplugs):
+  """Apply only the with_plugs that the phase knows.
+
+  This will determine the subset of plug overrides for only plugs the phase
+  actually has.
+
+  Args:
+    phase: phase_descriptor.PhaseDescriptor or PhaseGroup or callable, or
+        iterable of those, the phase or phase group (or iterable) to apply the
+        plug changes to.
+    **subplugs: mapping from plug name to derived plug class, the subplugs to
+        apply.
+
+  Raises:
+    openhtf.plugs.InvalidPlugError: if a specified subplug class is not a valid
+        replacement for the specified plug name.
+
+  Returns:
+    phase_descriptor.PhaseDescriptor or PhaseGroup or iterable with the updated
+    plugs.
+  """
+  if isinstance(phase, PhaseGroup):
+    return phase.with_plugs(**subplugs)
+  if isinstance(phase, collections.Iterable):
+    return [optionally_with_plugs(p, **subplugs) for p in phase]
+
+  if not isinstance(phase, phase_descriptor.PhaseDescriptor):
+    phase = phase_descriptor.PhaseDescriptor.wrap_or_copy(phase)
+  return phase.with_known_plugs(**subplugs)

--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -36,6 +36,7 @@ import mutablerecords
 from openhtf import util
 from openhtf.core import phase_descriptor
 from openhtf.core import phase_executor
+from openhtf.core import phase_group
 from openhtf.core import test_executor
 from openhtf.core import test_record
 
@@ -54,6 +55,12 @@ conf.declare('capture_source', description=textwrap.dedent(
 
     Set to 'true' if you want to capture your test's source.'''),
              default_value=False)
+# TODO(arsharma): Deprecate this configuration after removing the old teardown
+# specification.
+conf.declare('teardown_timeout_s', default_value=30, description=
+             'Default timeout (in seconds) for test teardown functions; '
+             'this option is deprecated and only applies to the deprecated '
+             'Test level teardown function.')
 
 
 class UnrecognizedTestUidError(Exception):
@@ -118,6 +125,7 @@ class Test(object):
   """
 
   TEST_INSTANCES = weakref.WeakValueDictionary()
+  HANDLED_SIGINT_ONCE = False
 
   def __init__(self, *phases, **metadata):
     # Some sanity checks on special metadata keys we automatically fill in.
@@ -135,16 +143,13 @@ class Test(object):
 
     if conf.capture_source:
       # First, we copy the phases with the real CodeInfo for them.
-      phases = [
-          mutablerecords.CopyRecord(
-              phase, code_info=test_record.CodeInfo.for_function(phase.func))
-          for phase in self._test_desc.phases]
+      group = self._test_desc.phase_group.load_code_info()
 
       # Then we replace the TestDescriptor with one that stores the test
       # module's CodeInfo as well as our newly copied phases.
       code_info = test_record.CodeInfo.for_module_from_stack(levels_up=2)
       self._test_desc = self._test_desc._replace(
-          code_info=code_info, phases=phases)
+          code_info=code_info, phase_group=group)
 
     # Make sure configure() gets called at least once before Execute().  The
     # user might call configure() again to override options, but we don't want
@@ -227,21 +232,37 @@ class Test(object):
     if cls.TEST_INSTANCES:
       _LOG.error('Received SIGINT, stopping all tests.')
       for test in cls.TEST_INSTANCES.values():
-        test.stop_from_sig_int()
-    # The default SIGINT handler does this. If we don't, then nobody above
-    # us is notified of the event. This will raise this exception in the main
-    # thread.
-    raise KeyboardInterrupt()
+        test.abort_from_sig_int()
+    if not cls.HANDLED_SIGINT_ONCE:
+      cls.HANDLED_SIGINT_ONCE = True
+      raise KeyboardInterrupt
+    # Otherwise, does not raise KeyboardInterrupt to ensure that the tests are
+    # cleaned up.
 
-  def stop_from_sig_int(self):
-    """Stop test execution as abruptly as we can, only in response to SIGINT."""
+  def abort_from_sig_int(self):
+    """Abort test execution abruptly, only in response to SIGINT."""
     with self._lock:
-      _LOG.error('Stopping %s due to SIGINT', self)
+      _LOG.error('Aborting %s due to SIGINT', self)
       if self._executor:
         # TestState str()'s nicely to a descriptive string, so let's log that
         # just for good measure.
         _LOG.error('Test state: %s', self._executor.test_state)
-        self._executor.stop()
+        self._executor.abort()
+
+  # TODO(arsharma): teardown_function test option is deprecated; remove this.
+  def _get_running_test_descriptor(self):
+    """If there is a teardown_function, wrap current descriptor with it."""
+    if not self._test_options.teardown_function:
+      return self._test_desc
+
+    teardown_phase = phase_descriptor.PhaseDescriptor.wrap_or_copy(
+        self._test_options.teardown_function)
+    if not teardown_phase.options.timeout_s:
+      teardown_phase.options.timeout_s = conf.teardown_timeout_s
+    return TestDescriptor(
+        phase_group.PhaseGroup(main=[self._test_desc.phase_group],
+                               teardown=[teardown_phase]),
+        self._test_desc.code_info, self._test_desc.metadata)
 
   def execute(self, test_start=None):
     """Starts the framework and executes the given test.
@@ -282,8 +303,9 @@ class Test(object):
       if conf.capture_source:
         trigger.code_info = test_record.CodeInfo.for_function(trigger.func)
 
+      test_desc = self._get_running_test_descriptor()
       self._executor = test_executor.TestExecutor(
-          self._test_desc, self.make_uid(), trigger, self._test_options)
+          test_desc, self.make_uid(), trigger, self._test_options)
 
       _LOG.info('Executing test: %s', self.descriptor.code_info.name)
       self.TEST_INSTANCES[self.uid] = self
@@ -291,6 +313,11 @@ class Test(object):
 
     try:
       self._executor.wait()
+    except KeyboardInterrupt:
+      # The SIGINT handler only raises the KeyboardInterrupt once, so only retry
+      # that once.
+      self._executor.wait()
+      raise
     finally:
       try:
         final_state = self._executor.finalize()
@@ -327,6 +354,7 @@ class Test(object):
     return final_state.test_record.outcome == test_record.Outcome.PASS
 
 
+# TODO(arsharma): Deprecate the teardown_function in favor of PhaseGroups.
 class TestOptions(mutablerecords.Record('TestOptions', [], {
     'name': 'openhtf_test',
     'output_callbacks': list,
@@ -351,31 +379,30 @@ class TestOptions(mutablerecords.Record('TestOptions', [], {
 
 
 class TestDescriptor(collections.namedtuple(
-    'TestDescriptor', ['phases', 'code_info', 'metadata', 'uid'])):
+    'TestDescriptor', ['phase_group', 'code_info', 'metadata', 'uid'])):
   """An object that represents the reusable portions of an OpenHTF test.
 
   This object encapsulates the static test information that is set once and used
   by the framework along the way.
 
   Attributes:
-    phases: The phases to execute for this Test.
+    phase_group: The top level phase group to execute for this Test.
     metadata: Any metadata that should be associated with test records.
     code_info: Information about the module that created the Test.
     uid: UID for this test.
   """
 
   def __new__(cls, phases, code_info, metadata):
-    phases = [
-        phase_descriptor.PhaseDescriptor.wrap_or_copy(phase)
-        for phase in phases
-    ]
+    group = phase_group.PhaseGroup.convert_if_not(phases)
     return super(TestDescriptor, cls).__new__(
-        cls, phases, code_info, metadata, uid=uuid.uuid4().hex[:16])
+        cls, group, code_info, metadata, uid=uuid.uuid4().hex[:16])
 
   @property
   def plug_types(self):
     """Returns set of plug types required by this test."""
-    return {plug.cls for phase in self.phases for plug in phase.plugs}
+    return {plug.cls
+            for phase in self.phase_group
+            for plug in phase.plugs}
 
 
 class TestApi(collections.namedtuple('TestApi', [

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -22,6 +22,7 @@ import contextlib2 as contextlib
 
 import openhtf
 from openhtf.core import phase_executor
+from openhtf.core import phase_group
 from openhtf.core import test_state
 from openhtf.util import conf
 from openhtf.util import threads
@@ -29,8 +30,6 @@ from openhtf.util import threads
 
 _LOG = logging.getLogger(__name__)
 
-conf.declare('teardown_timeout_s', default_value=30, description=
-             'Timeout (in seconds) for test teardown functions.')
 conf.declare('cancel_timeout_s', default_value=2,
              description='Timeout (in seconds) when the test has been cancelled'
              'to wait for the running phase to exit.')
@@ -57,22 +56,26 @@ class TestExecutor(threads.KillableThread):
     self._test_start = test_start
     self._test_options = test_options
     self._lock = threading.Lock()
-    self._exit_stack = None
+    self._phase_exec = None
     self.uid = execution_uid
-    self._latest_outcome = None
+    self._last_outcome = None
+    self._abort = threading.Event()
+    self._full_abort = threading.Event()
+    self._teardown_phases_lock = threading.Lock()
 
-  def stop(self):
-    """Stop this test."""
-    _LOG.debug('Stopping test executor.')
+  def abort(self):
+    """Abort this test."""
+    if self._abort.is_set():
+      _LOG.error('Abort already set; forcibly stopping the process.')
+      self._full_abort.set()
+      self._stop_phase_executor(force=True)
+      return
+    _LOG.error('Abort test executor.')
     # Deterministically mark the test as aborted.
-    self.finalize()
-    # Cause the exit stack to collapse immediately.
-    with self._lock:
-      if self._exit_stack:
-        self._exit_stack.close()
-    # No need to kill this thread because, with the test_state finalized, it
-    # will end soon since we are stopping the current phase and won't run
-    # anymore phases.
+    self._abort.set()
+    self._stop_phase_executor()
+    # No need to kill this thread because the abort state has been set, it will
+    # end as soon as all queued teardown phases are run.
 
   def finalize(self):
     """Finalize test execution and output resulting record to callbacks.
@@ -92,28 +95,22 @@ class TestExecutor(threads.KillableThread):
     if self.test_state.test_record.dut_id is None:
       _LOG.warning('DUT ID is still not set; using default.')
       self.test_state.test_record.dut_id = self._test_options.default_dut_id
-    if not self.test_state.is_finalized:
-      self.test_state.logger.debug('Finishing test with outcome ABORTED.')
-      self.test_state.abort()
 
     return self.test_state
 
   def wait(self):
     """Waits until death."""
-    try:
-      # Timeout needed for SIGINT handling.
-      if sys.version_info >= (3, 2):
-        self.join(threading.TIMEOUT_MAX)
-      else:
-        # Seconds in a year.
-        self.join(31557600)
-    except KeyboardInterrupt:
-      self.test_state.logger.debug('KeyboardInterrupt caught, aborting test.')
-      raise
+    # Must use a timeout here in case this is called from the main thread.
+    # Otherwise, the SIGINT abort logic in test_descriptor will not get called.
+    if sys.version_info >= (3, 2):
+      self.join(threading.TIMEOUT_MAX)
+    else:
+      # Seconds in a year.
+      self.join(31557600)
 
   def _thread_proc(self):
     """Handles one whole test from start to finish."""
-    with contextlib.ExitStack() as exit_stack:
+    try:
       # Top level steps required to run a single iteration of the Test.
       self.test_state = test_state.TestState(
           self._test_descriptor,
@@ -123,20 +120,11 @@ class TestExecutor(threads.KillableThread):
 
       # Any access to self._exit_stacks must be done while holding this lock.
       with self._lock:
-        self._exit_stack = exit_stack
-        # Ensure that we tear everything down when exiting.
-        exit_stack.callback(self._execute_test_teardown, phase_exec)
-        # We don't want to run the 'teardown function' unless the test has
-        # actually started.
-        self._do_teardown_function = False
+        self._phase_exec = phase_exec
 
-      if self._test_start is not None and self._execute_test_start(phase_exec):
+      if self._test_start is not None and self._execute_test_start():
         # Exit early if test_start returned a terminal outcome of any kind.
         return
-      # The trigger has run and the test has started, so from now on we want the
-      # teardown function to execute at the end, no matter what.
-      with self._lock:
-        self._do_teardown_function = True
       self.test_state.mark_test_started()
 
       # Full plug initialization happens _after_ the start trigger, as close to
@@ -146,7 +134,10 @@ class TestExecutor(threads.KillableThread):
         return
 
       # Everything is set, set status and begin test execution.
-      self._execute_test_phases(phase_exec)
+      self.test_state.set_status_running()
+      self._execute_phase_group(self._test_descriptor.phase_group)
+    finally:
+      self._execute_test_teardown()
 
   def _initialize_plugs(self, plug_types=None):
     """Initialize plugs.
@@ -162,18 +153,18 @@ class TestExecutor(threads.KillableThread):
       return False
     except Exception:  # pylint: disable=broad-except
       # Record the equivalent failure outcome and exit early.
-      self._latest_outcome = phase_executor.PhaseExecutionOutcome(
+      self._last_outcome = phase_executor.PhaseExecutionOutcome(
           phase_executor.ExceptionInfo(*sys.exc_info()))
       return True
 
-  def _execute_test_start(self, phase_exec):
+  def _execute_test_start(self):
     """Run the start trigger phase, and check that the DUT ID is set after.
 
     Initializes any plugs used in the trigger.
     Logs a warning if the start trigger failed to set the DUT ID.
 
-    Args:
-      phase_exec: openhtf.core.phase_executor.PhaseExecutor instance.
+    The test start is special because we wait to initialize all other plugs
+    until this phase runs.
 
     Returns:
       True if there was a terminal error either setting up or running the test
@@ -185,51 +176,124 @@ class TestExecutor(threads.KillableThread):
         phase_plug.cls for phase_plug in self._test_start.plugs]):
       return True
 
-    self._latest_outcome = phase_exec.execute_phase(self._test_start)
-    if self._latest_outcome.is_terminal:
+    outcome = self._phase_exec.execute_phase(self._test_start)
+    if outcome.is_terminal:
+      self._last_outcome = outcome
       return True
 
     if self.test_state.test_record.dut_id is None:
       _LOG.warning('Start trigger did not set a DUT ID.')
     return False
 
-  def _execute_test_teardown(self, phase_exec):
-    phase_exec.stop(timeout_s=conf.cancel_timeout_s)
-    phase_exec.reset_stop()
+  def _stop_phase_executor(self, force=False):
+    with self._lock:
+      phase_exec = self._phase_exec
+      if not phase_exec:
+        # The test executor has not started yet, so no stopping is required.
+        return
+    if not force and not self._teardown_phases_lock.acquire(False):
+      # If locked, teardown phases are running, so do not cancel those.
+      return
+    try:
+      phase_exec.stop(timeout_s=conf.cancel_timeout_s)
+      # Resetting so phase_exec can run teardown phases.
+      phase_exec.reset_stop()
+    finally:
+      if not force:
+        self._teardown_phases_lock.release()
 
-    if self._do_teardown_function and self._test_options.teardown_function:
-      try:
-        timeout_s = self._test_options.teardown_function.options.timeout_s
-      except AttributeError:
-        # Force teardown function timeout, otherwise we can hang for a long time
-        # when shutting down, such as in response to a SIGINT.
-        timeout_s = conf.teardown_timeout_s
-
-      teardown_function = openhtf.PhaseDescriptor.wrap_or_copy(
-          self._test_options.teardown_function, timeout_s=timeout_s)
-
-      outcome = phase_exec.execute_phase(teardown_function)
-      # Ignore teardown phase outcome if there is already a terminal error.
-      if not self._latest_outcome or not self._latest_outcome.is_terminal:
-        self._latest_outcome = outcome
+  # TODO(kschiller): Cleanup the naming here and possibly merge with finalize.
+  def _execute_test_teardown(self):
     # Plug teardown does not affect the test outcome.
     self.test_state.plug_manager.tear_down_plugs()
 
     # Now finalize the test state.
-    if self._latest_outcome and self._latest_outcome.is_terminal:
-      self.test_state.finalize_from_phase_outcome(self._latest_outcome)
+    if self._abort.is_set():
+      self.test_state.logger.debug('Finishing test with outcome ABORTED.')
+      self.test_state.abort()
+    elif self._last_outcome and self._last_outcome.is_terminal:
+      self.test_state.finalize_from_phase_outcome(self._last_outcome)
     else:
       self.test_state.finalize_normally()
 
-  def _execute_test_phases(self, phase_exec):
-    """Executes one test's phases from start to finish."""
-    self.test_state.set_status_running()
+  def _handle_phase(self, phase):
+    if isinstance(phase, phase_group.PhaseGroup):
+      return self._execute_phase_group(phase)
 
-    try:
-      for phase in self._test_descriptor.phases:
-        self._latest_outcome = phase_exec.execute_phase(phase)
-        if self._latest_outcome.is_terminal:
+    self.test_state.logger.debug('Handling phase %s', phase.name)
+    outcome = self._phase_exec.execute_phase(phase)
+    if outcome.is_terminal and not self._last_outcome:
+      self._last_outcome = outcome
+
+    return outcome.is_terminal
+
+  def _execute_abortable_phases(self, type_name, phases, group_name):
+    """Execute phases, returning immediately if any error or abort is triggered.
+
+    Args:
+      type_name: str, type of phases running, usually 'Setup' or 'Main'.
+      phases: iterable of phase_descriptor.Phase or phase_group.PhaseGroup
+          instances, the phases to execute.
+      group_name: str or None, name of the executing group.
+
+    Returns:
+      True if there is a terminal error or the test is aborted, False otherwise.
+    """
+    if group_name and phases:
+      self.test_state.logger.debug(
+          'Executing %s phases for %s', type_name, group_name)
+    for phase in phases:
+      if self._abort.is_set() or self._handle_phase(phase):
+        return True
+    return False
+
+  def _execute_teardown_phases(self, teardown_phases, group_name):
+    """Execute all the teardown phases, regardless of errors.
+
+    Args:
+      teardown_phases: iterable of phase_descriptor.Phase or
+          phase_group.PhaseGroup instances, the phases to execute.
+      group_name: str or None, name of the executing group.
+
+    Returns:
+      True if there is at least one terminal error, False otherwise.
+    """
+    if group_name and teardown_phases:
+      self.test_state.logger.debug('Executing teardown phases for %s',
+                                   group_name)
+    ret = False
+    with self._teardown_phases_lock:
+      for teardown_phase in teardown_phases:
+        if self._full_abort.is_set():
+          ret = True
           break
-    except KeyboardInterrupt:
-      self.test_state.logger.debug('KeyboardInterrupt caught, aborting test.')
-      raise
+        if self._handle_phase(teardown_phase):
+          ret = True
+    return ret
+
+  def _execute_phase_group(self, group):
+    """Executes the phases in a phase group.
+
+    This will run the phases in the phase group, ensuring if the setup
+    phases all run without error that the teardown phases will also run, no
+    matter the errors during the main phases.
+
+    This function is recursive.  Do not construct phase groups that contain
+    themselves.
+
+    Args:
+      group: phase_group.PhaseGroup, the phase group to execute.
+
+    Returns:
+      True if the phases are terminal; otherwise returns False.
+    """
+    if group.name:
+      self.test_state.logger.debug('Entering PhaseGroup %s', group.name)
+    if self._execute_abortable_phases(
+        'setup', group.setup, group.name):
+      return True
+    main_ret = self._execute_abortable_phases(
+        'main', group.main, group.name)
+    teardown_ret = self._execute_teardown_phases(
+        group.teardown, group.name)
+    return main_ret or teardown_ret

--- a/openhtf/output/servers/station_server.py
+++ b/openhtf/output/servers/station_server.py
@@ -355,7 +355,7 @@ class PhasesHandler(BaseTestHandler):
 
     phase_descriptors = [
         dict(id=id(phase), **data.convert_to_base_types(phase))
-        for phase in test.descriptor.phases]
+        for phase in test.descriptor.phase_group]
 
     # Wrap value in a dict because writing a list directly is prohibited.
     self.write({'data': phase_descriptors})

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -193,7 +193,6 @@ class BasePlug(object):
     """This method is called automatically at the end of each Test execution."""
     pass
 
-
   @classmethod
   def uses_base_tear_down(cls):
     """Checks whether the tearDown method is the BasePlug implementation."""

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -347,7 +347,7 @@ class TestCase(unittest.TestCase):
     test_method = getattr(self, methodName)
     if inspect.isgeneratorfunction(test_method):
       raise ValueError(
-          "%s yields without @openhtf.util.test.yields_phases" % methodName)
+          '%s yields without @openhtf.util.test.yields_phases' % methodName)
 
   def _AssertPhaseOrTestRecord(func):  # pylint: disable=no-self-argument,invalid-name
     """Decorator for automatically invoking self.assertTestPhases when needed.
@@ -390,6 +390,9 @@ class TestCase(unittest.TestCase):
 
   def assertTestFail(self, test_rec):
     self.assertEqual(test_record.Outcome.FAIL, test_rec.outcome)
+
+  def assertTestAborted(self, test_rec):
+    self.assertEqual(test_record.Outcome.ABORTED, test_rec.outcome)
 
   def assertTestError(self, test_rec, exc_type=None):
     self.assertEqual(test_record.Outcome.ERROR, test_rec.outcome)

--- a/test/capture_source_test.py
+++ b/test/capture_source_test.py
@@ -18,7 +18,7 @@ import unittest
 import openhtf as htf
 
 
-def phase(test):
+def phase():
   pass
 
 
@@ -29,13 +29,12 @@ class BasicCodeCaptureTest(unittest.TestCase):
   def testCaptured(self):
     htf.conf.load(capture_source=True)
     test = htf.Test(phase)
-    phase_descriptor = test.descriptor.phases[0]
+    phase_descriptor = list(test.descriptor.phase_group)[0]
     self.assertEqual(phase_descriptor.code_info.name, phase.__name__)
 
   @htf.conf.save_and_restore
   def testNotCaptured(self):
     htf.conf.load(capture_source=False)
     test = htf.Test(phase)
-    phase_descriptor = test.descriptor.phases[0]
+    phase_descriptor = list(test.descriptor.phase_group)[0]
     self.assertEqual(phase_descriptor.code_info.name, '')
-

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -22,12 +22,21 @@ import mock
 import openhtf
 from openhtf import plugs
 from openhtf import util
-from openhtf.core import test_executor
+from openhtf.core import phase_descriptor
 from openhtf.core import phase_executor
+from openhtf.core import phase_group
+from openhtf.core import test_descriptor
+from openhtf.core import test_executor
 from openhtf.core import test_state
 from openhtf.core.test_record import Outcome
 
 from openhtf.util import conf
+from openhtf.util import logs
+from openhtf.util import timeouts
+
+
+# Default logging to debug level.
+logs.CLI_LOGGING_VERBOSITY = 2
 
 
 class UnittestPlug(plugs.BasePlug):
@@ -77,7 +86,7 @@ def start_phase(test):
 def phase_one(test, test_plug):
   del test  # Unused.
   del test_plug  # Unused.
-  time.sleep(1)
+  time.sleep(0.01)
   print('phase_one completed')
 
 
@@ -85,7 +94,7 @@ def phase_one(test, test_plug):
 def phase_two(test, test_plug):
   del test  # Unused.
   del test_plug  # Unused.
-  time.sleep(2)
+  time.sleep(0.02)
   print('phase_two completed')
 
 
@@ -93,7 +102,7 @@ def phase_two(test, test_plug):
 @plugs.plug(test_plug=UnittestPlug.placeholder)
 def phase_repeat(test, test_plug):
   del test  # Unused.
-  time.sleep(.1)
+  time.sleep(0.01)
   ret = test_plug.increment()
   print('phase_repeat completed for %s time' % test_plug.count)
   return openhtf.PhaseResult.CONTINUE if ret else openhtf.PhaseResult.REPEAT
@@ -133,6 +142,22 @@ def teardown_fail():
   raise TeardownError()
 
 
+def _abort_executor_in_thread(executor_abort):
+  # If we were to stop it in this phase, it eventually causes the phase
+  # to be killed using KillableThread, which raises ThreadTerminationError
+  # inside here, which really raises it inside wherever executor.stop() is.
+  # That leads to the stopping of the executor to get stopped itself at a
+  # random point in time. To make this deterministic, we keep the phase
+  # alive as long as the executor is running, which really just means that
+  # the wait() call gets the error raised in it.
+  inner_ev = threading.Event()
+  def abort_executor():
+    executor_abort()
+    inner_ev.set()
+  threading.Thread(target=abort_executor).start()
+  inner_ev.wait(1)
+
+
 class TestExecutorTest(unittest.TestCase):
 
   class TestDummyExceptionError(Exception):
@@ -152,9 +177,13 @@ class TestExecutorTest(unittest.TestCase):
     # Configure test to throw exception midrun, and check that this causes
     # Outcome = ERROR.
     ev = threading.Event()
-    test = openhtf.Test(failure_phase)
+    group = phase_group.PhaseGroup(
+        main=[failure_phase],
+        teardown=[lambda: ev.set()],  # pylint: disable=unnecessary-lambda
+    )
+
+    test = openhtf.Test(group)
     test.configure(
-        teardown_function=lambda: ev.set(),  # pylint: disable=unnecessary-lambda
         default_dut_id='dut',
     )
 
@@ -187,7 +216,7 @@ class TestExecutorTest(unittest.TestCase):
     mock_starter = mock.Mock(spec=test_executor.TestExecutor)
     mock_starter.start()
     mock_starter.wait()
-    mock_starter.stop()
+    mock_starter.abort()
 
   def test_class_string(self):
     check_list = ['PhaseExecutorThread', 'phase_one']
@@ -209,24 +238,16 @@ class TestExecutorTest(unittest.TestCase):
       # We have 'executor' because we're inside the test method's scope.
       # We have to run it in a thread to avoid getting a nasty series of
       # confusing errors:
-      # If we were to stop it in this phase, it eventually causes the phase
-      # to be killed using KillableThread, which raises ThreadTerminationError
-      # inside here, which really raises it inside wherever executor.stop() is.
-      # That leads to the stopping of the executor to get stopped itself at a
-      # random point in time. To make this deterministic, we keep the phase
-      # alive as long as the executor is running, which really just means that
-      # the wait() call gets the error raised in it.
-      inner_ev = threading.Event()
-      def stop_executor():
-        executor.stop()
-        inner_ev.set()
-      threading.Thread(target=stop_executor).start()
-      inner_ev.wait(1)
+      _abort_executor_in_thread(executor.abort)
 
     ev = threading.Event()
-    test = openhtf.Test()
+
+    group = phase_group.PhaseGroup(
+        teardown=[lambda: ev.set()],  # pylint: disable=unnecessary-lambda
+    )
+
+    test = openhtf.Test(group)
     test.configure(
-        teardown_function=lambda: ev.set(),  # pylint: disable=unnecessary-lambda
         default_dut_id='dut',
     )
 
@@ -254,23 +275,17 @@ class TestExecutorTest(unittest.TestCase):
   def test_cancel_phase(self):
 
     @openhtf.PhaseOptions()
-    def cancel_phase(test):
-      del test  # Unused.
+    def cancel_phase():
       # See above cancel_phase for explanations.
-      inner_ev = threading.Event()
-      def stop_executor():
-        executor.stop()
-        inner_ev.set()
-      threading.Thread(target=stop_executor).start()
-      inner_ev.wait(1)
+      _abort_executor_in_thread(executor.abort)
 
     ev = threading.Event()
-    test = openhtf.Test(cancel_phase)
+    group = phase_group.PhaseGroup(main=[cancel_phase],
+                                   teardown=[lambda: ev.set()])  # pylint: disable=unnecessary-lambda
+    test = openhtf.Test(group)
     test.configure(
-        teardown_function=lambda: ev.set(),  # pylint: disable=unnecessary-lambda
         default_dut_id='dut',
     )
-    # Cancel during test start phase.
     executor = test_executor.TestExecutor(
         test.descriptor, 'uid', start_phase, test._test_options)
 
@@ -284,11 +299,63 @@ class TestExecutorTest(unittest.TestCase):
     # Teardown function should be executed.
     self.assertTrue(ev.wait(1))
 
+  def test_cancel_twice_phase(self):
+
+    def abort_twice():
+      executor.abort()
+      teardown_running.wait()
+      executor.abort()
+
+    @openhtf.PhaseOptions()
+    def cancel_twice_phase():
+      # See above cancel_phase for explanations.
+      _abort_executor_in_thread(abort_twice)
+
+    @openhtf.PhaseOptions()
+    def teardown_phase():
+      teardown_running.set()
+      # Sleeping for the entire duration has a race condition with cancellation.
+      timeout = timeouts.PolledTimeout(1)
+      while not timeout.has_expired():
+        time.sleep(0.01)
+      ev.set()
+
+    @openhtf.PhaseOptions()
+    def teardown2_phase():
+      ev2.set()
+
+    teardown_running = threading.Event()
+    ev = threading.Event()
+    ev2 = threading.Event()
+    group = phase_group.PhaseGroup(main=[cancel_twice_phase],
+                                   teardown=[teardown_phase, teardown2_phase])
+    test = openhtf.Test(group)
+    test.configure(
+        default_dut_id='dut',
+    )
+    executor = test_executor.TestExecutor(
+        test.descriptor, 'uid', start_phase, test._test_options)
+
+    executor.start()
+    executor.wait()
+    record = executor.test_state.test_record
+    self.assertEqual(record.phases[0].name, start_phase.name)
+    self.assertLessEqual(record.start_time_millis, util.time_millis())
+    self.assertLessEqual(record.start_time_millis, record.end_time_millis)
+    self.assertLessEqual(record.end_time_millis, util.time_millis())
+    # Teardown function should *NOT* be executed.
+    self.assertFalse(ev.is_set())
+    self.assertFalse(ev2.is_set())
+
   def test_failure_during_plug_init(self):
     ev = threading.Event()
-    test = openhtf.Test(fail_plug_phase)
+    group = phase_group.PhaseGroup(
+        main=[fail_plug_phase],
+        teardown=[lambda: ev.set()],  # pylint: disable=unnecessary-lambda
+    )
+
+    test = openhtf.Test(group)
     test.configure(
-        teardown_function=lambda: ev.set(),  # pylint: disable=unnecessary-lambda
         default_dut_id='dut',
     )
     executor = test_executor.TestExecutor(
@@ -299,27 +366,8 @@ class TestExecutorTest(unittest.TestCase):
     self.assertEqual(record.outcome, Outcome.ERROR)
     self.assertEqual(record.outcome_details[0].code, FailedPlugError.__name__)
     self.assertEqual(record.outcome_details[0].description, FAIL_PLUG_MESSAGE)
-    # Teardown function should be executed.
-    self.assertTrue(ev.wait(1))
-
-  def test_failure_during_plug_init_with_dut_id(self):
-    ev = threading.Event()
-    test = openhtf.Test(fail_plug_phase)
-    test.configure(
-        teardown_function=lambda: ev.set(),  # pylint: disable=unnecessary-lambda
-        default_dut_id='dut',
-    )
-
-    executor = test_executor.TestExecutor(
-        test.descriptor, 'uid', start_phase, test._test_options)
-    executor.start()
-    executor.wait()
-    record = executor.test_state.test_record
-    self.assertEqual(record.outcome, Outcome.ERROR)
-    self.assertEqual(record.outcome_details[0].code, FailedPlugError.__name__)
-    self.assertEqual(record.outcome_details[0].description, FAIL_PLUG_MESSAGE)
-    # Teardown function should be executed.
-    self.assertTrue(ev.wait(1))
+    # Teardown function should *NOT* be executed.
+    self.assertFalse(ev.is_set())
 
   def test_failure_during_start_phase_plug_init(self):
     def never_gonna_run_phase():
@@ -328,9 +376,13 @@ class TestExecutorTest(unittest.TestCase):
     ev = threading.Event()
     ev2 = threading.Event()
 
-    test = openhtf.Test(never_gonna_run_phase)
+    group = phase_group.PhaseGroup(
+        main=[never_gonna_run_phase],
+        teardown=[lambda: ev.set()],  # pylint: disable=unnecessary-lambda
+    )
+
+    test = openhtf.Test(group)
     test.configure(
-        teardown_function=lambda: ev.set(),  # pylint: disable=unnecessary-lambda
         default_dut_id='dut',
     )
 
@@ -350,9 +402,11 @@ class TestExecutorTest(unittest.TestCase):
     self.assertFalse(ev2.is_set())
 
   def test_error_during_teardown(self):
-    test = openhtf.Test(blank_phase)
+    group = phase_group.PhaseGroup(
+        main=[blank_phase], teardown=[teardown_fail])
+
+    test = openhtf.Test(group)
     test.configure(
-        teardown_function=teardown_fail,
         default_dut_id='dut',
     )
 
@@ -370,9 +424,12 @@ class TestExecutorTest(unittest.TestCase):
     def teardown_log(test):
       test.logger.info(message)
 
-    test = openhtf.Test(blank_phase)
+    group = phase_group.PhaseGroup(
+        main=[blank_phase], teardown=[teardown_log])
+
+    test = openhtf.Test(group)
+
     test.configure(
-        teardown_function=teardown_log,
         default_dut_id='dut',
     )
     executor = test_executor.TestExecutor(
@@ -386,13 +443,252 @@ class TestExecutorTest(unittest.TestCase):
     self.assertTrue(log_records)
 
 
-class TestPhaseExecutor(unittest.TestCase):
+class TestExecutorHandlePhaseTest(unittest.TestCase):
 
   def setUp(self):
     self.test_state = mock.MagicMock(
         spec=test_state.TestState,
         plug_manager=plugs.PlugManager(logger_name='mock.logger.for.openhtf'),
-        execution_uid='01234567890')
+        execution_uid='01234567890',
+        logger=mock.MagicMock())
+    self.phase_exec = mock.MagicMock(
+        spec=phase_executor.PhaseExecutor)
+    self.test_exec = test_executor.TestExecutor(None, 'uid', None,
+                                                test_descriptor.TestOptions())
+    self.test_exec.test_state = self.test_state
+    self.test_exec._phase_exec = self.phase_exec
+
+    patcher = mock.patch.object(self.test_exec, '_execute_phase_group')
+    self.mock_execute_phase_group = patcher.start()
+
+  def testPhaseGroup_NotTerminal(self):
+    self.mock_execute_phase_group.return_value = False
+    group = phase_group.PhaseGroup(name='test')
+    self.assertFalse(self.test_exec._handle_phase(group))
+    self.mock_execute_phase_group.assert_called_once_with(group)
+
+  def testPhaseGroup_Terminal(self):
+    self.mock_execute_phase_group.return_value = True
+    group = phase_group.PhaseGroup(name='test')
+    self.assertTrue(self.test_exec._handle_phase(group))
+    self.mock_execute_phase_group.assert_called_once_with(group)
+
+  def testPhase_NotTerminal(self):
+    phase = phase_descriptor.PhaseDescriptor(blank_phase)
+    self.phase_exec.execute_phase.return_value = (
+        phase_executor.PhaseExecutionOutcome(
+            phase_descriptor.PhaseResult.CONTINUE))
+    self.assertFalse(self.test_exec._handle_phase(phase))
+
+    self.mock_execute_phase_group.assert_not_called()
+    self.phase_exec.execute_phase.assert_called_once_with(phase)
+    self.assertIsNone(self.test_exec._last_outcome)
+
+  def testPhase_NotTerminal_PreviousLastOutcome(self):
+    phase = phase_descriptor.PhaseDescriptor(blank_phase)
+    set_outcome = phase_executor.PhaseExecutionOutcome(None)
+    self.test_exec._last_outcome = set_outcome
+
+    self.phase_exec.execute_phase.return_value = (
+        phase_executor.PhaseExecutionOutcome(
+            phase_descriptor.PhaseResult.CONTINUE))
+    self.assertFalse(self.test_exec._handle_phase(phase))
+
+    self.mock_execute_phase_group.assert_not_called()
+    self.phase_exec.execute_phase.assert_called_once_with(phase)
+    self.assertIs(set_outcome, self.test_exec._last_outcome)
+
+  def testPhase_Terminal_SetLastOutcome(self):
+    phase = phase_descriptor.PhaseDescriptor(blank_phase)
+    outcome = phase_executor.PhaseExecutionOutcome(
+        phase_descriptor.PhaseResult.STOP)
+    self.phase_exec.execute_phase.return_value = outcome
+    self.assertTrue(self.test_exec._handle_phase(phase))
+
+    self.mock_execute_phase_group.assert_not_called()
+    self.phase_exec.execute_phase.assert_called_once_with(phase)
+    self.assertIs(outcome, self.test_exec._last_outcome)
+
+  def testPhase_Terminal_PreviousLastOutcome(self):
+    phase = phase_descriptor.PhaseDescriptor(blank_phase)
+    set_outcome = phase_executor.PhaseExecutionOutcome(None)
+    self.test_exec._last_outcome = set_outcome
+    outcome = phase_executor.PhaseExecutionOutcome(
+        phase_descriptor.PhaseResult.STOP)
+    self.phase_exec.execute_phase.return_value = outcome
+    self.assertTrue(self.test_exec._handle_phase(phase))
+
+    self.mock_execute_phase_group.assert_not_called()
+    self.phase_exec.execute_phase.assert_called_once_with(phase)
+    self.assertIs(set_outcome, self.test_exec._last_outcome)
+
+
+class TestExecutorExecutePhasesTest(unittest.TestCase):
+
+  def setUp(self):
+    self.test_state = mock.MagicMock(
+        spec=test_state.TestState,
+        plug_manager=plugs.PlugManager(logger_name='mock.logger.for.openhtf'),
+        execution_uid='01234567890',
+        logger=mock.MagicMock())
+    self.test_exec = test_executor.TestExecutor(None, 'uid', None,
+                                                test_descriptor.TestOptions())
+    self.test_exec.test_state = self.test_state
+    patcher = mock.patch.object(self.test_exec, '_handle_phase')
+    self.mock_handle_phase = patcher.start()
+
+  def testExecuteAbortable_NoPhases(self):
+    self.assertFalse(self.test_exec._execute_abortable_phases(
+        'main', (), 'group'))
+    self.mock_handle_phase.assert_not_called()
+
+  def testExecuteAbortable_Normal(self):
+    self.mock_handle_phase.side_effect = [False]
+    self.assertFalse(self.test_exec._execute_abortable_phases(
+        'main', ('normal',), 'group'))
+    self.mock_handle_phase.assert_called_once_with('normal')
+
+  def testExecuteAbortable_AbortedPrior(self):
+    self.test_exec.abort()
+    self.assertTrue(self.test_exec._execute_abortable_phases(
+        'main', ('not-run',), 'group'))
+    self.mock_handle_phase.assert_not_called()
+
+  def testExecuteAbortable_AbortedDuring(self):
+    self.mock_handle_phase.side_effect = lambda x: self.test_exec.abort()
+    self.assertTrue(self.test_exec._execute_abortable_phases(
+        'main', ('abort', 'not-run'), 'group'))
+    self.mock_handle_phase.assert_called_once_with('abort')
+
+  def testExecuteAbortable_Terminal(self):
+    self.mock_handle_phase.side_effect = [False, True]
+    self.assertTrue(self.test_exec._execute_abortable_phases(
+        'main', ('normal', 'abort', 'not_run'), 'group'))
+    self.assertEqual([mock.call('normal'), mock.call('abort')],
+                     self.mock_handle_phase.call_args_list)
+
+  def testExecuteTeardown_Empty(self):
+    self.assertFalse(self.test_exec._execute_teardown_phases((), 'group'))
+    self.mock_handle_phase.assert_not_called()
+
+  def testExecuteTeardown_Normal(self):
+    self.mock_handle_phase.side_effect = [False]
+    self.assertFalse(self.test_exec._execute_teardown_phases(
+        ('normal',), 'group'))
+    self.mock_handle_phase.assert_called_once_with('normal')
+
+  def testExecuteTeardown_AbortPrior(self):
+    self.test_exec.abort()
+    self.mock_handle_phase.side_effect = [False]
+    self.assertFalse(self.test_exec._execute_teardown_phases(
+        ('normal',), 'group'))
+    self.mock_handle_phase.assert_called_once_with('normal')
+
+  def testExecuteTeardown_AbortedDuring(self):
+    def handle_phase(fake_phase):
+      if fake_phase == 'abort':
+        self.test_exec.abort()
+      return False
+    self.mock_handle_phase.side_effect = handle_phase
+    self.assertFalse(self.test_exec._execute_teardown_phases(
+        ('abort', 'still-run'), 'group'))
+    self.mock_handle_phase.assert_has_calls(
+        [mock.call('abort'), mock.call('still-run')])
+
+  def testExecuteTeardown_Terminal(self):
+    def handle_phase(fake_phase):
+      if fake_phase == 'error':
+        return True
+      return False
+    self.mock_handle_phase.side_effect = handle_phase
+    self.assertTrue(self.test_exec._execute_teardown_phases(
+        ('error', 'still-run'), 'group'))
+    self.mock_handle_phase.assert_has_calls(
+        [mock.call('error'), mock.call('still-run')])
+
+
+class TestExecutorExecutePhaseGroupTest(unittest.TestCase):
+
+  def setUp(self):
+    self.test_state = mock.MagicMock(
+        spec=test_state.TestState,
+        plug_manager=plugs.PlugManager(logger_name='mock.logger.for.openhtf'),
+        execution_uid='01234567890',
+        logger=mock.MagicMock())
+    self.test_exec = test_executor.TestExecutor(None, 'uid', None,
+                                                test_descriptor.TestOptions())
+    self.test_exec.test_state = self.test_state
+    patcher = mock.patch.object(self.test_exec, '_execute_abortable_phases')
+    self.mock_execute_abortable = patcher.start()
+
+    patcher = mock.patch.object(self.test_exec, '_execute_teardown_phases')
+    self.mock_execute_teardown = patcher.start()
+
+    def setup():
+      pass
+    self._setup = setup
+
+    def main():
+      pass
+    self._main = main
+
+    @openhtf.PhaseOptions(timeout_s=30)
+    def teardown():
+      pass
+    self._teardown = teardown
+
+    self.group = phase_group.PhaseGroup(
+        setup=[setup], main=[main], teardown=[teardown], name='group')
+
+  def testStopDuringSetup(self):
+    self.mock_execute_abortable.return_value = True
+    self.assertTrue(self.test_exec._execute_phase_group(self.group))
+    self.mock_execute_abortable.assert_called_once_with(
+        'setup', (self._setup,), 'group')
+    self.mock_execute_teardown.assert_not_called()
+
+  def testStopDuringMain(self):
+    self.mock_execute_abortable.side_effect = [False, True]
+    self.mock_execute_teardown.return_value = False
+    self.assertTrue(self.test_exec._execute_phase_group(self.group))
+    self.mock_execute_abortable.assert_has_calls([
+        mock.call('setup', (self._setup,), 'group'),
+        mock.call('main', (self._main,), 'group'),
+    ])
+    self.mock_execute_teardown.assert_called_once_with(
+        (self._teardown,), 'group')
+
+  def testStopDuringTeardown(self):
+    self.mock_execute_abortable.return_value = False
+    self.mock_execute_teardown.return_value = True
+    self.assertTrue(self.test_exec._execute_phase_group(self.group))
+    self.mock_execute_abortable.assert_has_calls([
+        mock.call('setup', (self._setup,), 'group'),
+        mock.call('main', (self._main,), 'group'),
+    ])
+    self.mock_execute_teardown.assert_called_once_with(
+        (self._teardown,), 'group')
+
+  def testNoStop(self):
+    self.mock_execute_abortable.return_value = False
+    self.mock_execute_teardown.return_value = False
+    self.assertFalse(self.test_exec._execute_phase_group(self.group))
+    self.mock_execute_abortable.assert_has_calls([
+        mock.call('setup', (self._setup,), 'group'),
+        mock.call('main', (self._main,), 'group'),
+    ])
+    self.mock_execute_teardown.assert_called_once_with(
+        (self._teardown,), 'group')
+
+
+class PhaseExecutorTest(unittest.TestCase):
+
+  def setUp(self):
+    self.test_state = mock.MagicMock(
+        spec=test_state.TestState,
+        plug_manager=plugs.PlugManager(logger_name='mock.logger.for.openhtf'),
+        execution_uid='01234567890',
+        logger=mock.MagicMock())
     self.test_state.plug_manager.initialize_plugs([
         UnittestPlug, MoreRepeatsUnittestPlug])
     self.phase_executor = phase_executor.PhaseExecutor(self.test_state)

--- a/test/core/phase_group_test.py
+++ b/test/core/phase_group_test.py
@@ -1,0 +1,438 @@
+"""Unit tests for PhaseGroups generally and running under the test executor."""
+
+import threading
+import unittest
+
+import openhtf as htf
+from openhtf import plugs
+from openhtf.util import test as htf_test
+
+
+def blank():
+  pass
+
+
+blank_phase = htf.PhaseDescriptor.wrap_or_copy(blank)
+
+
+@htf.PhaseOptions()
+def stop_phase():
+  return htf.PhaseResult.STOP
+
+
+def _rename(phase, new_name):
+  assert isinstance(new_name, str)
+  return htf.PhaseOptions(name=new_name)(phase)
+
+
+def _fake_phases(*new_names):
+  return [_rename(blank_phase, name) for name in new_names]
+
+
+@htf.PhaseOptions()
+def arg_phase(test, arg1=None, arg2=None):
+  del test  # Unused.
+  del arg1  # Unused.
+  del arg2  # Unused.
+
+
+class ParentPlug(plugs.BasePlug):
+  pass
+
+
+class ChildPlug(ParentPlug):
+  pass
+
+
+@plugs.plug(my_plug=ParentPlug.placeholder)
+def plug_phase(my_plug):
+  del my_plug  # Unused.
+
+
+def _abort_test_in_thread(test):
+  # See note in test/core/exe_test.py for _abort_executor_in_thread.
+  inner_ev = threading.Event()
+  def stop_executor():
+    test.abort_from_sig_int()
+    inner_ev.set()
+  threading.Thread(target=stop_executor).start()
+  inner_ev.wait(1)
+
+
+class PhaseGroupTest(unittest.TestCase):
+
+  def testInit(self):
+    setup = [1]
+    main = [2]
+    teardown = [3]
+    name = 'name'
+    pg = htf.PhaseGroup(setup=setup, main=main, teardown=teardown, name=name)
+    self.assertEqual(tuple(setup), pg.setup)
+    self.assertEqual(tuple(main), pg.main)
+    self.assertEqual(tuple(teardown), pg.teardown)
+    self.assertEqual(name, pg.name)
+
+  def testConvertIfNot_Not(self):
+    phases = _fake_phases('a', 'b', 'c')
+    expected = htf.PhaseGroup(main=_fake_phases('a', 'b', 'c'))
+    self.assertEqual(expected, htf.PhaseGroup.convert_if_not(phases))
+
+  def testConvertIfNot_Group(self):
+    expected = htf.PhaseGroup()
+    self.assertEqual(expected, htf.PhaseGroup.convert_if_not(expected))
+
+  def testWithContext(self):
+    setup = _fake_phases('setup')
+    main = _fake_phases('main')
+    teardown = _fake_phases('teardown')
+    expected = htf.PhaseGroup(setup=setup, main=main, teardown=teardown)
+
+    wrapper = htf.PhaseGroup.with_context(setup, teardown)
+    group = wrapper(*main)
+    self.assertEqual(expected, group)
+
+  def testWithSetup(self):
+    setup = _fake_phases('setup')
+    main = _fake_phases('main')
+    expected = htf.PhaseGroup(setup=setup, main=main)
+
+    wrapper = htf.PhaseGroup.with_setup(*setup)
+    group = wrapper(*main)
+    self.assertEqual(expected, group)
+
+  def testWithTeardown(self):
+    main = _fake_phases('main')
+    teardown = _fake_phases('teardown')
+    expected = htf.PhaseGroup(main=main, teardown=teardown)
+
+    wrapper = htf.PhaseGroup.with_teardown(*teardown)
+    group = wrapper(*main)
+    self.assertEqual(expected, group)
+
+  def testCombine(self):
+    group1 = htf.PhaseGroup(
+        setup=_fake_phases('s1'),
+        main=_fake_phases('m1'),
+        teardown=_fake_phases('t1'))
+    group2 = htf.PhaseGroup(
+        setup=_fake_phases('s2'),
+        main=_fake_phases('m2'),
+        teardown=_fake_phases('t2'))
+    expected = htf.PhaseGroup(
+        setup=_fake_phases('s1', 's2'),
+        main=_fake_phases('m1', 'm2'),
+        teardown=_fake_phases('t1', 't2'))
+    self.assertEqual(expected, group1.combine(group2))
+
+  def testWrap(self):
+    group = htf.PhaseGroup(
+        setup=_fake_phases('s1'),
+        main=_fake_phases('m1'),
+        teardown=_fake_phases('t1'))
+    extra = _fake_phases('m2', 'm3')
+    expected = htf.PhaseGroup(
+        setup=_fake_phases('s1'),
+        main=_fake_phases('m1', 'm2', 'm3'),
+        teardown=_fake_phases('t1'))
+    self.assertEqual(expected, group.wrap(extra))
+
+  def testWithArgs_Setup(self):
+    group = htf.PhaseGroup(setup=[blank_phase, arg_phase])
+    arg_group = group.with_args(arg1=1)
+    self.assertEqual(blank_phase, arg_group.setup[0])
+    self.assertEqual(arg_phase.with_args(arg1=1), arg_group.setup[1])
+
+  def testWithArgs_Main(self):
+    group = htf.PhaseGroup(main=[blank_phase, arg_phase])
+    arg_group = group.with_args(arg1=1)
+    self.assertEqual(blank_phase, arg_group.main[0])
+    self.assertEqual(arg_phase.with_args(arg1=1), arg_group.main[1])
+
+  def testWithArgs_Teardown(self):
+    group = htf.PhaseGroup(teardown=[blank_phase, arg_phase])
+    arg_group = group.with_args(arg1=1)
+    self.assertEqual(blank_phase, arg_group.teardown[0])
+    self.assertEqual(arg_phase.with_args(arg1=1), arg_group.teardown[1])
+
+  def testWithArgs_Recursive(self):
+    inner_group = htf.PhaseGroup(main=[blank_phase, arg_phase])
+    outer_group = htf.PhaseGroup(main=[inner_group, arg_phase])
+    arg_group = outer_group.with_args(arg2=2)
+
+    self.assertEqual(blank_phase, arg_group.main[0].main[0])
+    self.assertEqual(arg_phase.with_args(arg2=2), arg_group.main[0].main[1])
+    self.assertEqual(arg_phase.with_args(arg2=2), arg_group.main[1])
+
+  def testWithPlugs_Setup(self):
+    group = htf.PhaseGroup(setup=[blank_phase, plug_phase])
+    plug_group = group.with_plugs(my_plug=ChildPlug)
+    self.assertEqual(blank_phase, plug_group.setup[0])
+    self.assertEqual(plug_phase.with_plugs(my_plug=ChildPlug),
+                     plug_group.setup[1])
+
+  def testWithPlugs_Main(self):
+    group = htf.PhaseGroup(main=[blank_phase, plug_phase])
+    plug_group = group.with_plugs(my_plug=ChildPlug)
+    self.assertEqual(blank_phase, plug_group.main[0])
+    self.assertEqual(plug_phase.with_plugs(my_plug=ChildPlug),
+                     plug_group.main[1])
+
+  def testWithPlugs_Teardown(self):
+    group = htf.PhaseGroup(teardown=[blank_phase, plug_phase])
+    plug_group = group.with_plugs(my_plug=ChildPlug)
+    self.assertEqual(blank_phase, plug_group.teardown[0])
+    self.assertEqual(plug_phase.with_plugs(my_plug=ChildPlug),
+                     plug_group.teardown[1])
+
+  def testWithPlugs_Recursive(self):
+    inner_group = htf.PhaseGroup(main=[blank_phase, plug_phase])
+    outer_group = htf.PhaseGroup(main=[inner_group, plug_phase])
+    plug_group = outer_group.with_plugs(my_plug=ChildPlug)
+
+    self.assertEqual(blank_phase, plug_group.main[0].main[0])
+    self.assertEqual(plug_phase.with_plugs(my_plug=ChildPlug),
+                     plug_group.main[0].main[1])
+    self.assertEqual(plug_phase.with_plugs(my_plug=ChildPlug),
+                     plug_group.main[1])
+
+  def testIterate(self):
+    inner_group = htf.PhaseGroup(
+        setup=_fake_phases('a', 'b'),
+        main=_fake_phases('c', 'd'),
+        teardown=_fake_phases('e', 'f'))
+    outer_group = htf.PhaseGroup(
+        setup=_fake_phases('1', '2', '3', '4'),
+        main=_fake_phases('5', '6') + [inner_group] + _fake_phases('7'),
+        teardown=_fake_phases('8', '9'))
+    self.assertEqual(
+        _fake_phases(
+            '1', '2', '3', '4',  # Outer setup.
+            '5', '6',  # First outer main.
+            'a', 'b',  # Inner setup.
+            'c', 'd',  # Inner main.
+            'e', 'f',  # Inner teardown.
+            '7',  # Rest of outer main.
+            '8', '9',  # Outer teardown.
+        ), list(outer_group))
+
+  def testFlatten(self):
+    inner = htf.PhaseGroup(
+        setup=_fake_phases('a', 'b') + [_fake_phases('c')],
+        main=[_fake_phases('d')],
+        teardown=[_fake_phases('e'), _fake_phases('f')] + _fake_phases('g'))
+    outer = htf.PhaseGroup(
+        setup=_fake_phases('1', '2'),
+        main=[_fake_phases('3')] + [inner, _fake_phases('4')] +
+        _fake_phases('5'),
+        teardown=_fake_phases('6') + [_fake_phases('7', '8')] +
+        _fake_phases('9'))
+
+    expected_inner = htf.PhaseGroup(
+        setup=_fake_phases('a', 'b', 'c'),
+        main=_fake_phases('d'),
+        teardown=_fake_phases('e', 'f', 'g'))
+    expected_outer = htf.PhaseGroup(
+        setup=_fake_phases('1', '2'),
+        main=_fake_phases('3') + [expected_inner] + _fake_phases('4', '5'),
+        teardown=_fake_phases('6', '7', '8', '9'))
+    self.assertEqual(expected_outer, outer.flatten())
+
+  def testLoadCodeInfo(self):
+    group = htf.PhaseGroup(
+        setup=_fake_phases('setup'),
+        main=_fake_phases('main'),
+        teardown=_fake_phases('teardown'))
+    code_group = group.load_code_info()
+    self.assertEqual(blank.__name__, code_group.setup[0].code_info.name)
+    self.assertEqual(blank.__name__, code_group.main[0].code_info.name)
+    self.assertEqual(
+        blank.__name__, code_group.teardown[0].code_info.name)
+
+
+class PhaseGroupIntegrationTest(htf_test.TestCase):
+
+  def _assert_phase_names(self, expected_names, test_rec):
+    run_phase_names = [p.name for p in test_rec.phases[1:]]
+    self.assertEqual(expected_names, run_phase_names)
+
+  @htf_test.yields_phases
+  def testSimple(self):
+    simple = htf.PhaseGroup(
+        setup=_fake_phases('setup0', 'setup1'),
+        main=_fake_phases('main0', 'main1'),
+        teardown=_fake_phases('teardown0', 'teardown1'),
+        name='simple')
+    test_rec = yield htf.Test(simple)
+    self.assertTestPass(test_rec)
+    self._assert_phase_names(
+        ['setup0', 'setup1', 'main0', 'main1', 'teardown0', 'teardown1'],
+        test_rec)
+
+  @htf_test.yields_phases
+  def testRecursive(self):
+    inner = htf.PhaseGroup(
+        setup=_fake_phases('inner-setup'),
+        main=_fake_phases('inner-main'),
+        teardown=_fake_phases('inner-teardown'),
+        name='inner')
+    recursive = htf.PhaseGroup(
+        setup=_fake_phases('setup'),
+        main=(_fake_phases('main-pre') + [inner] +
+              _fake_phases('main-post')),
+        teardown=_fake_phases('teardown'),
+        name='recursive')
+    test_rec = yield htf.Test(recursive)
+    self.assertTestPass(test_rec)
+    self._assert_phase_names(
+        ['setup', 'main-pre', 'inner-setup', 'inner-main', 'inner-teardown',
+         'main-post', 'teardown'],
+        test_rec)
+
+  @htf_test.yields_phases
+  def testAbort_Setup(self):
+    @htf.PhaseOptions()
+    def abort_phase():
+      _abort_test_in_thread(test)
+
+    abort_setup = htf.PhaseGroup(
+        setup=_fake_phases('setup0') + [abort_phase] + _fake_phases('not-run'),
+        main=_fake_phases('not-run-main'),
+        teardown=_fake_phases('not-run-teardown'),
+        name='abort_setup')
+
+    test = htf.Test(abort_setup)
+    test_rec = yield test
+    self.assertTestAborted(test_rec)
+    self._assert_phase_names(['setup0', 'abort_phase'], test_rec)
+
+  @htf_test.yields_phases
+  def testAbort_Main(self):
+    @htf.PhaseOptions()
+    def abort_phase():
+      _abort_test_in_thread(test)
+
+    abort_main = htf.PhaseGroup(
+        setup=_fake_phases('setup0'),
+        main=_fake_phases('main0') + [abort_phase] + _fake_phases('not-run'),
+        teardown=_fake_phases('teardown0'),
+        name='abort_main')
+    test = htf.Test(abort_main)
+    test_rec = yield test
+    self.assertTestAborted(test_rec)
+    self._assert_phase_names(['setup0', 'main0', 'abort_phase', 'teardown0'],
+                             test_rec)
+
+  @htf_test.yields_phases
+  def testAbort_Teardown(self):
+    @htf.PhaseOptions()
+    def abort_phase():
+      _abort_test_in_thread(test)
+
+    abort_teardown = htf.PhaseGroup(
+        setup=_fake_phases('setup0'),
+        main=_fake_phases('main0'),
+        teardown=_fake_phases('td0') + [abort_phase] + _fake_phases('td1'),
+        name='abort_teardown')
+    test = htf.Test(abort_teardown)
+    test_rec = yield test
+    self.assertTestAborted(test_rec)
+    self._assert_phase_names(
+        ['setup0', 'main0', 'td0', 'abort_phase', 'td1'], test_rec)
+
+  @htf_test.yields_phases
+  def testFailure_Before(self):
+    not_run = htf.PhaseGroup(
+        setup=_fake_phases('not-run-setup'),
+        main=_fake_phases('not-run-main'),
+        teardown=_fake_phases('not-run-teardown'),
+        name='not_run')
+    test_rec = yield htf.Test(stop_phase, not_run)
+    self.assertTestFail(test_rec)
+    self._assert_phase_names(['stop_phase'], test_rec)
+
+  @htf_test.yields_phases
+  def testFailure_Setup(self):
+    fail_setup = htf.PhaseGroup(
+        setup=[stop_phase] + _fake_phases('not-run-setup'),
+        main=_fake_phases('not-run-main'),
+        teardown=_fake_phases('not-run-teardown'),
+        name='fail_setup')
+    test_rec = yield htf.Test(fail_setup)
+    self.assertTestFail(test_rec)
+    self._assert_phase_names(['stop_phase'], test_rec)
+
+  @htf_test.yields_phases
+  def testFailure_Main(self):
+    fail_main = htf.PhaseGroup(
+        setup=_fake_phases('setup'),
+        main=_fake_phases('main0') + [stop_phase] + _fake_phases('not-run'),
+        teardown=_fake_phases('teardown0'),
+        name='fail_main')
+    test_rec = yield htf.Test(fail_main)
+    self.assertTestFail(test_rec)
+    self._assert_phase_names(
+        ['setup', 'main0', 'stop_phase', 'teardown0'], test_rec)
+
+  @htf_test.yields_phases
+  def testFailure_Teardown(self):
+    fail_teardown = htf.PhaseGroup(
+        setup=_fake_phases('setup'),
+        main=_fake_phases('main'),
+        teardown=_fake_phases('td0') + [stop_phase] + _fake_phases('td1'),
+        name='fail_teardown')
+    test_rec = yield htf.Test(fail_teardown)
+    self.assertTestFail(test_rec)
+    self._assert_phase_names(
+        ['setup', 'main', 'td0', 'stop_phase', 'td1'], test_rec)
+
+  @htf_test.yields_phases
+  def testRecursive_FailureSetup(self):
+    inner_fail = htf.PhaseGroup(
+        setup=(
+            _fake_phases('inner-setup0') + [stop_phase] +
+            _fake_phases('not-run')),
+        main=_fake_phases('not-run-inner'),
+        teardown=_fake_phases('not-run-inner-teardown'),
+        name='inner_fail')
+    outer = htf.PhaseGroup(
+        setup=_fake_phases('setup0'),
+        main=_fake_phases('outer0') + [inner_fail] + _fake_phases('not-run'),
+        teardown=_fake_phases('teardown0'),
+        name='outer')
+    test_rec = yield htf.Test(outer)
+    self.assertTestFail(test_rec)
+    self._assert_phase_names(
+        ['setup0', 'outer0', 'inner-setup0', 'stop_phase', 'teardown0'],
+        test_rec)
+
+  @htf_test.yields_phases
+  def testRecursive_FailureMain(self):
+    inner_fail = htf.PhaseGroup(
+        setup=_fake_phases('inner-setup0'),
+        main=(_fake_phases('inner0') + [stop_phase] +
+              _fake_phases('not-run')),
+        teardown=_fake_phases('inner-teardown'),
+        name='inner_fail')
+    outer = htf.PhaseGroup(
+        setup=_fake_phases('setup0'),
+        main=_fake_phases('outer0') + [inner_fail] + _fake_phases('not-run'),
+        teardown=_fake_phases('teardown0'),
+        name='outer')
+    test_rec = yield htf.Test(outer)
+    self.assertTestFail(test_rec)
+    self._assert_phase_names(
+        ['setup0', 'outer0', 'inner-setup0', 'inner0', 'stop_phase',
+         'inner-teardown', 'teardown0'],
+        test_rec)
+
+  @htf_test.yields_phases
+  def testOldTeardown(self):
+    phases = _fake_phases('p0', 'p1', 'p2')
+    teardown_phase = _rename(blank_phase, 'teardown')
+
+    test = htf.Test(phases)
+    test.configure(teardown_function=teardown_phase)
+    run = test._get_running_test_descriptor()
+    test_rec = yield test
+    self.assertTestPass(test_rec)
+    self._assert_phase_names(['p0', 'p1', 'p2', 'teardown'], test_rec)


### PR DESCRIPTION
Implement PhaseGroups, which allow for setup and teardown contexts.  Teardown
phases in such groups are guaranteed to run if the setup phases are all
non-terminal.

See docs/event_sequence.md for more information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/809)
<!-- Reviewable:end -->
