### PR TITLE
Printing the exception error message with the traceback

### DIFF
--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -332,9 +332,15 @@ class TestState(util.SubscribableStateMixin):
         self.logger.critical(
             'Finishing test execution early due to an exception raised during '
             'phase execution; outcome ERROR.')
-        # Enable CLI printing of the fill traceback with the -v flag.
-        self.logger.critical('Traceback:%s%s', os.linesep, ''.join(
-            traceback.format_tb(phase_execution_outcome.phase_result.exc_tb)))
+        # Enable CLI printing of the full traceback with the -v flag.
+        self.logger.critical(
+            'Traceback:%s%s%s%s',
+            os.linesep,
+            ''.join(traceback.format_tb(
+                phase_execution_outcome.phase_result.exc_tb)),
+            os.linesep,
+            description,
+        )
         self._finalize(test_record.Outcome.ERROR)
     elif phase_execution_outcome.is_timeout:
       self.logger.error('Finishing test execution early due to phase '

--- a/test/plugs/plugs_test.py
+++ b/test/plugs/plugs_test.py
@@ -94,12 +94,19 @@ class PlugsTest(test.TestCase):
         AdderPlug.LAST_INSTANCE,
         self.plug_manager.provide_plugs(
             (('adder_plug', AdderPlug),))['adder_plug'])
-    self.assertEqual(self.plug_manager._asdict()['plug_descriptors'], {
-            'plugs_test.AdderPlug': {'mro': ['plugs_test.AdderPlug']},
-        })
-    self.assertEqual(self.plug_manager._asdict()['plug_states'], {
-            'plugs_test.AdderPlug': {'number': 0},
-        })
+    adder_plug_name = AdderPlug.__module__ + '.AdderPlug'
+    self.assertEqual(
+        {
+            adder_plug_name: {'mro': [adder_plug_name]}
+        },
+        self.plug_manager._asdict()['plug_descriptors']
+    )
+    self.assertEqual(
+        {
+            adder_plug_name: {'number': 0}
+        },
+        self.plug_manager._asdict()['plug_states']
+    )
     self.assertEqual('CREATED', AdderPlug.LAST_INSTANCE.state)
 
   @test.yields_phases
@@ -147,12 +154,13 @@ class PlugsTest(test.TestCase):
 
   def test_plug_updates(self):
     self.plug_manager.initialize_plugs({AdderPlug})
+    adder_plug_name = AdderPlug.__module__ + '.AdderPlug'
     update = self.plug_manager.wait_for_plug_update(
-        'plugs_test.AdderPlug', {}, .001)
+        adder_plug_name, {}, .001)
     self.assertEqual({'number': 0}, update)
     # No update since last time, this should time out (return None).
     self.assertIsNone(self.plug_manager.wait_for_plug_update(
-        'plugs_test.AdderPlug', update, .001))
+        adder_plug_name, update, .001))
 
     def _delay_then_update():
       time.sleep(.5)
@@ -160,7 +168,7 @@ class PlugsTest(test.TestCase):
     threading.Thread(target=_delay_then_update).start()
     start_time = time.time()
     self.assertEqual({'number': 1}, self.plug_manager.wait_for_plug_update(
-        'plugs_test.AdderPlug', update, 5))
+        adder_plug_name, update, 5))
     self.assertGreater(time.time() - start_time, .2)
 
   def test_invalid_plug(self):


### PR DESCRIPTION
Printing the exception error message with the traceback.  The actual error message often contains very useful information that points you exactly at problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/815)
<!-- Reviewable:end -->
