### PR TITLE
Using logging.exception to not suppress full traceback with message

### DIFF
--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -106,3 +106,4 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
       return attribute(*args, **kwargs)
 
     return logging_wrapper
+

--- a/openhtf/plugs/usb/adb_device.py
+++ b/openhtf/plugs/usb/adb_device.py
@@ -178,13 +178,15 @@ class AdbDevice(object):
 
   def command(self, command, raw=False, timeout_ms=None):
     """Run command on the device, returning the output."""
-    return self.shell_service.command(command, raw=raw, timeout_ms=timeout_ms)
+    return self.shell_service.command(
+        str(command), raw=raw, timeout_ms=timeout_ms)
+
   Shell = command  #pylint: disable=invalid-name
 
   def async_command(self, command, raw=False, timeout_ms=None):
     """See shell_service.ShellService.async_command()."""
-    return self.shell_service.async_command(command, raw=raw,
-                                            timeout_ms=timeout_ms)
+    return self.shell_service.async_command(
+        str(command), raw=raw, timeout_ms=timeout_ms)
 
   def _check_remote_command(self, destination, timeout_ms, success_msgs=None):
     """Open a stream to destination, check for remote errors.

--- a/openhtf/util/conf.py
+++ b/openhtf/util/conf.py
@@ -383,7 +383,7 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
     try:
       parsed_yaml = self._modules['yaml'].safe_load(yamlfile.read())
     except self._modules['yaml'].YAMLError:
-      logging.exception('Problem parsing YAML')
+      self._logger.exception('Problem parsing YAML')
       raise self.ConfigurationInvalidError(
           'Failed to load from %s as YAML' % yamlfile)
 

--- a/openhtf/util/conf.py
+++ b/openhtf/util/conf.py
@@ -382,9 +382,10 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
 
     try:
       parsed_yaml = self._modules['yaml'].safe_load(yamlfile.read())
-    except self._modules['yaml'].YAMLError as exception:
+    except self._modules['yaml'].YAMLError:
+      logging.exception('Problem parsing YAML')
       raise self.ConfigurationInvalidError(
-          'Failed to load from %s as YAML' % yamlfile, exception)
+          'Failed to load from %s as YAML' % yamlfile)
 
     if not isinstance(parsed_yaml, dict):
       # Parsed YAML, but it's not a dict.


### PR DESCRIPTION
Using logging.exception to not suppress full traceback with message YAML parsing errors.  This is a super annoying anti-pattern we use in OpenHTF that suppresses valuable debugging information.  When we catch and log exceptions we should just use logging.exception about 99.95% of the time.

Also upstreaming a change to adb_device.py that cast input to str() because underlying driver did not expect/support unicode.

PiperOrigin-RevId: 213366100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/819)
<!-- Reviewable:end -->
