### PR TITLE
Make all plugs now placeholders for subclasses.

### DIFF
--- a/openhtf/core/phase_descriptor.py
+++ b/openhtf/core/phase_descriptor.py
@@ -216,8 +216,8 @@ class PhaseDescriptor(mutablerecords.Record(
       openhtf.plugs.InvalidPlugError if for one of the plug names one of the
       following is true:
         - error_on_unknown is True and the plug name is not registered.
-        - The new plug subclass is not a subclass of the original.
-        - The original plug class is not a placeholder or automatic placeholder.
+        - The new plug subclass is not a subclass of the original plug or the
+          PlugPlaceholder's base_class.
 
     Returns:
       PhaseDescriptor with updated plugs.
@@ -235,11 +235,7 @@ class PhaseDescriptor(mutablerecords.Record(
       elif isinstance(original_plug.cls, openhtf.plugs.PlugPlaceholder):
         accept_substitute = issubclass(sub_class, original_plug.cls.base_class)
       else:
-        # Check __dict__ to see if the attribute is explicitly defined in the
-        # class, rather than being defined in a parent class.
-        accept_substitute = ('auto_placeholder' in original_plug.cls.__dict__
-                             and original_plug.cls.auto_placeholder
-                             and issubclass(sub_class, original_plug.cls))
+        accept_substitute = issubclass(sub_class, original_plug.cls)
 
       if not accept_substitute:
         raise openhtf.plugs.InvalidPlugError(

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -161,10 +161,6 @@ class BasePlug(object):
   enable_remote = False
   # Allow explicitly disabling remote access to specific attributes.
   disable_remote_attrs = set()
-  # Override this to True in subclasses to support using with_plugs with this
-  # plug without needing to use placeholder.  This will only affect the classes
-  # that explicitly define this; subclasses do not share the declaration.
-  auto_placeholder = False
   # Default logger to be used only in __init__ of subclasses.
   # This is overwritten both on the class and the instance so don't store
   # a copy of it anywhere.

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -47,22 +47,17 @@ def extra_plug_func(plug, phrase):
   return plug.echo(phrase)
 
 
-class PlaceholderCapablePlug(plugs.BasePlug):
-  auto_placeholder = True
-
-
-class SubPlaceholderCapablePlug(PlaceholderCapablePlug):
+class ParentPlug(plugs.BasePlug):
   pass
 
 
-@plugs.plug(placed=PlaceholderCapablePlug)
-def placeholder_using_plug(placed):
-  del placed  # Unused.
+class ChildPlug(ParentPlug):
+  pass
 
 
-@plugs.plug(subplaced=SubPlaceholderCapablePlug)
-def sub_placeholder_using_plug(subplaced):
-  del subplaced  # Unused.
+@plugs.plug(parent=ParentPlug)
+def using_parent_plug(parent):
+  del parent  # Unused.
 
 
 class TestPhaseDescriptor(unittest.TestCase):
@@ -119,17 +114,16 @@ class TestPhaseDescriptor(unittest.TestCase):
       result = phase(self._phase_data)
       self.assertEqual('extra_plug_0 says hello', result)
 
-  def test_with_plugs_auto_placeholder(self):
-      phase = placeholder_using_plug.with_plugs(
-          placed=SubPlaceholderCapablePlug)
-      self.assertIs(phase.func, placeholder_using_plug.func)
+  def test_with_plugs_subclass(self):
+      phase = using_parent_plug.with_plugs(parent=ChildPlug)
+      self.assertIs(phase.func, using_parent_plug.func)
       self.assertEqual(1, len(phase.plugs))
 
-  def test_with_plugs_subclass_auto_placeholder_error(self):
-      with self.assertRaises(plugs.InvalidPlugError):
-          sub_placeholder_using_plug.with_plugs(
-              subplaced=SubPlaceholderCapablePlug)
+  def test_with_same_plug(self):
+      phase = using_parent_plug.with_plugs(parent=ParentPlug)
+      self.assertIs(phase.func, using_parent_plug.func)
+      self.assertEqual(1, len(phase.plugs))
 
-  def test_with_plugs_auto_placeholder_non_subclass_error(self):
+  def test_with_plugs_non_subclass_error(self):
       with self.assertRaises(plugs.InvalidPlugError):
-          placeholder_using_plug.with_plugs(placed=ExtraPlug)
+          using_parent_plug.with_plugs(parent=ExtraPlug)


### PR DESCRIPTION
The auto_placeholder concept was confusing.  Instead, all plugs should
act as placeholders for their own subclasses.  The .placeholder class
property still exists for abstract placeholders that must be replaced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/824)
<!-- Reviewable:end -->
