### PR TITLE
Making phase_group.PhaseGroup.wrap accept a single phase

### DIFF
--- a/openhtf/core/phase_group.py
+++ b/openhtf/core/phase_group.py
@@ -130,7 +130,10 @@ class PhaseGroup(mutablerecords.Record(
   def wrap(self, main_phases, name=None):
     """Returns PhaseGroup with additional main phases."""
     new_main = list(self.main)
-    new_main.extend(main_phases)
+    if isinstance(main_phases, collections.Iterable):
+      new_main.extend(main_phases)
+    else:
+      new_main.append(main_phases)
     return PhaseGroup(
         setup=self.setup,
         main=new_main,

--- a/test/core/phase_group_test.py
+++ b/test/core/phase_group_test.py
@@ -136,6 +136,18 @@ class PhaseGroupTest(unittest.TestCase):
         teardown=_fake_phases('t1'))
     self.assertEqual(expected, group.wrap(extra))
 
+  def testWrap_SinglePhase(self):
+    group = htf.PhaseGroup(
+        setup=_fake_phases('s1'),
+        main=_fake_phases('m1'),
+        teardown=_fake_phases('t1'))
+    single_extra = _fake_phases('m2', 'm3')[0]
+    expected = htf.PhaseGroup(
+        setup=_fake_phases('s1'),
+        main=_fake_phases('m1', 'm2'),
+        teardown=_fake_phases('t1'))
+    self.assertEqual(expected, group.wrap(single_extra))
+
   def testWithArgs_Setup(self):
     group = htf.PhaseGroup(setup=[blank_phase, arg_phase])
     arg_group = group.with_args(arg1=1)


### PR DESCRIPTION
Making phase_group.PhaseGroup.wrap accept a single phase in addition to phase groups or a list of phases.

This allows you to do things like:

```
MyPhaseGroup = phase_group.PhaseGroup(
  setup=on_start,
  teardown=on_stop)

@MyPhaseGroup.wrap
def MyPhase(test):
   # do your thang!
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/825)
<!-- Reviewable:end -->
