### PR TITLE
When casting to str() fails, print the object type to assist in debugging

### DIFF
--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -173,7 +173,13 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple,
     return as_float
 
   # Convert all other types to strings.
-  return str(obj)
+  try:
+    return str(obj)
+  except:
+    logging.warning('Problem casting object of type %s to str.', type(obj))
+    raise
+
+
 
 
 def total_size(obj):


### PR DESCRIPTION
Since convert_to_base_types can be called recursively on large nested data structures like test_record chasing down a problem when casting to a str() is a bit like finding a needle in a haystack.  At least log the type of object that causes the problem to narrow down debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/827)
<!-- Reviewable:end -->
