### PR TITLE
logging of exception in TestExecutor, import cleanup

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -15,23 +15,8 @@
 
 """The main OpenHTF entry point."""
 
-import argparse
-import collections
-import copy
-import functools
-import inspect
-import itertools
-import json
-import logging
 import pkg_resources
 import signal
-import socket
-import sys
-import textwrap
-import threading
-from types import LambdaType
-import uuid
-import weakref
 
 from openhtf import plugs
 from openhtf.core import phase_executor
@@ -54,9 +39,8 @@ from openhtf.util import data
 from openhtf.util import functions
 from openhtf.util import logs
 from openhtf.util import units
-import six
 
-# TODO:  TestPhase is used for legacy reasons and should be deprecated.
+# TODO: TestPhase is used for legacy reasons and should be deprecated.
 TestPhase = PhaseOptions  # pylint: disable=invalid-name
 
 

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -18,9 +18,6 @@ import logging
 import sys
 import threading
 
-import contextlib2 as contextlib
-
-import openhtf
 from openhtf.core import phase_executor
 from openhtf.core import phase_group
 from openhtf.core import test_state
@@ -136,6 +133,9 @@ class TestExecutor(threads.KillableThread):
       # Everything is set, set status and begin test execution.
       self.test_state.set_status_running()
       self._execute_phase_group(self._test_descriptor.phase_group)
+    except:
+      _LOG.exception('Exception in TestExecutor.')
+      raise
     finally:
       self._execute_test_teardown()
 


### PR DESCRIPTION
Adding logging of exception inside TestExecutor.
Removing some unused (or should be unused) imports of built-ins and common modules into openhtf module namespace.

PiperOrigin-RevId: 217422914

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/828)
<!-- Reviewable:end -->
