### PR TITLE
Remove unused imports

### DIFF
--- a/examples/example_plugs.py
+++ b/examples/example_plugs.py
@@ -14,8 +14,6 @@
 
 """Example plugs for OpenHTF."""
 
-import time
-
 import openhtf.plugs as plugs
 from openhtf.util import conf
 

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -15,23 +15,8 @@
 
 """The main OpenHTF entry point."""
 
-import argparse
-import collections
-import copy
-import functools
-import inspect
-import itertools
-import json
-import logging
 import pkg_resources
 import signal
-import socket
-import sys
-import textwrap
-import threading
-from types import LambdaType
-import uuid
-import weakref
 
 from openhtf import plugs
 from openhtf.core import phase_executor
@@ -54,7 +39,6 @@ from openhtf.util import data
 from openhtf.util import functions
 from openhtf.util import logs
 from openhtf.util import units
-import six
 
 # TODO:  TestPhase is used for legacy reasons and should be deprecated.
 TestPhase = PhaseOptions  # pylint: disable=invalid-name

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -18,8 +18,6 @@ import logging
 import sys
 import threading
 
-import contextlib2 as contextlib
-
 import openhtf
 from openhtf.core import phase_executor
 from openhtf.core import phase_group

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -20,13 +20,11 @@ alternative serialization schemes, see json_factory.py and mfg_inspector.py for
 examples.
 """
 
-import base64
 import contextlib
 try:
    import cPickle as pickle
 except:
    import pickle
-import os
 import shutil
 import tempfile
 

--- a/openhtf/output/servers/dashboard_server.py
+++ b/openhtf/output/servers/dashboard_server.py
@@ -8,7 +8,6 @@ import argparse
 import collections
 import json
 import logging
-import os
 import six
 import socket
 import threading

--- a/openhtf/output/servers/station_server.py
+++ b/openhtf/output/servers/station_server.py
@@ -6,7 +6,6 @@ aggregate info from multiple station servers with a single frontend.
 """
 
 import contextlib
-import hashlib
 import itertools
 import json
 import logging
@@ -14,13 +13,11 @@ import os
 import re
 import six
 import socket
-import sys
 import threading
 import time
 import types
 
 import sockjs.tornado
-import tornado.web
 
 import openhtf
 from openhtf.output.callbacks import mfg_inspector

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -95,13 +95,7 @@ self._my_config having a value of 'my_config_value'.
 """
 
 import collections
-import functools
-import inspect
-import json
 import logging
-import threading
-import time
-import types
 
 import mutablerecords
 

--- a/openhtf/plugs/usb/fastboot_device.py
+++ b/openhtf/plugs/usb/fastboot_device.py
@@ -21,7 +21,6 @@ import time
 from openhtf.plugs.usb import fastboot_protocol
 from openhtf.plugs.usb import usb_exceptions
 from openhtf.util import timeouts
-import collections
 
 # From fastboot.c
 VENDORS = {0x18D1, 0x0451, 0x0502, 0x0FCE, 0x05C6, 0x22B8, 0x0955,

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -15,7 +15,6 @@
 
 """One-off utilities."""
 
-import collections
 import logging
 import re
 import threading

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -57,7 +57,6 @@ by the default copy.deepcopy().
 import abc
 import numbers
 import re
-import sys
 from future.utils import with_metaclass
 from openhtf import util
 import six

--- a/openhtf/util/xmlrpcutil.py
+++ b/openhtf/util/xmlrpcutil.py
@@ -16,7 +16,6 @@
 
 import http.client
 import xmlrpc.server
-import os
 import socketserver
 import sys
 import threading

--- a/pylint_plugins/conf_plugin.py
+++ b/pylint_plugins/conf_plugin.py
@@ -16,7 +16,6 @@
 import astroid
 
 from astroid import MANAGER
-from pylint import lint
 
 
 def __init__(self):

--- a/pylint_plugins/mutablerecords_plugin.py
+++ b/pylint_plugins/mutablerecords_plugin.py
@@ -16,7 +16,6 @@
 import astroid
 
 from astroid import MANAGER
-from pylint import lint
 
 
 def __init__(self):

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -20,7 +20,6 @@ actually care for.
 
 import sys
 from io import BytesIO, StringIO
-import unittest
 
 from examples import all_the_things
 import openhtf as htf

--- a/test/plugs/plugs_test.py
+++ b/test/plugs/plugs_test.py
@@ -15,7 +15,6 @@
 import threading
 import time
 
-import mock
 import openhtf
 from openhtf import plugs
 from openhtf.util import test

--- a/test/util/data_test.py
+++ b/test/util/data_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import mock
 
 from builtins import int
 from openhtf.util import data

--- a/test/util/logs_test.py
+++ b/test/util/logs_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import unittest
-import time
 import mock
 
 


### PR DESCRIPTION
I've left the internal openhtf imports for now. They can be cleaned up
in a separate patch once I've convinced myself it won't break anything
unexpected.

All tests pass on Python 2.7.15 and 3.6.6

Should be no functional changes as a result of this patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/831)
<!-- Reviewable:end -->
