### PR TITLE
Add unit test for mfg_inspector._test_run_from_test_record

### DIFF
--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -113,7 +113,8 @@ def attachments(test):
       os.path.join(os.path.dirname(__file__), 'example_attachment.txt'))
 
   test_attachment = test.get_attachment('test_attachment')
-  assert test_attachment.data == 'This is test attachment data.'
+  print(test_attachment.data)
+  assert test_attachment.data == b'This is test attachment data.'
 
 
 @htf.TestPhase(run_if=lambda: False)
@@ -125,7 +126,7 @@ def analysis(test):
   level_all = test.get_measurement('level_all')
   assert level_all.value == 9
   test_attachment = test.get_attachment('test_attachment')
-  assert test_attachment.data == 'This is test attachment data.'
+  assert test_attachment.data == b'This is test attachment data.'
   lots_of_dims = test.get_measurement('lots_of_dims')
   assert lots_of_dims.value.value == [
       (1, 21, 101, 123),

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -67,6 +67,7 @@ class TestOutput(test.TestCase):
     test_run_proto = mfg_inspector._test_run_from_test_record(record)
 
     # Assert test status
+    print(test_run_proto.test_status)
     self.assertEqual(test_runs_pb2.FAIL, test_run_proto.test_status)
 
     # Verify all expected phases included.

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -11,22 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for the openhtf.io.output module.
+"""Unit tests for the openhtf.output.callbacks module.
 
 This test currently only provides line coverage, checking that the Python code
 is sane. It might be worth expanding the tests to also check for things we
 actually care for.
 """
 
+import io
 import sys
-from io import BytesIO, StringIO
+import unittest
 
-from examples import all_the_things
 import openhtf as htf
+from openhtf import util
+from examples import all_the_things
 from openhtf.output.callbacks import console_summary
 from openhtf.output.callbacks import json_factory
 from openhtf.output.callbacks import mfg_inspector
-from openhtf import util
+from openhtf.output.proto import test_runs_pb2
 from openhtf.util import test
 
 
@@ -51,17 +53,50 @@ class TestOutput(test.TestCase):
     user_mock.prompt.return_value = 'SomeWidget'
     record = yield self._test
     if sys.version_info[0] < 3:
-      json_output = BytesIO()
+      json_output = io.BytesIO()
     else:
-      json_output = StringIO()
+      json_output = io.StringIO()
     json_factory.OutputToJSON(
         json_output, sort_keys=True, indent=2)(record)
+
+  @test.patch_plugs(user_mock='openhtf.plugs.user_input.UserInput')
+  def test_test_run_from_test_record(self, user_mock):
+    user_mock.prompt.return_value = 'SomeWidget'
+    record = yield self._test
+
+    test_run_proto = mfg_inspector._test_run_from_test_record(record)
+
+    # Assert test status
+    self.assertEqual(test_runs_pb2.FAIL, test_run_proto.test_status)
+
+    # Verify all expected phases included.
+    expected_phase_names = [
+        'trigger_phase', 'hello_world', 'dimensions', 'attachments'
+    ]
+    actual_phase_names = [phase.name for phase in test_run_proto.phases]
+    self.assertEqual(expected_phase_names, actual_phase_names)
+
+    # Spot check a measurement (widget_size)
+    measurement_name = 'widget_size'
+    for parameter in test_run_proto.test_parameters:
+      if parameter.name == measurement_name:
+        self.assertEqual(3.0, parameter.numeric_value)
+
+    # Spot check an attachment (example_attachment.txt)
+    attachment_name = 'example_attachment.txt'
+    for parameter in test_run_proto.info_parameters:
+      if parameter.name == attachment_name:
+        self.assertEqual(
+          'This is a text file attachment.\n',
+          parameter.value_binary,
+        )
+
 
   @test.patch_plugs(user_mock='openhtf.plugs.user_input.UserInput')
   def test_testrun(self, user_mock):
     user_mock.prompt.return_value = 'SomeWidget'
     record = yield self._test
-    testrun_output = BytesIO()
+    testrun_output = io.BytesIO()
     mfg_inspector.OutputToTestRunProto(testrun_output)(record)
 
 
@@ -71,4 +106,4 @@ class TestConsoleSummary(test.TestCase):
     """Ensure there is an output color for each outcome."""
     instance = console_summary.ConsoleSummary()
     for outcome in htf.test_record.Outcome:
-        self.assertIn(outcome, instance.color_table)
+      self.assertIn(outcome, instance.color_table)

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -67,7 +67,6 @@ class TestOutput(test.TestCase):
     test_run_proto = mfg_inspector._test_run_from_test_record(record)
 
     # Assert test status
-    print(test_run_proto.test_status)
     self.assertEqual(test_runs_pb2.FAIL, test_run_proto.test_status)
 
     # Verify all expected phases included.
@@ -88,7 +87,7 @@ class TestOutput(test.TestCase):
     for parameter in test_run_proto.info_parameters:
       if parameter.name == attachment_name:
         self.assertEqual(
-          'This is a text file attachment.\n',
+          b'This is a text file attachment.\n',
           parameter.value_binary,
         )
 


### PR DESCRIPTION
This is in preparation for some light refactoring of mfg_inspector where I'm going to separate the logic used to convert a test record into a proto from the logic used to upload said proto.

Also made examples/all_the_things compatible with python3.