### PR TITLE
Python 3 compatibility xrange(10) --> range(10)

### DIFF
--- a/examples/checkpoints.py
+++ b/examples/checkpoints.py
@@ -36,7 +36,7 @@ def long_running_phase(test):
   # A long running phase could be something like a hardware burn-in.  This
   # phase should not run if previous phases have failed, so we make sure
   # checkpoint phase is run right before this phase.
-  for i in xrange(10):
+  for i in range(10):
     test.logger.info('Still running....')
     time.sleep(10)
   test.logger.info('Done with long_running_phase')


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.  For unknown values we would __from six.moves import xrange__ but for the low value of __10__, there is no practical difference __range()__ and __xrange()__ performance on Python 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/835)
<!-- Reviewable:end -->
