### PR TITLE
Always log a stack trace when a phase yielded for unit tests exceptions.

### DIFF
--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -160,10 +160,13 @@ class PhaseExecutorThread(threads.KillableThread):
     # will get set to the InvalidPhaseResultError in _thread_exception instead.
     self._phase_execution_outcome = PhaseExecutionOutcome(phase_return)
 
+  def _log_exception(self, *args):
+    """Log exception, while allowing unit testing to override."""
+    self._test_state.logger.critical(*args)
+
   def _thread_exception(self, *args):
     self._phase_execution_outcome = PhaseExecutionOutcome(ExceptionInfo(*args))
-    self._test_state.logger.critical(
-        'Phase %s raised an exception', self._phase_desc.name)
+    self._log_exception('Phase %s raised an exception', self._phase_desc.name)
     return True  # Never propagate exceptions upward.
 
   def join_or_die(self):

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -195,8 +195,12 @@ class PhaseOrTestIterator(collections.Iterator):
 
     # Actually execute the phase, saving the result in our return value.
     executor = phase_executor.PhaseExecutor(test_state_)
-    # Use _execute_phase_once because we want to expose all possible outcomes.
-    executor._execute_phase_once(phase_desc, is_last_repeat=False)
+    # Log an exception stack when a Phase errors out.
+    with mock.patch.object(
+        phase_executor.PhaseExecutorThread, '_log_exception',
+        side_effect=logging.exception):
+      # Use _execute_phase_once because we want to expose all possible outcomes.
+      executor._execute_phase_once(phase_desc, is_last_repeat=False)
     return test_state_.test_record.phases[-1]
 
   def _handle_test(self, test):


### PR DESCRIPTION
Always log a stack trace when a phase yielded for unit tests exceptions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/837)
<!-- Reviewable:end -->
