### PR TITLE
Add caching to data.convert_to_base_types

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -70,6 +70,7 @@ import mutablerecords
 
 from openhtf import util
 from openhtf.core import phase_descriptor
+from openhtf.util import data
 from openhtf.util import validators
 from openhtf.util import units
 import six
@@ -112,8 +113,11 @@ class Measurement(  # pylint: disable=no-init
     mutablerecords.Record(
         'Measurement', ['name'],
         {'units': None, 'dimensions': None, 'docstring': None,
-         '_notification_cb': None, 'validators': list, 'outcome': Outcome.UNSET,
-         'measured_value': None})):
+         '_notification_cb': None,
+         'validators': list,
+         'outcome': Outcome.UNSET,
+         'measured_value': None,
+         '_cached': None})):
   """Record encapsulating descriptive data for a measurement.
 
   This record includes an _asdict() method so it can be easily output.  Output
@@ -129,6 +133,8 @@ class Measurement(  # pylint: disable=no-init
     outcome: One of the Outcome() enumeration values, starting at UNSET.
     measured_value: An instance of MeasuredValue or DimensionedMeasuredValue
       containing the value(s) of this Measurement that have been set, if any.
+    _cached: A cached dict representation of this measurement created initially
+      during as_base_types and updated in place to save allocation time.
   """
 
   def __init__(self, name, **kwargs):
@@ -213,6 +219,7 @@ class Measurement(  # pylint: disable=no-init
     """Declare dimensions for this Measurement, returns self for chaining."""
     self.dimensions = tuple(
         self._maybe_make_dimension(dim) for dim in dimensions)
+    self._cached = None
     return self
 
   def with_validator(self, validator):
@@ -220,6 +227,7 @@ class Measurement(  # pylint: disable=no-init
     if not callable(validator):
       raise ValueError('Validator must be callable', validator)
     self.validators.append(validator)
+    self._cached = None
     return self
 
   def with_args(self, **kwargs):
@@ -233,6 +241,7 @@ class Measurement(  # pylint: disable=no-init
         self, name=util.format_string(self.name, kwargs),
         docstring=util.format_string(self.docstring, kwargs),
         validators=validators,
+        _cached=None,
     )
 
   def __getattr__(self, attr):  # pylint: disable=invalid-name
@@ -262,29 +271,36 @@ class Measurement(  # pylint: disable=no-init
                  self.name, e)
       self.outcome = Outcome.FAIL
       raise
+    finally:
+      if self._cached:
+        self._cached['outcome'] = self.outcome.name
 
-  def _asdict(self):
+  def as_base_types(self):
     """Convert this measurement to a dict of basic types."""
-    retval = {
-        'name': self.name,
-        'outcome': self.outcome,
-    }
+    if not self._cached:
+      # Create the single cache file the first time this is called.
+      self._cached = {
+          'name': self.name,
+          'outcome': self.outcome.name,
+      }
+      if self.validators:
+        self._cached['validators'] = data.convert_to_base_types(
+            tuple(str(v) for v in self.validators))
+      if self.dimensions:
+        self._cached['dimensions'] = data.convert_to_base_types(self.dimensions)
+      if self.units:
+        self._cached['units'] = data.convert_to_base_types(self.units)
+      if self.docstring:
+        self._cached['docstring'] = self.docstring
     if self.measured_value.is_value_set:
-      retval['measured_value'] = self.measured_value.value
-
-    if len(self.validators):
-      retval['validators'] = [str(v) for v in self.validators]
-    for attr in ('units', 'dimensions', 'docstring'):
-      if getattr(self, attr) is not None:
-        retval[attr] = getattr(self, attr)
-    return retval
+      self._cached['measured_value'] = self.measured_value.basetype_value()
+    return self._cached
 
   def to_dataframe(self, columns=None):
     """Convert a multi-dim to a pandas dataframe."""
     if not isinstance(self.measured_value, DimensionedMeasuredValue):
       raise TypeError(
         'Only a dimensioned measurement can be converted to a DataFrame')
-
 
     if columns is None:
       columns = [d.name for d in self.dimensions]
@@ -297,7 +313,8 @@ class Measurement(  # pylint: disable=no-init
 
 class MeasuredValue(
     mutablerecords.Record('MeasuredValue', ['name'],
-                          {'stored_value': None, 'is_value_set': False})):
+                          {'stored_value': None, 'is_value_set': False,
+                           '_cached_value': None})):
   """Class encapsulating actual values measured.
 
   Note that this is really just a value wrapper with some sanity checks.  See
@@ -309,6 +326,9 @@ class MeasuredValue(
   dimensioned values, see the DimensionedMeasuredValue.  The interfaces are very
   similar, but differ slightly; the important part is the get_value() interface
   on both of them.
+
+  The _cached_value is the base type represention of the stored_value when that
+  is set.
   """
 
   def __str__(self):
@@ -328,6 +348,9 @@ class MeasuredValue(
       raise MeasurementNotSetError('Measurement not yet set', self.name)
     return self.stored_value
 
+  def basetype_value(self):
+    return self._cached_value
+
   def set(self, value):
     """Set the value for this measurement, with some sanity checks."""
     if self.is_value_set:
@@ -341,6 +364,7 @@ class MeasuredValue(
     if value is None:
       _LOG.warning('Measurement %s is set to None', self.name)
     self.stored_value = value
+    self._cached_value = data.convert_to_base_types(value)
     self.is_value_set = True
 
 
@@ -351,9 +375,17 @@ class Dimension(object):
   as a drop-in replacement for UnitDescriptor for backwards compatibility.
   """
 
+  __slots__ = ['_description', '_unit', '_cached_dict']
+
   def __init__(self, description='', unit=units.NO_DIMENSION):
-    self.description = description
-    self.unit = unit
+    self._description = description
+    self._unit = unit
+    self._cached_dict = data.convert_to_base_types({
+        'code': self.code,
+        'description': self.description,
+        'name': self.name,
+        'suffix': self.suffix,
+    })
 
   def __eq__(self, other):
     return (self.description == other.description and self.unit == other.unit)
@@ -379,36 +411,47 @@ class Dimension(object):
       return cls(description=string)
 
   @property
+  def description(self):
+    return self._description
+
+  @property
+  def unit(self):
+    return self._unit
+
+  @property
   def code(self):
     """Provides backwards compatibility to `units.UnitDescriptor` api."""
-    return self.unit.code
+    return self._unit.code
 
   @property
   def suffix(self):
     """Provides backwards compatibility to `units.UnitDescriptor` api."""
-    return self.unit.suffix
+    return self._unit.suffix
 
   @property
   def name(self):
     """Provides backwards compatibility to `units.UnitDescriptor` api."""
-    return self.description or self.unit.name
+    return self._description or self._unit.name
 
   def _asdict(self):
-    return {
-        'code': self.code,
-        'description': self.description,
-        'name': self.name,
-        'suffix': self.suffix,
-    }
+    return self._cached_dict
 
 
 class DimensionedMeasuredValue(mutablerecords.Record(
     'DimensionedMeasuredValue', ['name', 'num_dimensions'],
-    {'notify_value_set': None, 'value_dict': collections.OrderedDict})):
+    {'notify_value_set': None,
+     'value_dict': collections.OrderedDict,
+     '_cached_basetype_values': list})):
   """Class encapsulating actual values measured.
 
   See the MeasuredValue class docstring for more info.  This class provides a
   dict-like interface for indexing into dimensioned measurements.
+
+  The _cached_basetype_values is a cached list of the dimensioned entries in
+  order of being set.  Each list entry is a tuple that is composed of the key,
+  then the value.  This is set to None if a previous measurement is overridden;
+  in such a case, the list is fully reconstructed on the next call to
+  basetype_value.
   """
   def __str__(self):
     return str(self.value) if self.is_value_set else 'UNSET'
@@ -441,7 +484,13 @@ class DimensionedMeasuredValue(mutablerecords.Record(
       _LOG.warning(
           'Overriding previous measurement %s[%s] value of %s with %s',
           self.name, coordinates, self.value_dict[coordinates], value)
+      self._cached_basetype_values = None
+    elif self._cached_basetype_values is not None:
+      self._cached_basetype_values.append(data.convert_to_base_types(
+          coordinates + (value,)))
+
     self.value_dict[coordinates] = value
+
     if self.notify_value_set:
       self.notify_value_set()
 
@@ -465,6 +514,13 @@ class DimensionedMeasuredValue(mutablerecords.Record(
       raise MeasurementNotSetError('Measurement not yet set', self.name)
     return [dimensions + (value,) for dimensions, value in
             six.iteritems(self.value_dict)]
+
+  def basetype_value(self):
+    if self._cached_basetype_values is None:
+      self._cached_basetype_values = list(
+          data.convert_to_base_types(coordinates + (value,))
+          for coordinates, value in six.iteritems(self.value_dict))
+    return self._cached_basetype_values
 
   def to_dataframe(self, columns=None):
     """Converts to a `pandas.DataFrame`"""

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -103,6 +103,7 @@ from openhtf import util
 import openhtf.core.phase_descriptor
 from openhtf.util import classproperty
 from openhtf.util import conf
+from openhtf.util import data
 from openhtf.util import logs
 from openhtf.util import threads
 import six
@@ -180,6 +181,10 @@ class BasePlug(object):
     decorate it with functions.call_at_most_every() to limit the frequency at
     which updates happen (pass a number of seconds to it to limit samples to
     once per that number of seconds).
+
+    You can also implement an `as_base_types` function that can return a dict
+    where the values must be base types at all levels.  This can help prevent
+    recursive copying, which is time intensive.
     """
     return {}
 
@@ -312,14 +317,14 @@ class PlugManager(object):
     self._plug_descriptors = {}
     self.logger = logging.getLogger(record_logger_name).getChild('plug')
 
-  def _asdict(self):
+  def as_base_types(self):
     return {
         'plug_descriptors': {
             name: dict(descriptor._asdict())  # Convert OrderedDict to dict.
             for name, descriptor in six.iteritems(self._plug_descriptors)
         },
         'plug_states': {
-            name: plug._asdict()
+            name: data.convert_to_base_types(plug)
             for name, plug in six.iteritems(self._plugs_by_name)
         },
     }

--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -84,6 +84,8 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
     if self._device is None:
       raise openhtf.plugs.InvalidPlugError(
           'DeviceWrappingPlug instances must set the _device attribute.')
+    if attr == 'as_base_types':
+      return super(DeviceWrappingPlug, self).__getattr__(attr)
 
     attribute = getattr(self._device, attr)
 

--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -114,7 +114,11 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple,
   for sending internal objects via the network and outputting test records.
   Specifically, the conversions that are performed:
 
-    - If an object has an _asdict() method, use that to convert it to a dict.
+    - If an object has an as_base_types() method, immediately return the result
+      without any recursion; this can be used with caching in the object to
+      prevent unnecessary conversions.
+    - If an object has an _asdict() method, use that to convert it to a dict and
+      recursively converting its contents.
     - mutablerecords Record instances are converted to dicts that map
       attribute name to value.  Optional attributes with a value of None are
       skipped.
@@ -140,6 +144,8 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple,
   if type(obj) in PASSTHROUGH_TYPES:
     return obj
 
+  if hasattr(obj, 'as_base_types'):
+    return obj.as_base_types()
   if hasattr(obj, '_asdict'):
     obj = obj._asdict()
   elif isinstance(obj, records.RecordClass):
@@ -178,8 +184,6 @@ def convert_to_base_types(obj, ignore_keys=tuple(), tuple_type=tuple,
   except:
     logging.warning('Problem casting object of type %s to str.', type(obj))
     raise
-
-
 
 
 def total_size(obj):

--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -256,7 +256,7 @@ class RecordHandler(logging.Handler):
           record.levelno, record.name, os.path.basename(record.pathname),
           record.lineno, int(record.created * 1000), message,
       )
-      self._test_record.log_records.append(log_record)
+      self._test_record.add_log_record(log_record)
       self._notify_update()
     except Exception:  # pylint: disable=broad-except
       self.handleError(record)

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -146,15 +146,15 @@ class InRange(RangeValidatorBase):
     return True
 
   def __str__(self):
-    assert self.minimum is not None or self.maximum is not None
-    if self.minimum is not None and self.maximum is not None:
-      if self.minimum == self.maximum:
-        return 'x == %s' % self.minimum
-      return '%s <= x <= %s' % (self.minimum, self.maximum)
-    if self.minimum is not None:
-      return '%s <= x' % self.minimum
-    if self.maximum is not None:
-      return 'x <= %s' % self.maximum
+    assert self._minimum is not None or self._maximum is not None
+    if self._minimum is not None and self._maximum is not None:
+      if self._minimum == self._maximum:
+        return 'x == %s' % self._minimum
+      return '%s <= x <= %s' % (self._minimum, self._maximum)
+    if self._minimum is not None:
+      return '%s <= x' % self._minimum
+    if self._maximum is not None:
+      return 'x <= %s' % self._maximum
 
   def __eq__(self, other):
     return (isinstance(other, type(self)) and
@@ -195,7 +195,7 @@ class Equals(object):
     return value == self.expected
 
   def __str__(self):
-    return "'x' is equal to '%s'" % self.expected
+    return "'x' is equal to '%s'" % self._expected
 
   def __eq__(self, other):
     return isinstance(other, type(self)) and self.expected == other.expected

--- a/test/plugs/plugs_test.py
+++ b/test/plugs/plugs_test.py
@@ -98,13 +98,13 @@ class PlugsTest(test.TestCase):
         {
             adder_plug_name: {'mro': [adder_plug_name]}
         },
-        self.plug_manager._asdict()['plug_descriptors']
+        self.plug_manager.as_base_types()['plug_descriptors']
     )
     self.assertEqual(
         {
             adder_plug_name: {'number': 0}
         },
-        self.plug_manager._asdict()['plug_states']
+        self.plug_manager.as_base_types()['plug_states']
     )
     self.assertEqual('CREATED', AdderPlug.LAST_INSTANCE.state)
 

--- a/test/test_state_test.py
+++ b/test/test_state_test.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import tempfile
 import unittest
 
 import mock
 
 import openhtf
+from openhtf.core import phase_group
 from openhtf.core import test_descriptor
 from openhtf.core import test_state
+from openhtf.util import conf
 
 
 @openhtf.measures('test_measurement')
@@ -29,12 +32,65 @@ def test_phase():
   pass
 
 
+PHASE_STATE_BASE_TYPE_INITIAL = {
+    'name': 'test_phase',
+    'codeinfo': {
+        'docstring': None,
+        'name': '',
+        'sourcecode': '',
+    },
+    # The descriptor id is not static, so this must be updated.
+    'descriptor_id': 'MUST_BE_UPDATED',
+    'options': None,
+    'measurements': {
+        'test_measurement': {
+            'name': 'test_measurement',
+            'outcome': 'UNSET',
+        },
+    },
+    'attachments': {},
+}
+
+PHASE_RECORD_BASE_TYPE = copy.deepcopy(PHASE_STATE_BASE_TYPE_INITIAL)
+PHASE_RECORD_BASE_TYPE.update({
+    'start_time_millis': 0,
+    'end_time_millis': None,
+    'outcome': None,
+    'result': None,
+})
+
+TEST_STATE_BASE_TYPE_INITIAL = {
+    'status': 'WAITING_FOR_TEST_START',
+    'test_record': {
+        'station_id': conf.station_id,
+        'code_info': None,
+        'dut_id': None,
+        'start_time_millis': 0,
+        'end_time_millis': None,
+        'outcome': None,
+        'outcome_details': [],
+        'metadata': {
+            'config': {}
+        },
+        'phases': [],
+        'log_records': [],
+    },
+    'plugs': {
+        'plug_descriptors': {},
+        'plug_states': {},
+    },
+    'running_phase_state': copy.deepcopy(PHASE_STATE_BASE_TYPE_INITIAL),
+}
+
+
 class TestTestApi(unittest.TestCase):
 
   def setUp(self):
-    mock_test_descriptor = mock.MagicMock()
-    self.test_state = test_state.TestState(mock_test_descriptor, 'testing-123',
+    self.test_descriptor = test_descriptor.TestDescriptor(
+        phase_group.PhaseGroup(main=[test_phase]), None, {'config': {}})
+    self.test_state = test_state.TestState(self.test_descriptor, 'testing-123',
                                            test_descriptor.TestOptions())
+    self.test_record = self.test_state.test_record
     self.running_phase_state = test_state.PhaseState.from_descriptor(
         test_phase, lambda *args: None)
     self.test_state.running_phase_state = self.running_phase_state
@@ -42,7 +98,7 @@ class TestTestApi(unittest.TestCase):
 
   def test_get_attachment(self):
     attachment_name = 'attachment.txt'
-    input_contents = 'This is some attachment text!'
+    input_contents = b'This is some attachment text!'
     mimetype = 'text/plain'
     self.test_api.attach(attachment_name, input_contents, mimetype)
 
@@ -86,3 +142,40 @@ class TestTestApi(unittest.TestCase):
       self.test_api.attach_from_file(file_name, 'attachment.png')
     attachment = self.test_api.get_attachment('attachment.png')
     self.assertEqual(attachment.mimetype, 'image/png')
+
+  def test_phase_state_cache(self):
+    basetypes = self.running_phase_state.as_base_types()
+    expected_initial_basetypes = copy.deepcopy(PHASE_STATE_BASE_TYPE_INITIAL)
+    expected_initial_basetypes['descriptor_id'] = basetypes['descriptor_id']
+    self.assertEqual(expected_initial_basetypes, basetypes)
+    self.assertFalse(self.running_phase_state._update_measurements)
+    self.test_api.measurements.test_measurement = 5
+    self.assertEqual({'test_measurement'},
+                     self.running_phase_state._update_measurements)
+    self.running_phase_state.as_base_types()
+    expected_after_basetypes = copy.deepcopy(expected_initial_basetypes)
+    expected_after_basetypes['measurements']['test_measurement'].update({
+        'outcome': 'PASS',
+        'measured_value': 5,
+    })
+    self.assertEqual(expected_after_basetypes, basetypes)
+    self.assertFalse(self.running_phase_state._update_measurements)
+
+  def test_test_state_cache(self):
+    basetypes = self.test_state.as_base_types()
+    # The descriptor id is not static, so grab it.
+    expected_initial_basetypes = copy.deepcopy(TEST_STATE_BASE_TYPE_INITIAL)
+    descriptor_id = basetypes['running_phase_state']['descriptor_id']
+    expected_initial_basetypes['running_phase_state']['descriptor_id'] = (
+        descriptor_id)
+    self.assertEqual(expected_initial_basetypes, basetypes)
+    self.running_phase_state._finalize_measurements()
+    self.test_record.add_phase_record(self.running_phase_state.phase_record)
+    self.test_state.running_phase_state = None
+    basetypes2 = self.test_state.as_base_types()
+    expected_after_phase_record_basetypes = copy.deepcopy(
+        PHASE_RECORD_BASE_TYPE)
+    expected_after_phase_record_basetypes['descriptor_id'] = descriptor_id
+    self.assertEqual(expected_after_phase_record_basetypes,
+                     basetypes2['test_record']['phases'][0])
+    self.assertIsNone(basetypes2['running_phase_state'])

--- a/test/util/data_test.py
+++ b/test/util/data_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import unittest
 
 from builtins import int
@@ -25,30 +26,51 @@ class TestData(unittest.TestCase):
     class FloatSubclass(float):
       pass
 
+    class SpecialBaseTypes(
+        collections.namedtuple('SpecialBaseTypes', ['unsafe_value'])):
+
+      def as_base_types(self):
+        return {'safe_value': True}
+
+    class NotRecursivelyCopied(object):
+
+      def __init__(self):
+        self.value = []
+
+      def as_base_types(self):
+        return self.value
+
+    not_copied = NotRecursivelyCopied()
+
     example_data = {
-      'list': [10],
-      'tuple': (10,),
-      'str': '10',
-      'unicode': '10',
-      'int': 2 ** 40,
-      'float': 10.0,
-      'long': 2 ** 80,
-      'bool': True,
-      'none': None,
-      'complex': 10j,
-      'float_subclass': FloatSubclass(10.0),
+        'list': [10],
+        'tuple': (10,),
+        'str': '10',
+        'unicode': '10',
+        'int': 2 ** 40,
+        'float': 10.0,
+        'long': 2 ** 80,
+        'bool': True,
+        'none': None,
+        'complex': 10j,
+        'float_subclass': FloatSubclass(10.0),
+        'special': SpecialBaseTypes('must_not_be_present'),
+        'not_copied': not_copied,
     }
     converted = data.convert_to_base_types(example_data)
 
 
-    self.assertIs(type(converted['list']), list)
-    self.assertIs(type(converted['tuple']), tuple)
-    self.assertIs(type(converted['str']), str)
-    self.assertIs(type(converted['unicode']), str)
-    assert isinstance(converted['int'], int)
-    self.assertIs(type(converted['float']), float)
-    assert isinstance(converted['long'], long)
-    self.assertIs(type(converted['bool']), bool)
-    self.assertIs(converted['none'], None)
-    self.assertIs(type(converted['complex']), str)
-    self.assertIs(type(converted['float_subclass']), float)
+    self.assertIsInstance(converted['list'], list)
+    self.assertIsInstance(converted['tuple'], tuple)
+    self.assertIsInstance(converted['str'], str)
+    self.assertIsInstance(converted['unicode'], str)
+    self.assertIsInstance(converted['int'], int)
+    self.assertIsInstance(converted['float'], float)
+    self.assertIsInstance(converted['long'], long)
+    self.assertIsInstance(converted['bool'], bool)
+    self.assertIsNone(converted['none'])
+    self.assertIsInstance(converted['complex'], str)
+    self.assertIsInstance(converted['float_subclass'], float)
+    self.assertIsInstance(converted['special'], dict)
+    self.assertEqual(converted['special'], {'safe_value': True})
+    self.assertIs(converted['not_copied'], not_copied.value)


### PR DESCRIPTION
Make data.convert_to_base_types less expensive with caching and passthrough
functions.  This also involves moving some interactions with subfields to the
actual object so it can handle the caching.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/840)
<!-- Reviewable:end -->
