### PR TITLE
feat: make test execution return code usable in CI

### DIFF
--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -351,8 +351,10 @@ class Test(object):
         del self.TEST_INSTANCES[self.uid]
         self._executor = None
 
-    return final_state.test_record.outcome == test_record.Outcome.PASS
-
+    if final_state.test_record.outcome == test_record.Outcome.PASS:
+      return 0
+    else:
+      return final_state.test_record.outcome.value
 
 # TODO(arsharma): Deprecate the teardown_function in favor of PhaseGroups.
 class TestOptions(mutablerecords.Record('TestOptions', [], {


### PR DESCRIPTION
# What I did
In the current software, we get True if tests passed, False otherwise.
With the change we get 0 if it succeeded and the outcome enumeration value if failed. The goal is to get a 0 error code at the end of the test execution when it succeeds, to do

    sys.exit(test.execute(foo))

# Why I did it
This is useful in CI context for example where you need the error code to determine if a job failed. In the current situation, we get True if tests passed (1) and False (0) otherwise, which is not usable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/841)
<!-- Reviewable:end -->
