### PR TITLE
xrange() was removed in Python 3

### DIFF
--- a/examples/checkpoints.py
+++ b/examples/checkpoints.py
@@ -36,7 +36,7 @@ def long_running_phase(test):
   # A long running phase could be something like a hardware burn-in.  This
   # phase should not run if previous phases have failed, so we make sure
   # checkpoint phase is run right before this phase.
-  for i in xrange(10):
+  for i in range(10):
     test.logger.info('Still running....')
     time.sleep(10)
   test.logger.info('Done with long_running_phase')


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/843)
<!-- Reviewable:end -->
