### PR TITLE
Refactoring API of mfg_inspector.py 

### DIFF
--- a/openhtf/output/callbacks/mfg_inspector.py
+++ b/openhtf/output/callbacks/mfg_inspector.py
@@ -1,83 +1,19 @@
-"""Output or upload a TestRun proto for mfg-inspector.com
-
-MULTIDIM_JSON schema:
-{
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Multi-dimensional test parameter",
-  "type": "object",
-  "properties": {
-    "outcome": {"enum": ["PASS", "FAIL", "ERROR"]},
-    "name": {"type": "string"},
-    "dimensions": {
-      "type": array,
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "properties": {
-          "uom_code": {"type": "string"},
-          "uom_suffix": {"type": "string"}
-        }
-      }
-    },
-    "values": {
-      "type": "array",
-      "items": {}
-    }
-  }
-}
+"""Output and/or upload a TestRun or MfgEvent proto for mfg-inspector.com.
 """
 
 import json
 import logging
-import numbers
-import os
 import threading
+import time
 import zlib
-try:
-  from past.types import unicode
-except ImportError:
-  pass
 
 import httplib2
 import oauth2client.client
 
-from openhtf.core import measurements
-from openhtf.core import test_record
 from openhtf.output import callbacks
-from openhtf.output.callbacks import json_factory
-from openhtf.output.proto import guzzle_pb2
-from openhtf.output.proto import test_runs_pb2
-from openhtf.util import validators
-import six
+from openhtf.output.proto import test_runs_converter
 
-# pylint: disable=no-member
-MIMETYPE_MAP = {
-    'image/jpeg': test_runs_pb2.JPG,
-    'image/png': test_runs_pb2.PNG,
-    'audio/x-wav': test_runs_pb2.WAV,
-    'text/plain': test_runs_pb2.TEXT_UTF8,
-    'image/tiff': test_runs_pb2.TIFF,
-    'video/mp4': test_runs_pb2.MP4,
-}
-OUTCOME_MAP = {
-    test_record.Outcome.ERROR: test_runs_pb2.ERROR,
-    test_record.Outcome.FAIL: test_runs_pb2.FAIL,
-    test_record.Outcome.PASS: test_runs_pb2.PASS,
-    test_record.Outcome.TIMEOUT: test_runs_pb2.ERROR,
-    test_record.Outcome.ABORTED: test_runs_pb2.ERROR,
-}
-
-UOM_CODE_MAP = {
-    u.GetOptions().Extensions[
-        test_runs_pb2.uom_code]: num
-    for num, u in six.iteritems(
-        test_runs_pb2.Units.UnitCode.DESCRIPTOR.values_by_number)
-}
-# pylint: enable=no-member
-
-# Control how many flattened parameters we'll output per multidimensional
-# measurement.
-MAX_PARAMS_PER_MEASUREMENT = 100
+from google3.googlex.warhol.proto import quantum_data_pb2
 
 
 class UploadFailedError(Exception):
@@ -88,302 +24,95 @@ class InvalidTestRunError(Exception):
   """Raised if test run is invalid."""
 
 
-# pylint: disable=invalid-name
-def _populate_header(record, testrun):
-  """Populate header-like info in testrun from record.
+def _send_mfg_inspector_request(envelope_data, credentials, destination_url):
+  """Send upload http request.  Intended to be run in retry loop."""
+  logging.info('Uploading result...')
+  http = httplib2.Http()
 
-  Mostly obvious, some stuff comes from metadata, see docstring of
-  _test_run_from_test_record for details.
-  """
-  testrun.dut_serial = record.dut_id
-  testrun.tester_name = record.station_id
-  if 'test_name' in record.metadata:
-    testrun.test_info.name = record.metadata['test_name']
-  else:
-    # Default to copying tester_name into test_info.name.
-    testrun.test_info.name = record.station_id
-  if 'test_description' in record.metadata:
-    testrun.test_info.description = record.metadata['test_description']
-  if 'test_version' in record.metadata:
-    testrun.test_info.version_string = record.metadata['test_version']
-  testrun.test_status = OUTCOME_MAP[record.outcome]
-  testrun.start_time_millis = record.start_time_millis
-  testrun.end_time_millis = record.end_time_millis
-  if 'run_name' in record.metadata:
-    testrun.run_name = record.metadata['run_name']
-  for details in record.outcome_details:
-    testrun_code = testrun.failure_codes.add()
-    testrun_code.code = details.code
-    testrun_code.details = details.description
-  for phase in record.phases:
-    testrun_phase = testrun.phases.add()
-    testrun_phase.name = phase.name
-    testrun_phase.description = phase.codeinfo.sourcecode
-    testrun_phase.timing.start_time_millis = phase.start_time_millis
-    testrun_phase.timing.end_time_millis = phase.end_time_millis
-  if 'config' in record.metadata:
-    attachment = testrun.info_parameters.add()
-    attachment.name = 'config'
-    attachment.value_binary = json.dumps(
-        record.metadata['config'], sort_keys=True, indent=4).encode('utf-8')
+  if credentials.access_token_expired:
+    credentials.refresh(http)
+  credentials.authorize(http)
+
+  resp, content = http.request(destination_url, 'POST', envelope_data)
+
+  try:
+    result = json.loads(content)
+  except Exception:
+    logging.debug('Upload failed with response %s: %s', resp, content)
+    raise UploadFailedError(resp, content)
+
+  if resp.status != 200:
+    logging.debug('Upload failed: %s', result)
+    raise UploadFailedError(result['error'], result)
+
+  return result
 
 
-def _ensure_unique_parameter_name(name, used_parameter_names):
-  while name in used_parameter_names:
-    name += '_'  # Hack to avoid collisions between phases.
-  used_parameter_names.add(name)
-  return name
+def send_mfg_inspector_data(inspector_proto, credentials, destination_url):
+  """Upload MfgEvent to steam_engine."""
+  envelope = guzzle_pb2.TestRunEnvelope()
+  envelope.payload = zlib.compress(inspector_proto.SerializeToString())
+  envelope.payload_type = guzzle_pb2.COMPRESSED_MFG_EVENT
+  envelope_data = envelope.SerializeToString()
+
+  for _ in xrange(5):
+    try:
+      result = _send_mfg_inspector_request(
+          envelope_data, credentials, destination_url)
+      return result
+    except UploadFailedError:
+      time.sleep(1)
+
+  logging.critical(
+      'Could not upload to mfg-inspector after 5 attempts. Giving up.')
+
+  return {}
 
 
-def _attach_json(record, testrun):
-  """Attach a copy of the JSON-ified record as an info parameter.
+class _MemStorage(oauth2client.client.Storage):
+  # pylint: disable=invalid-name
+  """Helper Storage class that keeps credentials in memory."""
 
-  Save a copy of the JSON-ified record in an attachment so we can access
-  un-mangled fields later if we want.  Remove attachments since those get
-  copied over and can potentially be quite large.
-  """
-  record_json = json_factory.OutputToJSON(
-      inline_attachments=False,
-      sort_keys=True, indent=2).serialize_test_record(record)
-  testrun_param = testrun.info_parameters.add()
-  testrun_param.name = 'OpenHTF_record.json'
-  testrun_param.value_binary = record_json.encode('utf-8')
-  # pylint: disable=no-member
-  testrun_param.type = test_runs_pb2.TEXT_UTF8
-  # pylint: enable=no-member
+  def __init__(self):
+    self._lock = threading.Lock()
+    self._credentials = None
 
+  def acquire_lock(self):
+    self._lock.acquire(True)
 
-def _extract_attachments(phase, testrun, used_parameter_names):
-  """Extract attachments, just copy them over."""
-  for name, (attachment_data, mimetype) in sorted(six.iteritems(phase.attachments)):
-    name = _ensure_unique_parameter_name(name, used_parameter_names)
-    testrun_param = testrun.info_parameters.add()
-    testrun_param.name = name
-    if isinstance(attachment_data, unicode):
-      attachment_data = attachment_data.encode('utf-8')
-    testrun_param.value_binary = attachment_data
-    if mimetype in MIMETYPE_MAP:
-      testrun_param.type = MIMETYPE_MAP[mimetype]
-    else:
-      # pylint: disable=no-member
-      testrun_param.type = test_runs_pb2.BINARY
-      # pylint: enable=no-member
+  def release_lock(self):
+    self._lock.release()
+
+  def locked_get(self):
+    return self._credentials
+
+  def locked_put(self, credentials):
+    self._credentials = credentials
 
 
-def _mangle_measurement(name, measured_value, measurement, mangled_parameters,
-                        attachment_name):
-  """Flatten parameters for backwards compatibility, watch for collisions.
+class MfgInspector(object):
+  """Interface to convert a TestRun to a mfg-inspector compatible proto.
 
-  We generate these by doing some name mangling, using some sane limits for
-  very large multidimensional measurements.
-  """
-  for coord, val in list(measured_value.value_dict.items(
-      ))[:MAX_PARAMS_PER_MEASUREMENT]:
-    # Mangle names so they look like 'myparameter_Xsec_Ynm_ZHz'
-    mangled_name = '_'.join([name] + [
-        '%s%s' % (
-            dim_val,
-            dim_units.suffix if dim_units.suffix else '') for
-        dim_val, dim_units in zip(
-          coord, measurement.dimensions)])
-    while mangled_name in mangled_parameters:
-      logging.warning('Mangled name %s already in use', mangled_name)
-      mangled_name += '_'
-    mangled_param = test_runs_pb2.TestParameter()
-    mangled_param.name = mangled_name
-    mangled_param.associated_attachment = attachment_name
-    mangled_param.description = (
-        'Mangled parameter from measurement %s with dimensions %s' % (
-            name, tuple(d.suffix for d in measurement.dimensions)))
+  Instances of this class are typically used to create callbacks that are
+  compatible with the OpenHTF output callbacks.
 
-    if isinstance(val, numbers.Number):
-      mangled_param.numeric_value = float(val)
-    else:
-      mangled_param.text_value = str(val)
-    # Check for validators we know how to translate.
-    for validator in measurement.validators:
-      mangled_param.description += '\nValidator: ' + str(validator)
+  Typical usage:
+  interface = mfg_inspector.MfgInspector.from_json().set_converter(
+    my_custom_converter)
+  my_tester.add_output_callbacks(interface.save_to_disk(), interface.upload())
 
-    if measurement.units and measurement.units.code in UOM_CODE_MAP:
-      mangled_param.unit_code = UOM_CODE_MAP[measurement.units.code]
-    mangled_parameters[mangled_name] = mangled_param
+  **Important** the conversion of the TestRecord to protofbuf as specified in
+  the _converter callable attribute only occurs once and the resulting protobuf
+  is cached in memory on the instance.
 
-
-def _extract_parameters(record, testrun, used_parameter_names):
-  """Extract parameters from phases.
-
-  Generate mangled parameters afterwards so we give real measurements priority
-  getting names.
-  """
-  mangled_parameters = {}
-  for phase in record.phases:
-    _extract_attachments(phase, testrun, used_parameter_names)
-    for name, measurement in sorted(six.iteritems(phase.measurements)):
-      tr_name = _ensure_unique_parameter_name(name, used_parameter_names)
-      testrun_param = testrun.test_parameters.add()
-      testrun_param.name = tr_name
-      if measurement.docstring:
-        testrun_param.description = measurement.docstring
-      if measurement.units and measurement.units.code in UOM_CODE_MAP:
-        testrun_param.unit_code = UOM_CODE_MAP[measurement.units.code]
-
-      if measurement.outcome == measurements.Outcome.PASS:
-        testrun_param.status = test_runs_pb2.PASS
-      elif (not measurement.measured_value
-            or not measurement.measured_value.is_value_set):
-        testrun_param.status = test_runs_pb2.ERROR
-        continue
-      else:
-        testrun_param.status = test_runs_pb2.FAIL
-
-      value = None
-      if measurement.measured_value.is_value_set:
-        value = measurement.measured_value.value
-      else:
-        testrun_param.status = test_runs_pb2.ERROR
-      if measurement.dimensions is None:
-        # Just a plain ol' value.
-        if isinstance(value, numbers.Number):
-          testrun_param.numeric_value = float(value)
-        else:
-          testrun_param.text_value = str(value)
-        # Check for validators we know how to translate.
-        for validator in measurement.validators:
-          if isinstance(validator, validators.RangeValidatorBase):
-            if validator.minimum is not None:
-              testrun_param.numeric_minimum = float(validator.minimum)
-            if validator.maximum is not None:
-              testrun_param.numeric_maximum = float(validator.maximum)
-          elif isinstance(validator, validators.RegexMatcher):
-            testrun_param.expected_text = validator.regex
-          else:
-            testrun_param.description += '\nValidator: ' + str(validator)
-      else:
-        attachment = testrun.info_parameters.add()
-        attachment.name = 'multidim_%s' % name
-        dims = [{
-            'uom_suffix': d.suffix,
-            'uom_code': d.code}
-                for d in measurement.dimensions]
-        # Refer to the module docstring for the expected schema.
-        attachment.value_binary = json.dumps({
-            'outcome': str(testrun_param.status), 'name': name,
-            'dimensions': dims,
-            'value': value
-        }, sort_keys=True).encode('utf-8')
-        attachment.type = test_runs_pb2.MULTIDIM_JSON
-        _mangle_measurement(
-            name, measurement.measured_value, measurement, mangled_parameters,
-            attachment.name)
-      if testrun_param.status == test_runs_pb2.FAIL:
-        testrun_code = testrun.failure_codes.add()
-        testrun_code.code = testrun_param.name
-        if measurement.dimensions is None:
-          if isinstance(testrun_param.numeric_value, float):
-            testrun_code.details = str(testrun_param.numeric_value)
-          else:
-            testrun_code.details = testrun_param.text_value
-  return mangled_parameters
-
-
-def _add_mangled_parameters(testrun, mangled_parameters, used_parameter_names):
-  """Add any mangled parameters we generated from multidim measurements."""
-  for mangled_name, mangled_param in sorted(six.iteritems(mangled_parameters)):
-    if mangled_name != _ensure_unique_parameter_name(mangled_name,
-                                                     used_parameter_names):
-      logging.warning('Mangled name %s in use by non-mangled parameter',
-                      mangled_name)
-    testrun_param = testrun.test_parameters.add()
-    testrun_param.CopyFrom(mangled_param)
-
-
-def _add_log_lines(record, testrun):
-  """Copy log records over, this is a fairly straightforward mapping."""
-  for log in record.log_records:
-    testrun_log = testrun.test_logs.add()
-    testrun_log.timestamp_millis = log.timestamp_millis
-    testrun_log.log_message = log.message
-    testrun_log.logger_name = log.logger_name
-    testrun_log.levelno = log.level
-    # pylint: disable=no-member
-    if log.level <= logging.DEBUG:
-      testrun_log.level = test_runs_pb2.TestRunLogMessage.DEBUG
-    elif log.level <= logging.INFO:
-      testrun_log.level = test_runs_pb2.TestRunLogMessage.INFO
-    elif log.level <= logging.WARNING:
-      testrun_log.level = test_runs_pb2.TestRunLogMessage.WARNING
-    elif log.level <= logging.ERROR:
-      testrun_log.level = test_runs_pb2.TestRunLogMessage.ERROR
-    elif log.level <= logging.CRITICAL:
-      testrun_log.level = test_runs_pb2.TestRunLogMessage.CRITICAL
-    # pylint: enable=no-member
-    testrun_log.log_source = log.source
-    testrun_log.lineno = log.lineno
-
-
-def _test_run_from_test_record(record):
-  """Create a TestRun proto from an OpenHTF TestRecord.
-
-  Most fields are just copied over, some are pulled out of metadata (listed
-  below), and measurements are munged a bit for backwards compatibility.
-
-  Metadata fields:
-    'test_description': TestInfo's description field.
-    'test_version': TestInfo's version_string field.
-    'test_name': TestInfo's name field.
-    'run_name': TestRun's run_name field.
-    'operator_name': TestRun's operator_name field.
-
-
-  Returns:  An instance of the TestRun proto for the given record.
-  """
-  testrun = test_runs_pb2.TestRun()
-  _populate_header(record, testrun)
-  _attach_json(record, testrun)
-
-  used_parameter_names = set(['OpenHTF_record.json'])
-  mangled_parameters = _extract_parameters(record, testrun,
-                                           used_parameter_names)
-  _add_mangled_parameters(testrun, mangled_parameters, used_parameter_names)
-  _add_log_lines(record, testrun)
-  return testrun
-
-
-class OutputToTestRunProto(callbacks.OutputToFile):
-  """Return an output callback that writes mfg-inspector TestRun Protos.
-
-  Example filename_patterns might be:
-    '/data/test_records/{dut_id}.{metadata[test_name]}.pb' or
-    '/data/test_records/%(dut_id)s.%(start_time_millis)s'
-
-  To use this output mechanism:
-    test = openhtf.Test(PhaseOne, PhaseTwo)
-    test.add_output_callback(openhtf.OutputToTestRunProto(
-        '/data/test_records/{dut_id}.{metadata[test_name]}.pb'))
-
-  Args:
-    filename_pattern: A format string specifying the filename to write to,
-      will be formatted with the Test Record as a dictionary.  May also be a
-      file-like object to write directly to.
-
-  Returns:
-    filename of local file.
-  """
-
-  def __init__(self, filename_pattern):
-    super(OutputToTestRunProto, self).__init__(filename_pattern)
-
-  @staticmethod
-  def serialize_test_record(test_record_obj):
-    return _test_run_from_test_record(test_record_obj).SerializeToString()
-
-
-class UploadToMfgInspector(object):
-  """Generate a mfg-inspector TestRun proto and upload it.
-
-  Create an output callback to upload to mfg-inspector.com using the given
+  The upload callback will upload to mfg-inspector.com using the given
   username and authentication key (which should be the key data itself, not a
   filename or file).
+
+  In typical productin setups, we *first* save the protobuf to disk then attempt
+  to upload the protobuf to mfg-inspector.  In the event of a network outage,
+  the result of the test run is available on disk and a separate process can
+  retry the upload when network is available.
   """
 
   TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
@@ -391,39 +120,38 @@ class UploadToMfgInspector(object):
   DESTINATION_URL = ('https://clients2.google.com/factoryfactory/'
                      'uploads/quantum_upload/?json')
 
-  # pylint: disable=invalid-name,missing-docstring
-  class _MemStorage(oauth2client.client.Storage):
-    """Helper Storage class that keeps credentials in memory."""
-    def __init__(self):
-      self._lock = threading.Lock()
-      self._credentials = None
+  # These attributes control format of callback and what actions are undertaken
+  # when called.  These should either be set by a subclass or via configure.
 
-    def acquire_lock(self):
-      self._lock.acquire(True)
+  # _converter is a callable that can be set either via set_converter method
+  # or by defining a _converter @staticmethod on subclasses.
+  _converter = None
 
-    def release_lock(self):
-      self._lock.release()
+  # A default filename pattern can be specified on subclasses for use when
+  # saving to disk via save_to_disk.
+  _default_filename_pattern = None
 
-    def locked_get(self):
-      return self._credentials
-
-    def locked_put(self, credentials):
-      self._credentials = credentials
-  # pylint: enable=invalid-name,missing-docstring
-
-  def __init__(self, user, keydata,
+  def __init__(self, user=None, keydata=None,
                token_uri=TOKEN_URI, destination_url=DESTINATION_URL):
     self.user = user
     self.keydata = keydata
     self.token_uri = token_uri
     self.destination_url = destination_url
-    self.credentials = oauth2client.client.SignedJwtAssertionCredentials(
-        service_account_name=self.user,
-        private_key=self.keydata,
-        scope=self.SCOPE_CODE_URI,
-        user_agent='OpenHTF Guzzle Upload Client',
-        token_uri=self.token_uri)
-    self.credentials.set_store(self._MemStorage())
+
+    if user and keydata:
+      self.credentials = oauth2client.client.SignedJwtAssertionCredentials(
+          service_account_name=self.user,
+          private_key=self.keydata,
+          scope=self.SCOPE_CODE_URI,
+          user_agent='OpenHTF Guzzle Upload Client',
+          token_uri=self.token_uri)
+      self.credentials.set_store(_MemStorage())
+    else:
+      self.credentials = None
+
+    self.upload_result = None
+
+    self._cached_proto = None
 
   @classmethod
   def from_json(cls, json_data):
@@ -435,78 +163,97 @@ class UploadToMfgInspector(object):
 
     Args:
       json_data: Dict containing the loaded JSON key data.
+
+    Returns:
+      a MfgInspectorCallback with credentials.
     """
     return cls(user=json_data['client_email'],
                keydata=json_data['private_key'],
                token_uri=json_data['token_uri'])
 
-  def upload_test_run(self, testrun):
-    """Uploads the TestRun at a particular file.
+  def _convert(self, test_record_obj):
+    """Convert and cache a test record to a mfg-inspector proto."""
+
+    if self._cached_proto is None:
+      self._cached_proto = self._converter(test_record_obj)
+
+    return self._cached_proto
+
+  def save_to_disk(self, filename_pattern=None):
+    """Returns a callback to convert test record to proto and save to disk."""
+    if not self._converter:
+      raise RuntimeError(
+          'Must set _converter on subclass or via set_converter before calling '
+          'save_to_disk.')
+
+    pattern = filename_pattern or self._default_filename_pattern
+    if not pattern:
+      raise RuntimeError(
+          'Must specify provide a filename_pattern or set a '
+          '_default_filename_pattern on subclass.')
+
+    def save_to_disk_callback(test_record_obj):
+      proto = self._convert(test_record_obj)
+      output_to_file = callbacks.OutputToFile(pattern)
+
+      with output_to_file.open_output_file(test_record_obj) as outfile:
+        outfile.write(proto.SerializeToString())
+
+    return save_to_disk_callback
+
+  def upload(self):
+    """Returns a callback to convert a test record to a proto and upload."""
+    if not self._converter:
+      raise RuntimeError(
+          'Must set _converter on subclass or via set_converter before calling '
+          'upload.')
+
+    if not self.credentials:
+      raise RuntimeError('Must provide credentials to use upload callback.')
+
+    def upload_callback(test_record_obj):
+      proto = self._convert(test_record_obj)
+      self.upload_result = send_mfg_inspector_data(
+          proto, self.credentials, self.destination_url)
+
+    return upload_callback
+
+  def set_converter(self, converter):
+    """Set converter callable to convert a OpenHTF tester_record to a proto.
 
     Args:
-      testrun: TestRun proto or filepath.
+      converter: a callable that accepts an OpenHTF TestRecord and returns a
+        manufacturing-inspector compatible protobuf.
+
+    Returns:
+      self to make this call chainable.
     """
-    http = httplib2.Http()
-    if self.credentials.access_token_expired:
-      self.credentials.refresh(http)
-    self.credentials.authorize(http)
+    assert callable(converter), 'Converter must be callable.'
 
-    if isinstance(testrun, test_runs_pb2.TestRun):
-      serialized_run = testrun.SerializeToString()
-    elif os.path.isfile(testrun):
-      with open(testrun, 'rb') as testrun_file:
-        serialized_run = testrun_file.read()
-    else:
-      InvalidTestRunError('Invalid test run data')
+    self._converter = converter
 
-    test_run_envelope = guzzle_pb2.TestRunEnvelope()
-    test_run_envelope.payload = zlib.compress(serialized_run)
-    test_run_envelope.payload_type = guzzle_pb2.COMPRESSED_TEST_RUN
-    serialized_envelope = test_run_envelope.SerializeToString()
-
-    resp, content = http.request(self.destination_url, 'POST',
-                                 serialized_envelope)
-    if resp.status != 200:
-      try:
-        results = json.loads(content)
-      except Exception:
-        raise UploadFailedError(resp, content)
-      else:
-        raise UploadFailedError(results['error'], results)
-
-    result = json.loads(content)
-    return result['key']
-
-  def __call__(self, test_record_obj):  # pylint: disable=invalid-name
-
-    testrun = _test_run_from_test_record(test_record_obj)
-    self.upload_test_run(testrun)
+    return self
 
 
-class UploadOrOutput(object):
-  """Attempt to upload to inspector, output to local if fail.
+# LEGACY / DEPRECATED
+class UploadToMfgInspector(MfgInspector):
+  """Generate a mfg-inspector TestRun proto and upload it.
 
-  Args:
-    user: Google cloud service account for Oauth2client.
-    keydata: Google cloud key data for Oauth2client.
-    filename_pattern: A format string specifying the filename to write to,
-      will be formatted with the Test Record as a dictionary.  May also be a
-      file-like object to write directly to.
-    upload_fail_message: Message to log on upload failure.
+  LEGACY / DEPRECATED
+  This class is provided only for legacy reasons and may be deleted in future.
+  Please replace usage by configuring a MfgInspectorCallback directly. For
+  example:
+  test.add_output_callbacks(
+    mfg_inspector.MfgInspectorCallback.from_json(**json_data).set_converter(
+      test_runs_converter.test_run_from_test_record).upload()
+  )
   """
 
-  def __init__(self, user, keydata, filename_pattern,
-               upload_fail_message='Upload to mfg-inspector failed!'):
-    self._upload_fail_message = upload_fail_message
-    self._UploadToMfgInspector = UploadToMfgInspector(user, keydata)
-    self._OutputToTestRunProto = OutputToTestRunProto(filename_pattern)
+  @staticmethod
+  def _converter(test_record_obj):
+    return test_runs_converter.test_run_from_test_record(test_record_obj)
 
   def __call__(self, test_record_obj):  # pylint: disable=invalid-name
-    try:
-      logging.info('Attempting to upload to mfg-inspector')
-      return self._UploadToMfgInspector(test_record_obj)
-    except Exception:
-      logging.warning('%s', self._upload_fail_message)
-      filename = self._OutputToTestRunProto(test_record_obj)
-      logging.info('Saved local file: %s', filename)
-      raise
+    upload_callback = self.upload()
+    upload_callback(test_record_obj)
+

--- a/openhtf/output/proto/test_runs_converter.py
+++ b/openhtf/output/proto/test_runs_converter.py
@@ -1,0 +1,347 @@
+"""Utils to convert OpenHTF TestRecord to test_runs_pb2 proto.
+
+MULTIDIM_JSON schema:
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Multi-dimensional test parameter",
+  "type": "object",
+  "properties": {
+    "outcome": {"enum": ["PASS", "FAIL", "ERROR"]},
+    "name": {"type": "string"},
+    "dimensions": {
+      "type": array,
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "uom_code": {"type": "string"},
+          "uom_suffix": {"type": "string"}
+        }
+      }
+    },
+    "values": {
+      "type": "array",
+      "items": {}
+    }
+  }
+}
+"""
+
+import json
+import logging
+import numbers
+
+from openhtf.core import measurements
+from openhtf.core import test_record
+from openhtf.output.callbacks import json_factory
+from openhtf.util import validators
+
+from openhtf.output.proto import test_runs_pb2
+
+try:
+  from past.types import unicode  # pylint: disable=redefined-builtin,g-import-not-at-top
+except ImportError:
+  pass
+
+import six  # pylint: disable=g-import-not-at-top,g-bad-import-order
+
+
+# pylint: disable=no-member
+MIMETYPE_MAP = {
+    'image/jpeg': test_runs_pb2.JPG,
+    'image/png': test_runs_pb2.PNG,
+    'audio/x-wav': test_runs_pb2.WAV,
+    'text/plain': test_runs_pb2.TEXT_UTF8,
+    'image/tiff': test_runs_pb2.TIFF,
+    'video/mp4': test_runs_pb2.MP4,
+}
+OUTCOME_MAP = {
+    test_record.Outcome.ERROR: test_runs_pb2.ERROR,
+    test_record.Outcome.FAIL: test_runs_pb2.FAIL,
+    test_record.Outcome.PASS: test_runs_pb2.PASS,
+    test_record.Outcome.TIMEOUT: test_runs_pb2.ERROR,
+    test_record.Outcome.ABORTED: test_runs_pb2.ERROR,
+}
+
+UOM_CODE_MAP = {
+    u.GetOptions().Extensions[
+        test_runs_pb2.uom_code]: num
+    for num, u in six.iteritems(
+        test_runs_pb2.Units.UnitCode.DESCRIPTOR.values_by_number)
+}
+# pylint: enable=no-member
+
+# Control how many flattened parameters we'll output per multidimensional
+# measurement.
+MAX_PARAMS_PER_MEASUREMENT = 100
+
+
+# pylint: disable=invalid-name
+def _populate_header(record, testrun):
+  """Populate header-like info in testrun from record.
+
+  Mostly obvious, some stuff comes from metadata, see docstring of
+  _test_run_from_test_record for details.
+
+  Args:
+    record: the OpenHTF TestRecord being converted
+    testrun: a TestRun proto
+  """
+  testrun.dut_serial = record.dut_id
+  testrun.tester_name = record.station_id
+  if 'test_name' in record.metadata:
+    testrun.test_info.name = record.metadata['test_name']
+  else:
+    # Default to copying tester_name into test_info.name.
+    testrun.test_info.name = record.station_id
+  if 'test_description' in record.metadata:
+    testrun.test_info.description = record.metadata['test_description']
+  if 'test_version' in record.metadata:
+    testrun.test_info.version_string = record.metadata['test_version']
+  testrun.test_status = OUTCOME_MAP[record.outcome]
+  testrun.start_time_millis = record.start_time_millis
+  testrun.end_time_millis = record.end_time_millis
+  if 'run_name' in record.metadata:
+    testrun.run_name = record.metadata['run_name']
+  for details in record.outcome_details:
+    testrun_code = testrun.failure_codes.add()
+    testrun_code.code = details.code
+    testrun_code.details = details.description
+  for phase in record.phases:
+    testrun_phase = testrun.phases.add()
+    testrun_phase.name = phase.name
+    testrun_phase.description = phase.codeinfo.sourcecode
+    testrun_phase.timing.start_time_millis = phase.start_time_millis
+    testrun_phase.timing.end_time_millis = phase.end_time_millis
+  if 'config' in record.metadata:
+    attachment = testrun.info_parameters.add()
+    attachment.name = 'config'
+    attachment.value_binary = json.dumps(
+        record.metadata['config'], sort_keys=True, indent=4).encode('utf-8')
+
+
+def _ensure_unique_parameter_name(name, used_parameter_names):
+  while name in used_parameter_names:
+    name += '_'  # Hack to avoid collisions between phases.
+  used_parameter_names.add(name)
+  return name
+
+
+def _attach_json(record, testrun):
+  """Attach a copy of the JSON-ified record as an info parameter.
+
+  Save a copy of the JSON-ified record in an attachment so we can access
+  un-mangled fields later if we want.  Remove attachments since those get
+  copied over and can potentially be quite large.
+
+  Args:
+    record: the OpenHTF TestRecord being converted
+    testrun: a TestRun proto
+  """
+  record_json = json_factory.OutputToJSON(
+      inline_attachments=False,
+      sort_keys=True, indent=2).serialize_test_record(record)
+  testrun_param = testrun.info_parameters.add()
+  testrun_param.name = 'OpenHTF_record.json'
+  testrun_param.value_binary = record_json.encode('utf-8')
+  # pylint: disable=no-member
+  testrun_param.type = test_runs_pb2.TEXT_UTF8
+  # pylint: enable=no-member
+
+
+def _extract_attachments(phase, testrun, used_parameter_names):
+  """Extract attachments, just copy them over."""
+  for name, attachment in sorted(six.iteritems(phase.attachments)):
+    attachment_data, mimetype = attachment
+    name = _ensure_unique_parameter_name(name, used_parameter_names)
+    testrun_param = testrun.info_parameters.add()
+    testrun_param.name = name
+    if isinstance(attachment_data, unicode):
+      attachment_data = attachment_data.encode('utf-8')
+    testrun_param.value_binary = attachment_data
+    if mimetype in MIMETYPE_MAP:
+      testrun_param.type = MIMETYPE_MAP[mimetype]
+    else:
+      # pylint: disable=no-member
+      testrun_param.type = test_runs_pb2.BINARY
+      # pylint: enable=no-member
+
+
+def _mangle_measurement(name, measured_value, measurement, mangled_parameters,
+                        attachment_name):  # pylint: disable=g-doc-args
+  """Flatten parameters for backwards compatibility, watch for collisions.
+
+  We generate these by doing some name mangling, using some sane limits for
+  very large multidimensional measurements.
+  """
+  for coord, val in list(measured_value.value_dict.items(
+      ))[:MAX_PARAMS_PER_MEASUREMENT]:
+    # Mangle names so they look like 'myparameter_Xsec_Ynm_ZHz'
+    mangled_name = '_'.join([name] + [
+        '%s%s' % (
+            dim_val,
+            dim_units.suffix if dim_units.suffix else '') for
+        dim_val, dim_units in zip(
+            coord, measurement.dimensions)])
+    while mangled_name in mangled_parameters:
+      logging.warning('Mangled name %s already in use', mangled_name)
+      mangled_name += '_'
+    mangled_param = test_runs_pb2.TestParameter()
+    mangled_param.name = mangled_name
+    mangled_param.associated_attachment = attachment_name
+    mangled_param.description = (
+        'Mangled parameter from measurement %s with dimensions %s' % (
+            name, tuple(d.suffix for d in measurement.dimensions)))
+
+    if isinstance(val, numbers.Number):
+      mangled_param.numeric_value = float(val)
+    else:
+      mangled_param.text_value = str(val)
+    # Check for validators we know how to translate.
+    for validator in measurement.validators:
+      mangled_param.description += '\nValidator: ' + str(validator)
+
+    if measurement.units and measurement.units.code in UOM_CODE_MAP:
+      mangled_param.unit_code = UOM_CODE_MAP[measurement.units.code]
+    mangled_parameters[mangled_name] = mangled_param
+
+
+def _extract_parameters(record, testrun, used_parameter_names):
+  """Extract parameters from phases."""
+  # Generate mangled parameters afterwards so we give real measurements priority
+  # getting names.
+  mangled_parameters = {}
+  for phase in record.phases:
+    _extract_attachments(phase, testrun, used_parameter_names)
+    for name, measurement in sorted(six.iteritems(phase.measurements)):
+      tr_name = _ensure_unique_parameter_name(name, used_parameter_names)
+      testrun_param = testrun.test_parameters.add()
+      testrun_param.name = tr_name
+      if measurement.docstring:
+        testrun_param.description = measurement.docstring
+      if measurement.units and measurement.units.code in UOM_CODE_MAP:
+        testrun_param.unit_code = UOM_CODE_MAP[measurement.units.code]
+
+      if measurement.outcome == measurements.Outcome.PASS:
+        testrun_param.status = test_runs_pb2.PASS
+      elif (not measurement.measured_value
+            or not measurement.measured_value.is_value_set):
+        testrun_param.status = test_runs_pb2.ERROR
+        continue
+      else:
+        testrun_param.status = test_runs_pb2.FAIL
+
+      value = None
+      if measurement.measured_value.is_value_set:
+        value = measurement.measured_value.value
+      else:
+        testrun_param.status = test_runs_pb2.ERROR
+      if measurement.dimensions is None:
+        # Just a plain ol' value.
+        if isinstance(value, numbers.Number):
+          testrun_param.numeric_value = float(value)
+        else:
+          testrun_param.text_value = str(value)
+        # Check for validators we know how to translate.
+        for validator in measurement.validators:
+          if isinstance(validator, validators.RangeValidatorBase):
+            if validator.minimum is not None:
+              testrun_param.numeric_minimum = float(validator.minimum)
+            if validator.maximum is not None:
+              testrun_param.numeric_maximum = float(validator.maximum)
+          elif isinstance(validator, validators.RegexMatcher):
+            testrun_param.expected_text = validator.regex
+          else:
+            testrun_param.description += '\nValidator: ' + str(validator)
+      else:
+        attachment = testrun.info_parameters.add()
+        attachment.name = 'multidim_%s' % name
+        dims = [{
+            'uom_suffix': d.suffix,
+            'uom_code': d.code}
+                for d in measurement.dimensions]
+        # Refer to the module docstring for the expected schema.
+        attachment.value_binary = json.dumps({
+            'outcome': str(testrun_param.status), 'name': name,
+            'dimensions': dims,
+            'value': value
+        }, sort_keys=True).encode('utf-8')
+        attachment.type = test_runs_pb2.MULTIDIM_JSON
+        _mangle_measurement(
+            name, measurement.measured_value, measurement, mangled_parameters,
+            attachment.name)
+      if testrun_param.status == test_runs_pb2.FAIL:
+        testrun_code = testrun.failure_codes.add()
+        testrun_code.code = testrun_param.name
+        if measurement.dimensions is None:
+          if isinstance(testrun_param.numeric_value, float):
+            testrun_code.details = str(testrun_param.numeric_value)
+          else:
+            testrun_code.details = testrun_param.text_value
+  return mangled_parameters
+
+
+def _add_mangled_parameters(testrun, mangled_parameters, used_parameter_names):
+  """Add any mangled parameters we generated from multidim measurements."""
+  for mangled_name, mangled_param in sorted(six.iteritems(mangled_parameters)):
+    if mangled_name != _ensure_unique_parameter_name(mangled_name,
+                                                     used_parameter_names):
+      logging.warning('Mangled name %s in use by non-mangled parameter',
+                      mangled_name)
+    testrun_param = testrun.test_parameters.add()
+    testrun_param.CopyFrom(mangled_param)
+
+
+def _add_log_lines(record, testrun):
+  """Copy log records over, this is a fairly straightforward mapping."""
+  for log in record.log_records:
+    testrun_log = testrun.test_logs.add()
+    testrun_log.timestamp_millis = log.timestamp_millis
+    testrun_log.log_message = log.message
+    testrun_log.logger_name = log.logger_name
+    testrun_log.levelno = log.level
+    # pylint: disable=no-member
+    if log.level <= logging.DEBUG:
+      testrun_log.level = test_runs_pb2.TestRunLogMessage.DEBUG
+    elif log.level <= logging.INFO:
+      testrun_log.level = test_runs_pb2.TestRunLogMessage.INFO
+    elif log.level <= logging.WARNING:
+      testrun_log.level = test_runs_pb2.TestRunLogMessage.WARNING
+    elif log.level <= logging.ERROR:
+      testrun_log.level = test_runs_pb2.TestRunLogMessage.ERROR
+    elif log.level <= logging.CRITICAL:
+      testrun_log.level = test_runs_pb2.TestRunLogMessage.CRITICAL
+    # pylint: enable=no-member
+    testrun_log.log_source = log.source
+    testrun_log.lineno = log.lineno
+
+
+def test_run_from_test_record(record):
+  """Create a TestRun proto from an OpenHTF TestRecord.
+
+  Most fields are just copied over, some are pulled out of metadata (listed
+  below), and measurements are munged a bit for backwards compatibility.
+
+  Metadata fields:
+    'test_description': TestInfo's description field.
+    'test_version': TestInfo's version_string field.
+    'test_name': TestInfo's name field.
+    'run_name': TestRun's run_name field.
+    'operator_name': TestRun's operator_name field.
+
+  Args:
+    record: the OpenHTF TestRecord being converted
+
+  Returns:
+    An instance of the TestRun proto for the given record.
+  """
+  testrun = test_runs_pb2.TestRun()
+  _populate_header(record, testrun)
+  _attach_json(record, testrun)
+
+  used_parameter_names = set(['OpenHTF_record.json'])
+  mangled_parameters = _extract_parameters(record, testrun,
+                                           used_parameter_names)
+  _add_mangled_parameters(testrun, mangled_parameters, used_parameter_names)
+  _add_log_lines(record, testrun)
+  return testrun

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -27,7 +27,7 @@ from openhtf import util
 from examples import all_the_things
 from openhtf.output.callbacks import console_summary
 from openhtf.output.callbacks import json_factory
-from openhtf.output.callbacks import mfg_inspector
+from openhtf.output.proto import test_runs_converter
 from openhtf.output.proto import test_runs_pb2
 from openhtf.util import test
 
@@ -64,7 +64,7 @@ class TestOutput(test.TestCase):
     user_mock.prompt.return_value = 'SomeWidget'
     record = yield self._test
 
-    test_run_proto = mfg_inspector._test_run_from_test_record(record)
+    test_run_proto = test_runs_converter.test_run_from_test_record(record)
 
     # Assert test status
     self.assertEqual(test_runs_pb2.FAIL, test_run_proto.test_status)
@@ -87,17 +87,9 @@ class TestOutput(test.TestCase):
     for parameter in test_run_proto.info_parameters:
       if parameter.name == attachment_name:
         self.assertEqual(
-          b'This is a text file attachment.\n',
-          parameter.value_binary,
+            b'This is a text file attachment.\n',
+            parameter.value_binary,
         )
-
-
-  @test.patch_plugs(user_mock='openhtf.plugs.user_input.UserInput')
-  def test_testrun(self, user_mock):
-    user_mock.prompt.return_value = 'SomeWidget'
-    record = yield self._test
-    testrun_output = io.BytesIO()
-    mfg_inspector.OutputToTestRunProto(testrun_output)(record)
 
 
 class TestConsoleSummary(test.TestCase):

--- a/test/output/callbacks/mfg_inspector_test.py
+++ b/test/output/callbacks/mfg_inspector_test.py
@@ -1,0 +1,130 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the openhtf.output.callbacks module.
+
+This test currently only provides line coverage, checking that the Python code
+is sane. It might be worth expanding the tests to also check for things we
+actually care for.
+"""
+
+import io
+import unittest
+
+import mock
+
+import openhtf as htf
+from openhtf import util
+from examples import all_the_things
+from openhtf.output.callbacks import mfg_inspector
+from openhtf.output.proto import test_runs_converter
+from openhtf.output.proto import test_runs_pb2
+from openhtf.util import test
+
+MOCK_TEST_RUN_PROTO = xtf_pb2.TestRun(
+    tester_name='mock_test_run',
+    dut_serial='UNITTEST1234',
+    test_status=test_runs_pb2.PASS,
+    test_info=xtf_pb2.TestInfo(name='unit_test')
+)
+
+
+class TestMfgInspector(test.TestCase):
+
+  def setUp(self):
+    self.mock_credentials = mock.patch(
+        'oauth2client.client.SignedJwtAssertionCredentials'
+        ).start().return_value
+
+    self.mock_send_mfg_inspector_data = mock.patch.object(
+        mfg_inspector, 'send_mfg_inspector_data').start()
+
+  def tearDown(self):
+    mock.patch.stopall()
+
+  @classmethod
+  def setUpClass(cls):
+    # Create input record.
+    result = util.NonLocalResult()
+    def _save_result(test_record):
+      result.result = test_record
+    cls._test = htf.Test(
+        all_the_things.hello_world,
+        all_the_things.dimensions,
+        all_the_things.attachments,
+    )
+    cls._test.add_output_callbacks(_save_result)
+    cls._test.make_uid = lambda: 'UNITTEST:MOCK:UID'
+
+  @test.patch_plugs(user_mock='openhtf.plugs.user_input.UserInput')
+  def test_save_only(self, user_mock):
+    user_mock.prompt.return_value = 'SomeWidget'
+    record = yield self._test
+
+    testrun_output = io.BytesIO()
+    callback = mfg_inspector.MfgInspector()
+
+    callback.set_converter(
+        converter=test_runs_converter.test_run_from_test_record,
+    )
+    save_to_disk_callback = callback.save_to_disk(
+        filename_pattern=testrun_output)
+    save_to_disk_callback(record)
+
+    # Parse what was written to BytesIO back into a proto and compare
+    testrun_output.seek(0)
+    testrun = xtf_pb2.TestRun()
+    testrun.ParseFromString(testrun_output.read())
+
+    expected_test_run_proto = test_runs_converter.test_run_from_test_record(
+        record)
+    self.assertEqual(expected_test_run_proto, testrun)
+
+    self.assertFalse(self.mock_send_mfg_inspector_data.called)
+
+  def test_upload_only(self):
+    mock_converter = mock.MagicMock(return_value=MOCK_TEST_RUN_PROTO)
+    callback = mfg_inspector.MfgInspector(
+        user='user', keydata='keydata', token_uri='').set_converter(
+            mock_converter)
+
+    callback.upload()({})
+
+    self.mock_send_mfg_inspector_data.assert_called_with(
+        MOCK_TEST_RUN_PROTO, self.mock_credentials, callback.destination_url)
+
+  def test_save_and_upload(self):
+    testrun_output = io.BytesIO()
+    mock_converter = mock.MagicMock(return_value=MOCK_TEST_RUN_PROTO)
+
+    callback = mfg_inspector.MfgInspector(
+        user='user', keydata='keydata', token_uri='')
+    callback.set_converter(mock_converter)
+
+    callback.save_to_disk(filename_pattern=testrun_output)({})
+    callback.upload()({})
+
+    # Parse what was written to BytesIO back into a proto and compare
+    testrun_output.seek(0)
+    testrun = xtf_pb2.TestRun()
+    testrun.ParseFromString(testrun_output.read())
+
+    self.assertEqual(MOCK_TEST_RUN_PROTO, testrun)
+
+    self.mock_send_mfg_inspector_data.assert_called_with(
+        MOCK_TEST_RUN_PROTO, self.mock_credentials, callback.destination_url)
+
+    # Make sure mock converter only called once i.e. the test record was
+    # was converted to a proto only once.  This important because some custom
+    # converters mutate the test record, so the converter is not idempotent.
+    self.assertEqual(1, mock_converter.call_count)


### PR DESCRIPTION
Primary change is to include a MfgInspectorCallback that can be configured to use a specific converter to convert a test_record to a mfg-inspector compatible protobuf.  The callback can also be configured to save the proto to disk and/or upload the proto to mfg-inspector.

Removed UploadOrOutput class, this functionality was un-used.

PiperOrigin-RevId: 227938986

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/847)
<!-- Reviewable:end -->
