### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/openhtf/output/callbacks/mfg_inspector.py
+++ b/openhtf/output/callbacks/mfg_inspector.py
@@ -55,7 +55,7 @@ def send_mfg_inspector_data(inspector_proto, credentials, destination_url):
   envelope.payload_type = guzzle_pb2.COMPRESSED_MFG_EVENT
   envelope_data = envelope.SerializeToString()
 
-  for _ in xrange(5):
+  for _ in range(5):
     try:
       result = _send_mfg_inspector_request(
           envelope_data, credentials, destination_url)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/850)
<!-- Reviewable:end -->
