### PR TITLE
all_the_things.py PASS by default, console_summary.py handle UNSET

### DIFF
--- a/openhtf/output/callbacks/console_summary.py
+++ b/openhtf/output/callbacks/console_summary.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from openhtf.core import test_record
-from openhtf.core import measurements as meas_module
+from openhtf.core import measurements
 import six
 
 
@@ -47,14 +47,14 @@ class ConsoleSummary():
         phase_time_sec = (float(phase.end_time_millis)
                           - float(phase.start_time_millis)) / 1000.0
         for name, measurement in six.iteritems(phase.measurements):
-          if measurement.outcome == meas_module.Outcome.FAIL:
+          if measurement.outcome != measurements.Outcome.PASS:
             if new_phase:
               output_lines.append('failed phase: %s [ran for %.2f sec]' %
                                   (phase.name, phase_time_sec))
               new_phase = False
 
-            output_lines.append('%sfailed_item: %s' %
-                                (self.indent, name))
+            output_lines.append('%sfailed_item: %s (%s)' %
+                                (self.indent, name, measurement.outcome))
             output_lines.append('%smeasured_value: %s' %
                                 (self.indent*2, measurement.measured_value))
             output_lines.append('%svalidators:' % (self.indent*2))

--- a/test/core/measurements_test.py
+++ b/test/core/measurements_test.py
@@ -97,7 +97,6 @@ class TestMeasurements(htf_test.TestCase):
   def test_chaining_in_measurement_declarations(self, user_mock):
     user_mock.prompt.return_value = 'mock_widget'
     record = yield all_the_things.hello_world
-    self.assertNotMeasured(record, 'unset_meas')
     self.assertMeasured(record, 'widget_type', 'mock_widget')
     self.assertMeasured(record, 'widget_color', 'Black')
     self.assertMeasurementPass(record, 'widget_size')
@@ -106,7 +105,6 @@ class TestMeasurements(htf_test.TestCase):
   @htf_test.yields_phases
   def test_measurements_with_dimensions(self):
     record = yield all_the_things.dimensions
-    self.assertNotMeasured(record, 'unset_dims')
     self.assertMeasured(record, 'dimensions',
                         [(0, 1), (1, 2), (2, 4), (3, 8), (4, 16)])
     self.assertMeasured(record, 'lots_of_dims',
@@ -132,7 +130,7 @@ class TestMeasurements(htf_test.TestCase):
   def test_measurement_order(self):
     record = yield all_the_things.dimensions
     self.assertEqual(list(record.measurements.keys()),
-                     ['unset_dims', 'dimensions', 'lots_of_dims'])
+                     ['dimensions', 'lots_of_dims'])
     record = yield all_the_things.measures_with_args.with_args(min=2, max=4)
     self.assertEqual(list(record.measurements.keys()),
                      ['replaced_min_only', 'replaced_max_only',

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -67,7 +67,7 @@ class TestOutput(test.TestCase):
     test_run_proto = test_runs_converter.test_run_from_test_record(record)
 
     # Assert test status
-    self.assertEqual(test_runs_pb2.FAIL, test_run_proto.test_status)
+    self.assertEqual(test_runs_pb2.PASS, test_run_proto.test_status)
 
     # Verify all expected phases included.
     expected_phase_names = [


### PR DESCRIPTION
Make all_the_things.py PASS by default.

Make console_summary do a better job of handling UNSET dimensions (previously did not print out this as reason for test failure).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/851)
<!-- Reviewable:end -->
