### PR TITLE
feat: add junit output callback

### DIFF
--- a/openhtf/output/callbacks/junit.py
+++ b/openhtf/output/callbacks/junit.py
@@ -1,0 +1,83 @@
+"""Module for outputting test record to JUNIT-formatted files."""
+
+import base64
+from junit_xml import TestSuite, TestCase
+
+from openhtf.output import callbacks
+from openhtf.util import data
+import six
+
+
+class OutputToJUNIT(callbacks.OutputToFile):
+  """Return an output callback that writes JSON Test Records.
+  Example filename_patterns might be:
+    '/data/test_records/{dut_id}.{metadata[test_name]}.json', indent=4)) or
+    '/data/test_records/%(dut_id)s.%(start_time_millis)s'
+  To use this output mechanism:
+    test = openhtf.Test(PhaseOne, PhaseTwo)
+    test.add_output_callback(openhtf.output.callbacks.OutputToJson(
+        '/data/test_records/{dut_id}.{metadata[test_name]}.json'))
+
+  Args:
+    filename_pattern: A format string specifying the filename to write to,
+      will be formatted with the Test Record as a dictionary.  May also be a
+      file-like object to write to directly.
+    inline_attachments: Whether attachments should be included inline in the
+      output. Set to False if you expect to have large binary attachments. If
+      True (the default), then attachments are base64 encoded to allow for
+      binary data that's not supported by JSON directly.
+  """
+
+  def __init__(self, filename_pattern=None, inline_attachments=True, **kwargs):
+    super(OutputToJUNIT, self).__init__(filename_pattern)
+    self.inline_attachments = inline_attachments
+
+    # Conform strictly to the JSON spec by default.
+    kwargs.setdefault('allow_nan', False)
+    self.allow_nan = kwargs['allow_nan']
+    self.test_cases = []
+
+  def serialize_test_record(self, test_record):
+    dict_test_record = self.convert_to_dict(test_record)
+
+    for phase in dict_test_record["phases"]:
+      output = []
+      for _, phase_data in phase["measurements"].items():
+
+        output.extend(["name: " + phase_data["name"],
+                       "validators: " + str(phase_data["validators"]),
+                       "measured_value: " + str(phase_data["measured_value"]),
+                       "outcome: " + phase_data["outcome"], "\n"])
+
+      if phase["outcome"] == "PASS":
+        self.test_cases.append(
+            TestCase(phase["name"],
+                     dict_test_record["dut_id"] + "." +
+                     dict_test_record["metadata"]["test_name"],
+                     (phase["end_time_millis"] -
+                      phase["start_time_millis"]) * 1000,
+                     "\n".join(output),
+                     ''))
+      else:
+        self.test_cases.append(
+            TestCase(phase["name"],
+                     dict_test_record["dut_id"] + "." +
+                     dict_test_record["metadata"]["test_name"],
+                     (phase["end_time_millis"] -
+                      phase["start_time_millis"]) * 1000,
+                     "\n".join(output),
+                     ''))
+
+    return TestSuite.to_xml_string([TestSuite("Test", self.test_cases)])
+
+  def convert_to_dict(self, test_record):
+    as_dict = data.convert_to_base_types(test_record,
+                                         json_safe=(not self.allow_nan))
+
+    if self.inline_attachments:
+      for phase, original_phase in zip(as_dict['phases'], test_record.phases):
+        for name, attachment in six.iteritems(phase['attachments']):
+          original_data = original_phase.attachments[name].data
+          attachment['data'] = base64.standard_b64encode(
+              original_data).decode('utf-8')
+    return as_dict

--- a/openhtf/output/callbacks/junit.py
+++ b/openhtf/output/callbacks/junit.py
@@ -1,22 +1,22 @@
 """Module for outputting test record to JUNIT-formatted files."""
 
 import base64
+import six
 from junit_xml import TestSuite, TestCase
 
 from openhtf.output import callbacks
 from openhtf.util import data
-import six
 
 
 class OutputToJUNIT(callbacks.OutputToFile):
-  """Return an output callback that writes JSON Test Records.
+  """Return an output callback that writes JUNIT Test Records.
   Example filename_patterns might be:
-    '/data/test_records/{dut_id}.{metadata[test_name]}.json', indent=4)) or
+    '/data/test_records/{dut_id}.{metadata[test_name]}.xml', indent=4)) or
     '/data/test_records/%(dut_id)s.%(start_time_millis)s'
   To use this output mechanism:
     test = openhtf.Test(PhaseOne, PhaseTwo)
-    test.add_output_callback(openhtf.output.callbacks.OutputToJson(
-        '/data/test_records/{dut_id}.{metadata[test_name]}.json'))
+    test.add_output_callback(openhtf.output.callbacks.OutputToJUNIT(
+        '/data/test_records/{dut_id}.{metadata[test_name]}.xml'))
 
   Args:
     filename_pattern: A format string specifying the filename to write to,
@@ -25,16 +25,11 @@ class OutputToJUNIT(callbacks.OutputToFile):
     inline_attachments: Whether attachments should be included inline in the
       output. Set to False if you expect to have large binary attachments. If
       True (the default), then attachments are base64 encoded to allow for
-      binary data that's not supported by JSON directly.
+      binary data that's not supported by JUNIT directly.
   """
 
-  def __init__(self, filename_pattern=None, inline_attachments=True, **kwargs):
+  def __init__(self, filename_pattern=None, **kwargs):
     super(OutputToJUNIT, self).__init__(filename_pattern)
-    self.inline_attachments = inline_attachments
-
-    # Conform strictly to the JSON spec by default.
-    kwargs.setdefault('allow_nan', False)
-    self.allow_nan = kwargs['allow_nan']
     self.test_cases = []
 
   def serialize_test_record(self, test_record):
@@ -55,7 +50,7 @@ class OutputToJUNIT(callbacks.OutputToFile):
                      dict_test_record["dut_id"] + "." +
                      dict_test_record["metadata"]["test_name"],
                      (phase["end_time_millis"] -
-                      phase["start_time_millis"]) * 1000,
+                      phase["start_time_millis"]) / 1000,
                      "\n".join(output),
                      ''))
       else:
@@ -64,20 +59,18 @@ class OutputToJUNIT(callbacks.OutputToFile):
                      dict_test_record["dut_id"] + "." +
                      dict_test_record["metadata"]["test_name"],
                      (phase["end_time_millis"] -
-                      phase["start_time_millis"]) * 1000,
+                      phase["start_time_millis"]) / 1000,
                      "\n".join(output),
                      ''))
 
-    return TestSuite.to_xml_string([TestSuite("Test", self.test_cases)])
+    return TestSuite.to_xml_string([TestSuite("test", self.test_cases)])
 
   def convert_to_dict(self, test_record):
-    as_dict = data.convert_to_base_types(test_record,
-                                         json_safe=(not self.allow_nan))
+    as_dict = data.convert_to_base_types(test_record)
 
-    if self.inline_attachments:
-      for phase, original_phase in zip(as_dict['phases'], test_record.phases):
-        for name, attachment in six.iteritems(phase['attachments']):
-          original_data = original_phase.attachments[name].data
-          attachment['data'] = base64.standard_b64encode(
-              original_data).decode('utf-8')
+    for phase, original_phase in zip(as_dict['phases'], test_record.phases):
+      for name, attachment in six.iteritems(phase['attachments']):
+        original_data = original_phase.attachments[name].data
+        attachment['data'] = base64.standard_b64encode(
+            original_data).decode('utf-8')
     return as_dict


### PR DESCRIPTION
# What I did
I added a callback to get JUNIT files as an output.

# Why I did it
In CI context, Jenkins uses JUNIT files to record tests. I have based my work on the JSON factory example.

# XML example
```
<?xml version="1.0" ?>
<testsuites disabled="0" errors="0" failures="0" tests="6" time="14.463">
  <testsuite disabled="0" errors="0" failures="0" name="test" skipped="0" tests="6" time="14.463">
    <testcase classname="single_node_chain.io" name="trigger_phase" time="0.002000"/>
    <testcase classname="single_node_chain.io" name="test_digital_input" time="3.017000">
      <system-out>name: input_4
validators: ['x == 0']
measured_value: 0
outcome: PASS


name: input_2
validators: ['x == 0']
measured_value: 0
outcome: PASS


name: input_3
validators: ['x == 1']
measured_value: 1
outcome: PASS


name: input_1
validators: ['x == 1']
measured_value: 1
outcome: PASS

</system-out>
    </testcase>
    <testcase classname="single_node_chain.io" name="test_analog_single_ended_input" time="2.864000">
      <system-out>name: voltage_2
validators: ['1.44 &lt;= x &lt;= 1.7600000000000002']
measured_value: 1.6173095703125
outcome: PASS


name: voltage_0
validators: ['-0.05 &lt;= x &lt;= 0.05']
measured_value: 0.0018310546875
outcome: PASS


name: voltage_3
validators: ['2.25 &lt;= x &lt;= 2.75']
measured_value: 2.527099609375
outcome: PASS


name: voltage_5
validators: ['3.6899999999999995 &lt;= x &lt;= 4.51']
measured_value: 4.1453857421875
outcome: PASS


name: voltage_1
validators: ['0.72 &lt;= x &lt;= 0.8800000000000001']
measured_value: 0.80908203125
outcome: PASS


name: voltage_4
validators: ['2.9699999999999998 &lt;= x &lt;= 3.63']
measured_value: 3.33642578125
outcome: PASS

</system-out>
    </testcase>
  </testsuite>
</testsuites>
```

This is then read by Jenkins properly, I used Test results analyzer as an example:
![screenshot_20190116_170407](https://user-images.githubusercontent.com/1220912/51261544-bd288a80-19b0-11e9-8be7-05fb52357145.png)

