### PR TITLE
Replace /deep/ and >>> with ::ng-deep

### DIFF
--- a/openhtf/output/web_gui/src/app/plugs/user-input-plug.component.scss
+++ b/openhtf/output/web_gui/src/app/plugs/user-input-plug.component.scss
@@ -1,8 +1,8 @@
 @import 'vars';
 
 // Styling for lists injected into the prompt.
-:host /deep/ ol,
-:host /deep/ ul {
+:host ::ng-deep ol,
+:host ::ng-deep ul {
   padding-left: 25px;
   margin: 0;
 }

--- a/openhtf/output/web_gui/src/app/stations/station/test-summary.component.scss
+++ b/openhtf/output/web_gui/src/app/stations/station/test-summary.component.scss
@@ -23,7 +23,7 @@ htf-progress-bar {
   padding: 0;
 }
 
-:host /deep/ htf-phase .phase-name {
+:host ::ng-deep htf-phase .phase-name {
   font-weight: bold;
 
   &::before {


### PR DESCRIPTION
PiperOrigin-RevId: 230618529
The /deep/ and >>> combinators are no longer supported in stylesheets according to the CSS spec. Replacing them will allow new versions of Sass that match the most recent spec to be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/856)
<!-- Reviewable:end -->
