### PR TITLE
Improve clean up code after running a Test

### DIFF
--- a/openhtf/core/monitors.py
+++ b/openhtf/core/monitors.py
@@ -148,5 +148,6 @@ def monitors(measurement_name, monitor_func, units=None, poll_interval_ms=1000):
         return phase_desc(test_state, *args, **kwargs)
       finally:
         monitor_thread.kill()
+        monitor_thread.join()
     return monitored_phase_func
   return wrapper

--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -349,6 +349,7 @@ class Test(object):
               rst=colorama.Style.RESET_ALL))
       finally:
         del self.TEST_INSTANCES[self.uid]
+        self._executor.close()
         self._executor = None
 
     return final_state.test_record.outcome == test_record.Outcome.PASS

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -68,6 +68,7 @@ class TestExecutor(threads.KillableThread):
     This function is defined instead of a __del__ function because Python calls
     the __del__ function unreliably.
     """
+    self.wait()
     self.test_state.close()
 
   def abort(self):

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -60,6 +60,16 @@ class TestExecutor(threads.KillableThread):
     self._full_abort = threading.Event()
     self._teardown_phases_lock = threading.Lock()
 
+  def close(self):
+    """Close and remove any global registrations.
+
+    Always call this function when finished with this instance.
+
+    This function is defined instead of a __del__ function because Python calls
+    the __del__ function unreliably.
+    """
+    self.test_state.close()
+
   def abort(self):
     """Abort this test."""
     if self._abort.is_set():

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -150,7 +150,15 @@ class TestState(util.SubscribableStateMixin):
     self.execution_uid = execution_uid
     self.test_options = test_options
 
-  def __del__(self):
+  def close(self):
+    """Close and remove any global registrations.
+
+    Always call this function when finished with this instance as it ensures
+    that it can be garbage collected.
+
+    This function is defined instead of a __del__ function because Python calls
+    the __del__ function unreliably.
+    """
     logs.remove_record_handler(self.execution_uid)
 
   @property

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -161,11 +161,15 @@ class UserInput(plugs.FrontendAwareBasePlug):
               'message': self._prompt.message,
               'text-input': self._prompt.text_input}
 
+  def tearDown(self):
+    self.remove_prompt()
+
   def remove_prompt(self):
     """Remove the prompt."""
     self._prompt = None
-    self._console_prompt.Stop()
-    self._console_prompt = None
+    if self._console_prompt:
+      self._console_prompt.Stop()
+      self._console_prompt = None
     self.notify_update()
 
   def prompt(self, message, text_input=False, timeout_s=None, cli_color=''):

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -298,6 +298,7 @@ class TestExecutorTest(unittest.TestCase):
     self.assertLessEqual(record.end_time_millis, util.time_millis())
     # Teardown function should be executed.
     self.assertTrue(ev.wait(1))
+    executor.close()
 
   def test_cancel_twice_phase(self):
 
@@ -346,6 +347,7 @@ class TestExecutorTest(unittest.TestCase):
     # Teardown function should *NOT* be executed.
     self.assertFalse(ev.is_set())
     self.assertFalse(ev2.is_set())
+    executor.close()
 
   def test_failure_during_plug_init(self):
     ev = threading.Event()
@@ -368,6 +370,7 @@ class TestExecutorTest(unittest.TestCase):
     self.assertEqual(record.outcome_details[0].description, FAIL_PLUG_MESSAGE)
     # Teardown function should *NOT* be executed.
     self.assertFalse(ev.is_set())
+    executor.close()
 
   def test_failure_during_start_phase_plug_init(self):
     def never_gonna_run_phase():
@@ -417,6 +420,7 @@ class TestExecutorTest(unittest.TestCase):
     record = executor.test_state.test_record
     self.assertEqual(record.outcome, Outcome.ERROR)
     self.assertEqual(record.outcome_details[0].code, TeardownError.__name__)
+    executor.close()
 
   def test_log_during_teardown(self):
     message = 'hello'
@@ -441,6 +445,7 @@ class TestExecutorTest(unittest.TestCase):
     log_records = [log_record for log_record in record.log_records
                    if log_record.message == message]
     self.assertTrue(log_records)
+    executor.close()
 
 
 class TestExecutorHandlePhaseTest(unittest.TestCase):

--- a/test/plugs/user_input_test.py
+++ b/test/plugs/user_input_test.py
@@ -22,7 +22,11 @@ from openhtf.plugs import user_input
 class PlugsTest(unittest.TestCase):
 
   def setUp(self):
+    super(PlugsTest, self).setUp()
     self.plug = user_input.UserInput()
+
+  def tearDown(self):
+    self.plug.tearDown()
 
   def test_respond_to_blocking_prompt(self):
     def _respond_to_prompt():


### PR DESCRIPTION
Improve clean up code after running a Test by not relying on the `__del__` function being called.  Instead, rename to `cleanup` and call it explicitly when needed.

Also made cleanup more explicit for unit  tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/861)
<!-- Reviewable:end -->
