### PR TITLE
Use custom logger subclass for test records.

### DIFF
--- a/openhtf/core/monitors.py
+++ b/openhtf/core/monitors.py
@@ -112,7 +112,7 @@ class _MonitorThread(threads.KillableThread):
                    (mean_sample_ms / 1000.0))
         continue
       elif new_sample > last_sample + 2:
-        self.test_state.logger.warning(
+        self.test_state.state_logger.warning(
             'Monitor for "%s" skipping %s sample(s).', self.measurement_name,
             new_sample - last_sample - 1)
       last_sample, cur_sample_ms = _take_sample()

--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -162,7 +162,7 @@ class PhaseExecutorThread(threads.KillableThread):
 
   def _log_exception(self, *args):
     """Log exception, while allowing unit testing to override."""
-    self._test_state.logger.critical(*args)
+    self._test_state.state_logger.critical(*args)
 
   def _thread_exception(self, *args):
     self._phase_execution_outcome = PhaseExecutionOutcome(ExceptionInfo(*args))

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -220,7 +220,7 @@ class TestExecutor(threads.KillableThread):
 
     # Now finalize the test state.
     if self._abort.is_set():
-      self.test_state.logger.debug('Finishing test with outcome ABORTED.')
+      self.test_state.state_logger.debug('Finishing test with outcome ABORTED.')
       self.test_state.abort()
     elif self._last_outcome and self._last_outcome.is_terminal:
       self.test_state.finalize_from_phase_outcome(self._last_outcome)
@@ -231,7 +231,7 @@ class TestExecutor(threads.KillableThread):
     if isinstance(phase, phase_group.PhaseGroup):
       return self._execute_phase_group(phase)
 
-    self.test_state.logger.debug('Handling phase %s', phase.name)
+    self.test_state.state_logger.debug('Handling phase %s', phase.name)
     outcome = self._phase_exec.execute_phase(phase)
     if outcome.is_terminal and not self._last_outcome:
       self._last_outcome = outcome
@@ -251,7 +251,7 @@ class TestExecutor(threads.KillableThread):
       True if there is a terminal error or the test is aborted, False otherwise.
     """
     if group_name and phases:
-      self.test_state.logger.debug(
+      self.test_state.state_logger.debug(
           'Executing %s phases for %s', type_name, group_name)
     for phase in phases:
       if self._abort.is_set() or self._handle_phase(phase):
@@ -270,8 +270,8 @@ class TestExecutor(threads.KillableThread):
       True if there is at least one terminal error, False otherwise.
     """
     if group_name and teardown_phases:
-      self.test_state.logger.debug('Executing teardown phases for %s',
-                                   group_name)
+      self.test_state.state_logger.debug('Executing teardown phases for %s',
+                                         group_name)
     ret = False
     with self._teardown_phases_lock:
       for teardown_phase in teardown_phases:
@@ -299,7 +299,7 @@ class TestExecutor(threads.KillableThread):
       True if the phases are terminal; otherwise returns False.
     """
     if group.name:
-      self.test_state.logger.debug('Entering PhaseGroup %s', group.name)
+      self.test_state.state_logger.debug('Entering PhaseGroup %s', group.name)
     if self._execute_abortable_phases(
         'setup', group.setup, group.name):
       return True

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -117,8 +117,7 @@ class TestState(util.SubscribableStateMixin):
 
   Attributes:
     test_record: TestRecord instance for the currently running test.
-    logger: Logger that logs to test_record's log_records attribute. May be
-        overridden with more specific (phase) loggers during execution.
+    state_logger: Logger that logs to test_record's log_records attribute.
     running_phase_state: PhaseState object for the currently running phase,
         if any, otherwise None.
     user_defined_state: Dictionary for users to persist state across phase
@@ -142,9 +141,9 @@ class TestState(util.SubscribableStateMixin):
         metadata=copy.deepcopy(test_desc.metadata))
     logs.initialize_record_handler(
         execution_uid, self.test_record, self.notify_update)
-    self.logger = logs.get_record_logger_for(execution_uid)
+    self.state_logger = logs.get_record_logger_for(execution_uid)
     self.plug_manager = plugs.PlugManager(
-        test_desc.plug_types, self.logger.name)
+        test_desc.plug_types, self.state_logger)
     self.running_phase_state = None
     self.user_defined_state = {}
     self.execution_uid = execution_uid
@@ -160,6 +159,14 @@ class TestState(util.SubscribableStateMixin):
     the __del__ function unreliably.
     """
     logs.remove_record_handler(self.execution_uid)
+
+  @property
+  def logger(self):
+    if self.running_phase_state:
+      return self.running_phase_state.logger
+    raise RuntimeError(
+        'Calling `logger` attribute while phase not running; use state_logger '
+        'instead.')
 
   @property
   def test_api(self):
@@ -207,7 +214,7 @@ class TestState(util.SubscribableStateMixin):
         attachment = phase_record.attachments[attachment_name]
         return copy.deepcopy(attachment)
 
-    self.logger.warning('Could not find attachment: %s', attachment_name)
+    self.state_logger.warning('Could not find attachment: %s', attachment_name)
     return None
 
   def get_measurement(self, measurement_name):
@@ -238,7 +245,8 @@ class TestState(util.SubscribableStateMixin):
         measurement = phase_record.measurements[measurement_name]
         return ImmutableMeasurement.FromMeasurement(measurement)
 
-    self.logger.warning('Could not find measurement: %s', measurement_name)
+    self.state_logger.warning(
+        'Could not find measurement: %s', measurement_name)
     return None
 
   @contextlib.contextmanager
@@ -259,8 +267,9 @@ class TestState(util.SubscribableStateMixin):
       PhaseState to track transient state.
     """
     assert not self.running_phase_state, 'Phase already running!'
+    phase_logger = self.state_logger.getChild('phase.' + phase_desc.name)
     phase_state = self.running_phase_state = PhaseState.from_descriptor(
-        phase_desc, self.notify_update)
+        phase_desc, self.notify_update, logger=phase_logger)
     try:
       with phase_state.record_timing_context:
         self.notify_update()  # New phase started.
@@ -344,15 +353,16 @@ class TestState(util.SubscribableStateMixin):
         description = str(phase_execution_outcome.phase_result)
       self.test_record.add_outcome_details(code, description)
       if self._outcome_is_failure_exception(phase_execution_outcome):
-        self.logger.error('Outcome will be FAIL since exception was of type %s'
-                          % phase_execution_outcome.phase_result.exc_val)
+        self.state_logger.error(
+            'Outcome will be FAIL since exception was of type %s',
+            phase_execution_outcome.phase_result.exc_val)
         self._finalize(test_record.Outcome.FAIL)
       else:
-        self.logger.critical(
+        self.state_logger.critical(
             'Finishing test execution early due to an exception raised during '
             'phase execution; outcome ERROR.')
         # Enable CLI printing of the full traceback with the -v flag.
-        self.logger.critical(
+        self.state_logger.critical(
             'Traceback:%s%s%s%s',
             os.linesep,
             ''.join(traceback.format_tb(
@@ -362,14 +372,14 @@ class TestState(util.SubscribableStateMixin):
         )
         self._finalize(test_record.Outcome.ERROR)
     elif phase_execution_outcome.is_timeout:
-      self.logger.error('Finishing test execution early due to phase '
-                        'timeout, outcome TIMEOUT.')
+      self.state_logger.error('Finishing test execution early due to '
+                              'phase timeout, outcome TIMEOUT.')
       self.test_record.add_outcome_details('TIMEOUT',
                                            'A phase hit its timeout.')
       self._finalize(test_record.Outcome.TIMEOUT)
     elif phase_execution_outcome.phase_result == openhtf.PhaseResult.STOP:
-      self.logger.error('Finishing test execution early due to '
-                        'PhaseResult.STOP, outcome FAIL.')
+      self.state_logger.error('Finishing test execution early due to '
+                              'PhaseResult.STOP, outcome FAIL.')
       self.test_record.add_outcome_details('STOP',
                                            'A phase stopped the test run.')
       self._finalize(test_record.Outcome.FAIL)
@@ -395,7 +405,7 @@ class TestState(util.SubscribableStateMixin):
         phase.outcome == test_record.PhaseOutcome.SKIP for phase in phases):
       # Error when all phases are skipped; otherwise, it could lead to
       # unintentional passes.
-      self.logger.error('All phases were skipped, outcome ERROR.')
+      self.state_logger.error('All phases were skipped, outcome ERROR.')
       self.test_record.add_outcome_details(
           'ALL_SKIPPED', 'All phases were unexpectedly skipped.')
       self._finalize(test_record.Outcome.ERROR)
@@ -403,15 +413,16 @@ class TestState(util.SubscribableStateMixin):
       # Otherwise, the test run was successful.
       self._finalize(test_record.Outcome.PASS)
 
-    self.logger.debug('Finishing test execution normally with outcome %s.',
-                      self.test_record.outcome.name)
+    self.state_logger.debug(
+        'Finishing test execution normally with outcome %s.',
+        self.test_record.outcome.name)
 
   def abort(self):
     if self._is_aborted():
       return
 
-    self.logger.debug('Finishing test execution early due to '
-                      'test abortion, outcome ABORTED.')
+    self.state_logger.debug('Finishing test execution early due to '
+                            'test abortion, outcome ABORTED.')
     self.test_record.add_outcome_details('ABORTED', 'Test aborted by operator.')
     self._finalize(test_record.Outcome.ABORTED)
 
@@ -427,7 +438,6 @@ class TestState(util.SubscribableStateMixin):
     if self.test_record.start_time_millis == 0:
       self.test_record.start_time_millis = util.time_millis()
     # The test is done at this point, no further updates to test_record.
-    self.logger.handlers = []
     self.test_record.end_time_millis = util.time_millis()
     self._status = self.Status.COMPLETED
     self.notify_update()
@@ -435,7 +445,7 @@ class TestState(util.SubscribableStateMixin):
   def _is_aborted(self):
     if (self.is_finalized and
         self.test_record.outcome == test_record.Outcome.ABORTED):
-      self.logger.debug('Test already aborted.')
+      self.state_logger.debug('Test already aborted.')
       return True
     return False
 
@@ -459,6 +469,7 @@ class PhaseState(
                           ['name', 'phase_record', 'measurements', 'options'],
                           {'hit_repeat_limit': False,
                            'notify_cb': None,
+                           'logger': None,
                            '_cached': dict,
                            '_update_measurements': set})):
   """Data type encapsulating interesting information about a running phase.
@@ -493,7 +504,7 @@ class PhaseState(
     }
 
   @classmethod
-  def from_descriptor(cls, phase_desc, notify_cb):
+  def from_descriptor(cls, phase_desc, notify_cb, logger=None):
     return cls(
         phase_desc.name,
         test_record.PhaseRecord.from_descriptor(phase_desc),
@@ -501,7 +512,8 @@ class PhaseState(
             (measurement.name, copy.deepcopy(measurement))
             for measurement in phase_desc.measurements),
         phase_desc.options,
-        notify_cb=notify_cb)
+        notify_cb=notify_cb,
+        logger=logger)
 
   def _notify(self, measurement_name):
     self._update_measurements.add(measurement_name)

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -299,14 +299,14 @@ class PlugManager(object):
   Attributes:
     _plug_types: Initial set of plug types, additional plug types may be
         passed into calls to initialize_plugs().
-    _logger_name: The name of this test's plug logger. The loggers passed to the
-        plugs will be children of this logger.
     _plugs_by_type: Dict mapping plug type to plug instance.
     _plugs_by_name: Dict mapping plug name to plug instance.
     _plug_descriptors: Dict mapping plug type to plug descriptor.
+    logger: logging.Logger instance that can save logs to the running test
+        record.
   """
 
-  def __init__(self, plug_types=None, record_logger_name=None):
+  def __init__(self, plug_types=None, record_logger=None):
     self._plug_types = plug_types or set()
     for plug in self._plug_types:
       if isinstance(plug, PlugPlaceholder):
@@ -315,7 +315,9 @@ class PlugManager(object):
     self._plugs_by_type = {}
     self._plugs_by_name = {}
     self._plug_descriptors = {}
-    self.logger = logging.getLogger(record_logger_name).getChild('plug')
+    if not record_logger:
+      record_logger = _LOG
+    self.logger = record_logger.getChild('plug')
 
   def as_base_types(self):
     return {

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -163,7 +163,7 @@ class PhaseOrTestIterator(collections.Iterator):
     # Since we want to run single phases, we instantiate our own PlugManager.
     # Don't do this sort of thing outside OpenHTF unless you really know what
     # you're doing (http://imgur.com/iwBCmQe).
-    self.plug_manager = plugs.PlugManager(record_logger_name='test.PlugManager')
+    self.plug_manager = plugs.PlugManager()
     self.iterator = iterator
     self.mock_plugs = mock_plugs
     self.last_result = None

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -451,12 +451,12 @@ class TestExecutorTest(unittest.TestCase):
 class TestExecutorHandlePhaseTest(unittest.TestCase):
 
   def setUp(self):
+    super(TestExecutorHandlePhaseTest, self).setUp()
     self.test_state = mock.MagicMock(
         spec=test_state.TestState,
-        plug_manager=plugs.PlugManager(
-            record_logger_name='mock.logger.for.openhtf'),
+        plug_manager=plugs.PlugManager(),
         execution_uid='01234567890',
-        logger=mock.MagicMock())
+        state_logger=mock.MagicMock())
     self.phase_exec = mock.MagicMock(
         spec=phase_executor.PhaseExecutor)
     self.test_exec = test_executor.TestExecutor(None, 'uid', None,
@@ -532,12 +532,12 @@ class TestExecutorHandlePhaseTest(unittest.TestCase):
 class TestExecutorExecutePhasesTest(unittest.TestCase):
 
   def setUp(self):
+    super(TestExecutorExecutePhasesTest, self).setUp()
     self.test_state = mock.MagicMock(
         spec=test_state.TestState,
-        plug_manager=plugs.PlugManager(
-            record_logger_name='mock.logger.for.openhtf'),
+        plug_manager=plugs.PlugManager(),
         execution_uid='01234567890',
-        logger=mock.MagicMock())
+        state_logger=mock.MagicMock())
     self.test_exec = test_executor.TestExecutor(None, 'uid', None,
                                                 test_descriptor.TestOptions())
     self.test_exec.test_state = self.test_state
@@ -617,12 +617,12 @@ class TestExecutorExecutePhasesTest(unittest.TestCase):
 class TestExecutorExecutePhaseGroupTest(unittest.TestCase):
 
   def setUp(self):
+    super(TestExecutorExecutePhaseGroupTest, self).setUp()
     self.test_state = mock.MagicMock(
         spec=test_state.TestState,
-        plug_manager=plugs.PlugManager(
-            record_logger_name='mock.logger.for.openhtf'),
+        plug_manager=plugs.PlugManager(),
         execution_uid='01234567890',
-        logger=mock.MagicMock())
+        state_logger=mock.MagicMock())
     self.test_exec = test_executor.TestExecutor(None, 'uid', None,
                                                 test_descriptor.TestOptions())
     self.test_exec.test_state = self.test_state
@@ -692,12 +692,12 @@ class TestExecutorExecutePhaseGroupTest(unittest.TestCase):
 class PhaseExecutorTest(unittest.TestCase):
 
   def setUp(self):
+    super(PhaseExecutorTest, self).setUp()
     self.test_state = mock.MagicMock(
         spec=test_state.TestState,
-        plug_manager=plugs.PlugManager(
-            record_logger_name='mock.logger.for.openhtf'),
+        plug_manager=plugs.PlugManager(),
         execution_uid='01234567890',
-        logger=mock.MagicMock())
+        state_logger=mock.MagicMock())
     self.test_state.plug_manager.initialize_plugs([
         UnittestPlug, MoreRepeatsUnittestPlug])
     self.phase_executor = phase_executor.PhaseExecutor(self.test_state)

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -68,9 +68,9 @@ def sub_placeholder_using_plug(subplaced):
 class TestPhaseDescriptor(unittest.TestCase):
 
   def setUp(self):
+      super(TestPhaseDescriptor, self).setUp()
       self._phase_data = mock.Mock(
-          plug_manager=plugs.PlugManager(
-              record_logger_name='mock.logger.for.openhtf'),
+          plug_manager=plugs.PlugManager(),
           execution_uid='01234567890')
 
   def test_basics(self):

--- a/test/plugs/plugs_test.py
+++ b/test/plugs/plugs_test.py
@@ -69,8 +69,7 @@ class TearDownRaisesPlug2(plugs.BasePlug):
 class PlugsTest(test.TestCase):
 
   def setUp(self):
-    self.plug_manager = plugs.PlugManager(
-        {AdderPlug}, record_logger_name='mock.logger.for.openhtf')
+    self.plug_manager = plugs.PlugManager({AdderPlug})
     AdderPlug.INSTANCE_COUNT = 0
 
   def tearDown(self):


### PR DESCRIPTION
The test-specific logger is now a custom subclass that overrides the
getChild method to avoid the Python logging module's log hierarchy.
Subloggers must now call the parent's getChild method to construct the
appropriate logger.

In addition, this change moves creating the phase-specific logger to
TestState's running_phase_context.  This ensures that the logger is only
created once for a particular phase, rather than creating multiples in
scenarios where phases recursively call other phases. To make this
clearer, the TestState.logger has been renamed to
TestState.state_logger; TestState.logger is now a property that returns
the running phase state's logger instance or exceptions if it is not
set.

Lastly, fix flakiness in user_input that was causing unit tests to
intermittently failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/862)
<!-- Reviewable:end -->
