### PR TITLE
Added expected_value and percent_range field to mfg_event measurement when using within_percent validator.

### DIFF
--- a/openhtf/output/proto/mfg_event.proto
+++ b/openhtf/output/proto/mfg_event.proto
@@ -85,6 +85,10 @@ message Measurement {
   optional double numeric_minimum = 12;
   optional double numeric_maximum = 13;
 
+  // If this parameter is a percent range
+  optional double expected_value = 24;
+  optional double percent_range = 25;
+
   // If this parameter is text then fill in these fields
   optional string text_value = 14;
   // This field may be a regular expression describing the expected value
@@ -100,7 +104,7 @@ message Measurement {
   // Created for visualization by UIs that don't support certain fancy
   // parameters. UIs that do support them should hide these parameters.
   optional string associated_attachment = 21;
-  // Next tag = 24
+  // Next tag = 26
 
   extensions 5000 to 5199;
 }

--- a/openhtf/output/proto/mfg_event_converter.py
+++ b/openhtf/output/proto/mfg_event_converter.py
@@ -390,6 +390,11 @@ class PhaseCopier(object):
           mfg_measurement.numeric_minimum = float(validator.minimum)
         if validator.maximum is not None:
           mfg_measurement.numeric_maximum = float(validator.maximum)
+      elif isinstance(validator, validators.WithinPercent):
+        if validator.expected is not None:
+          mfg_measurement.expected_value = float(validator.expected)
+        if validator.percent is not None:
+          mfg_measurement.percent_range = float(validator.percent)
       elif isinstance(validator, validators.RegexMatcher):
         mfg_measurement.expected_text = validator.regex
       else:

--- a/openhtf/output/proto/test_runs.proto
+++ b/openhtf/output/proto/test_runs.proto
@@ -127,6 +127,10 @@ message TestParameter {
   optional double numeric_minimum = 12;
   optional double numeric_maximum = 13;
 
+  // If this parameter is a percent range
+  optional double expected_value = 22;
+  optional double percent_range = 23;
+
   // If this parameter is text then fill in these fields
   optional string text_value = 14;
   // This field may be a regular expression describing the expected value
@@ -139,7 +143,7 @@ message TestParameter {
   // Created for visualization by UIs that don't support certain fancy
   // parameters. UIs that do support them should hide these parameters.
   optional string associated_attachment = 21;
-  // Next tag = 22
+  // Next tag = 24
 
   extensions 5000 to 5199;
 }

--- a/openhtf/output/proto/test_runs_converter.py
+++ b/openhtf/output/proto/test_runs_converter.py
@@ -249,6 +249,11 @@ def _extract_parameters(record, testrun, used_parameter_names):
               testrun_param.numeric_minimum = float(validator.minimum)
             if validator.maximum is not None:
               testrun_param.numeric_maximum = float(validator.maximum)
+          elif isinstance(validator, validators.WithinPercent):
+            if validator.expected is not None:
+              testrun_param.expected_value = float(validator.expected)
+            if validator.percent is not None:
+              testrun_param.percent_range = float(validator.percent)
           elif isinstance(validator, validators.RegexMatcher):
             testrun_param.expected_text = validator.regex
           else:


### PR DESCRIPTION
# What I did
I added `expected_value` and `percent_range` as parameters to a measurement when `within_percent` measurement validator is being used.

# Why I did it
I did that change because otherwise to extract the `expected_value` and `percent_range` information we need to do some string parsing to the description field of the test parameters (`numeric_maximum` and `numeric_minimum`) are not included in test parameters when used with within_percent. The description field has the following syntax:
`description: "\nValidator: \'x\' is within 5% of 5.0"`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/866)
<!-- Reviewable:end -->
