### PR TITLE
Adding numeric_minimum and numeric_maximum instead of using expected_value and percent_range when using within_percent validator

### DIFF
--- a/openhtf/output/proto/mfg_event.proto
+++ b/openhtf/output/proto/mfg_event.proto
@@ -85,10 +85,6 @@ message Measurement {
   optional double numeric_minimum = 12;
   optional double numeric_maximum = 13;
 
-  // If this parameter is a percent range
-  optional double expected_value = 24;
-  optional double percent_range = 25;
-
   // If this parameter is text then fill in these fields
   optional string text_value = 14;
   // This field may be a regular expression describing the expected value
@@ -104,7 +100,7 @@ message Measurement {
   // Created for visualization by UIs that don't support certain fancy
   // parameters. UIs that do support them should hide these parameters.
   optional string associated_attachment = 21;
-  // Next tag = 26
+  // Next tag = 24
 
   extensions 5000 to 5199;
 }

--- a/openhtf/output/proto/mfg_event_converter.py
+++ b/openhtf/output/proto/mfg_event_converter.py
@@ -385,16 +385,11 @@ class PhaseCopier(object):
 
     # Copy measurement validators.
     for validator in measurement.validators:
-      if isinstance(validator, validators.in_range):
+      if isinstance(validator, validators.RangeValidatorBase):
         if validator.minimum is not None:
           mfg_measurement.numeric_minimum = float(validator.minimum)
         if validator.maximum is not None:
           mfg_measurement.numeric_maximum = float(validator.maximum)
-      elif isinstance(validator, validators.WithinPercent):
-        if validator.expected is not None:
-          mfg_measurement.expected_value = float(validator.expected)
-        if validator.percent is not None:
-          mfg_measurement.percent_range = float(validator.percent)
       elif isinstance(validator, validators.RegexMatcher):
         mfg_measurement.expected_text = validator.regex
       else:

--- a/openhtf/output/proto/test_runs.proto
+++ b/openhtf/output/proto/test_runs.proto
@@ -127,10 +127,6 @@ message TestParameter {
   optional double numeric_minimum = 12;
   optional double numeric_maximum = 13;
 
-  // If this parameter is a percent range
-  optional double expected_value = 22;
-  optional double percent_range = 23;
-
   // If this parameter is text then fill in these fields
   optional string text_value = 14;
   // This field may be a regular expression describing the expected value
@@ -143,7 +139,7 @@ message TestParameter {
   // Created for visualization by UIs that don't support certain fancy
   // parameters. UIs that do support them should hide these parameters.
   optional string associated_attachment = 21;
-  // Next tag = 24
+  // Next tag = 22
 
   extensions 5000 to 5199;
 }

--- a/openhtf/output/proto/test_runs_converter.py
+++ b/openhtf/output/proto/test_runs_converter.py
@@ -249,11 +249,6 @@ def _extract_parameters(record, testrun, used_parameter_names):
               testrun_param.numeric_minimum = float(validator.minimum)
             if validator.maximum is not None:
               testrun_param.numeric_maximum = float(validator.maximum)
-          elif isinstance(validator, validators.WithinPercent):
-            if validator.expected is not None:
-              testrun_param.expected_value = float(validator.expected)
-            if validator.percent is not None:
-              testrun_param.percent_range = float(validator.percent)
           elif isinstance(validator, validators.RegexMatcher):
             testrun_param.expected_text = validator.regex
           else:

--- a/test/output/callbacks/mfg_event_converter_test.py
+++ b/test/output/callbacks/mfg_event_converter_test.py
@@ -196,8 +196,8 @@ class MfgEventConverterTest(unittest.TestCase):
     measurement_within_percent = (
         self._create_and_set_measurement(
             'within-percent',
-            8).doc('mock measurement within percent docstring').with_units(
-                units.Unit('radian')).within_percent(8, 9))
+            9).doc('mock measurement within percent docstring').with_units(
+                units.Unit('radian')).within_percent(10, 20))
 
     # We 'incorrectly' create a measurement with a unicode character as
     # a python2 string.  We don't want mfg_event_converter to guess at it's
@@ -248,7 +248,7 @@ class MfgEventConverterTest(unittest.TestCase):
 
     # Measurement value.
     self.assertEqual(mock_measurement_in_range.numeric_value, 5.0)
-    self.assertEqual(mock_measurement_within_percent.numeric_value, 8.0)
+    self.assertEqual(mock_measurement_within_percent.numeric_value, 9)
 
     # FFFD is unicode's '?'.  This occurs when we can't easily convert a python2
     # string to unicode.
@@ -258,8 +258,8 @@ class MfgEventConverterTest(unittest.TestCase):
     # Measurement validators.
     self.assertEqual(mock_measurement_in_range.numeric_minimum, 1.0)
     self.assertEqual(mock_measurement_in_range.numeric_maximum, 10.0)
-    self.assertEqual(mock_measurement_within_percent.expected_value, 8.0)
-    self.assertEqual(mock_measurement_within_percent.percent_range, 9.0)
+    self.assertEqual(mock_measurement_within_percent.numeric_minimum, 8.0)
+    self.assertEqual(mock_measurement_within_percent.numeric_maximum, 12.0)
 
   def testCopyAttachmentsFromPhase(self):
     attachment = test_record.Attachment('mock-data', 'text/plain')


### PR DESCRIPTION
# What I did
I removed `expected_value` and `percent_range` as parameters to a measurement when `within_percent` measurement validator is being used. I instead populate `numeric_minimum` and `numeric_maximum` in the `mfg_event.proto` and `test_runs.proto` when the validator inherits from `in_range` in `openhtf/output/proto/mfg_event_converter.py`.

# Why I did it
In my previous pull request, I added expected_value and percent_range field to the measurement proto:
https://github.com/google/openhtf/pull/866
I received some emails from openhtf users letting me know that they would prefer if within_percent would extract the `numeric_minimum` and `numeric_maximum` fields. `mfg_event.proto` is a fundamental data structure and making changes to it may break other code that is not in the openhtf library (such as the frontend). We should minimize the amount of changes done to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/867)
<!-- Reviewable:end -->
