### PR TITLE
Remove console prompt thread join

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -86,7 +86,6 @@ class ConsolePrompt(threading.Thread):
     self._stop_event.set()
     if not self._answered:
       _LOG.debug('Stopping ConsolePrompt--prompt was answered from elsewhere.')
-    self.join()
 
   def run(self):
     """Main logic for this thread to execute."""
@@ -112,7 +111,7 @@ class ConsolePrompt(threading.Thread):
     line = ''
     while not self._stop_event.is_set():
       inputs, _, _ = select.select([sys.stdin], [], [], 0.001)
-      if [sys.stdin] in inputs:
+      if sys.stdin in inputs:
         new = os.read(sys.stdin.fileno(), 1024)
         if not new:
           # Hit EOF!

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -266,8 +266,8 @@ class TestExecutorTest(unittest.TestCase):
     # The test will end at the same time it starts because the test never
     # actually started, we canceled it inside of test_start, resulting in a
     # short vacuous start. Start and end times should be no more than a
-    # millisecond or two apart in that case.
-    self.assertLess(record.end_time_millis - record.start_time_millis, 2)
+    # few milliseconds apart in that case.
+    self.assertLess(record.end_time_millis - record.start_time_millis, 4)
     self.assertLessEqual(record.end_time_millis, util.time_millis())
     # Teardown function should not be executed.
     self.assertFalse(ev.wait(3))


### PR DESCRIPTION
The console prompt thread join causes deadlocks under certain
circumstances.

Additionally, increase time buffer in exe_test's test_cancel_start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/871)
<!-- Reviewable:end -->
