### PR TITLE
fix: doc from phase instead of phase des class

### DIFF
--- a/openhtf/core/phase_descriptor.py
+++ b/openhtf/core/phase_descriptor.py
@@ -173,7 +173,7 @@ class PhaseDescriptor(mutablerecords.Record(
     return self.options.name or self.func.__name__
 
   @property
-  def doc(self):
+  def __doc__(self):
     return self.func.__doc__
 
   def with_known_args(self, **kwargs):


### PR DESCRIPTION
Docstring of phases displays phase descriptor. With this patch, it now displays the phase docstring.
I suspect this was a typo because name doesn't need the underscores but doc does.

Resolves #877