### PR TITLE
Add stop_on_failure to PhaseOptions

### DIFF
--- a/examples/stop_on_failure.py
+++ b/examples/stop_on_failure.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example OpenHTF stop_on_failure PhaseOption.
+
+Decorating Phase with stop_on_failure=True option
+PhaseResult will be set to STOP instead of CONTINUE in case
+of a failed measurement in a Phase.
+"""
+
+
+import openhtf as htf
+
+from openhtf.util import validators
+from openhtf.output.callbacks import console_summary
+
+
+# Phase that fails.
+@htf.PhaseOptions(stop_on_failure=True)
+@htf.measures('number_sum', validators=[validators.in_range(0, 5)])
+def add_numbers_fails(test):
+  """Add numbers fails phase
+
+  This phase will result in number_sum fail in_range validation
+  """
+  test.logger.info('Add numbers 2 and 4')
+  number_sum = 2 + 4
+  test.measurements.number_sum = number_sum
+
+
+@htf.measures(htf.Measurement('hello_world_measurement'))
+def hello_world(test):
+  """A hello world test phase."""
+  test.logger.info('This phase will not be run since previous phase failed')
+  test.measurements.hello_world_measurement = 'Hello World!'
+
+
+if __name__ == '__main__':
+  test = htf.Test(add_numbers_fails, hello_world)
+  test.add_output_callbacks(console_summary.ConsoleSummary())
+  test.execute(test_start=lambda: True)

--- a/openhtf/core/phase_descriptor.py
+++ b/openhtf/core/phase_descriptor.py
@@ -64,7 +64,7 @@ PhaseResult = enum.Enum('PhaseResult', [   # pylint: disable=invalid-name
 
 class PhaseOptions(mutablerecords.Record('PhaseOptions', [], {
     'name': None, 'timeout_s': None, 'run_if': None, 'requires_state': None,
-    'repeat_limit': None, 'run_under_pdb': False})):
+    'repeat_limit': None, 'run_under_pdb': False, 'stop_on_failure': False})):
   """Options used to override default test phase behaviors.
 
   Attributes:
@@ -82,6 +82,9 @@ class PhaseOptions(mutablerecords.Record('PhaseOptions', [], {
     run_under_pdb: If True, run the phase under the Python Debugger (pdb).  When
         setting this option, increase the phase timeout as well because the
         timeout will still apply when under the debugger.
+    stop_on_failure: If True, the phase will return PhaseResult as STOP instead
+        of CONTINUE (default) in case of any failed measurement.
+
 
   Example Usages:
     @PhaseOptions(timeout_s=1)

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -644,6 +644,17 @@ class PhaseState(
                  else test_record.PhaseOutcome.FAIL)
     self.phase_record.outcome = outcome
 
+  def _update_phase_result_from_phase_outcome(self):
+    """Update PhaseResult based on PhaseOutcome.
+
+    This method updates PhaseResult to STOP in case of PhaseOutcome is FAIL.
+    """
+    if self.phase_record.outcome is test_record.PhaseOutcome.FAIL:
+      self.logger.error('Stopping test due to failed measurement.')
+      self.result = openhtf.phase_executor.PhaseExecutionOutcome(
+          openhtf.PhaseResult.STOP)
+
+
   @property
   @contextlib.contextmanager
   def record_timing_context(self):
@@ -663,4 +674,7 @@ class PhaseState(
     finally:
       self._finalize_measurements()
       self._set_phase_outcome()
+      if self.options.stop_on_failure is True:
+        # Stop test on PhaseOutcome == FAIL if PhaseOption stop_on_failure is True
+        self._update_phase_result_from_phase_outcome()
       self.phase_record.finalize_phase(self.options)


### PR DESCRIPTION
If stop_on_failure Phase Option is set to True
PhaseResult is set to STOP instead of CONTINUE
when the PhaseOutcome is FAIL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/883)
<!-- Reviewable:end -->
