### PR TITLE
test executor: Shorter timeouts for 32-bit OSes

### DIFF
--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -116,11 +116,12 @@ class TestExecutor(threads.KillableThread):
     """Waits until death."""
     # Must use a timeout here in case this is called from the main thread.
     # Otherwise, the SIGINT abort logic in test_descriptor will not get called.
+    timeout = 31557600  # Seconds in a year.
     if sys.version_info >= (3, 2):
-      self.join(threading.TIMEOUT_MAX)
-    else:
-      # Seconds in a year.
-      self.join(31557600)
+      # TIMEOUT_MAX can be too large and cause overflows on 32-bit OSes, so take
+      # whichever timeout is shorter.
+      timeout = min(threading.TIMEOUT_MAX, timeout)
+    self.join(timeout)
 
   def _thread_proc(self):
     """Handles one whole test from start to finish."""

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,9 @@ setup(
     ],
     tests_require=[
         'mock>=2.0.0',
-        'pandas>=0.22.0',
+        # Remove max version here after we drop Python 2 support.
+        'pandas>=0.22.0,<0.25.0',
+        'numpy<1.17.0',
         'pytest>=2.9.2',
         'pytest-cov>=2.2.1',
     ],


### PR DESCRIPTION
threading.MAX_TIMEOUT causes overflows on 32-bit OSes, so take the
shorter MAX_TIMEOUT or 1 year in seconds when waiting for the test
executor to finish.

Fixes issue #888.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/891)
<!-- Reviewable:end -->
