### PR TITLE
Adding support for classes containing enum members for device_wrapping.DeviceWrapping class

### DIFF
--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -21,6 +21,7 @@ Device-wrapping plugs are your friends in such times.
 """
 
 import functools
+import types
 
 import openhtf
 import six
@@ -89,7 +90,7 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
 
     attribute = getattr(self._device, attr)
 
-    if not self.verbose or not callable(attribute):
+    if not self.verbose or not isinstance(attribute, types.MethodType):
       return attribute
 
     # Attribute callable; return a wrapper that logs calls with args and kwargs.


### PR DESCRIPTION
# What I did
We now return the attribute directly from the __getattr__ method when the attribute is a method rather than only when it's a callable.

# Why I did it
I have an existing driver that I want to convert to a plug using device_wrapping.DeviceWrapping. The driver has an Enum class attribute. The current implementation of device_wrapping.DeviceWrapping doesn't support having enum as class attributes.

By not making this change I get the following error when accessing an enum attribute:
```
AttributeError: 'function' object has no attribute 'ON'
```
when accessing the enum attribute output_states:
```
class PowerSupply(object):
     output_states = enum.Enum('output_states', {'ON': True, 'OFF': False})
```

Demo that enums are considered as callables:
```
Python 2.7.16 
>>> import enum
>>> class PowerSupply(object):
...     output_states = enum.Enum('OUTPUT_STATES', {'ON': True, 'OFF': False})
... 
>>> power_supply = PowerSupply()
>>> callable(getattr(power_supply, 'output_states'))
True
>>> import types
>>> isinstance(getattr(power_supply, 'output_states'), types.MethodType)
False
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/906)
<!-- Reviewable:end -->
