### PR TITLE
device_wrapping.DeviceWrappingPlug now supports setting attributes

### DIFF
--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -81,6 +81,13 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
                           'but using the no-op BasePlug tearDown method.',
                           type(self._device))
 
+  def __setattr__(self, name, value):
+    if name == '_device' or not hasattr(
+        super(DeviceWrappingPlug, self), '__getattr__'):
+      super(DeviceWrappingPlug, self).__setattr__(name, value)
+    else:
+      setattr(self._device, name, value)
+
   def __getattr__(self, attr):
     if self._device is None:
       raise openhtf.plugs.InvalidPlugError(

--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -21,6 +21,7 @@ Device-wrapping plugs are your friends in such times.
 """
 
 import functools
+import types
 
 import openhtf
 import six
@@ -89,7 +90,7 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
 
     attribute = getattr(self._device, attr)
 
-    if not self.verbose or not callable(attribute):
+    if not self.verbose or not isinstance(attribute, types.MethodType):
       return attribute
 
     # Attribute callable; return a wrapper that logs calls with args and kwargs.


### PR DESCRIPTION
# What I did
Added attribute method of device_wrapping.DeviceWrapping to set the attributes of the device.

# Why I did it
In the past it wasn't possible to call setter methods from the underlying driver in the device wrapping plug (only getters were allowed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/907)
<!-- Reviewable:end -->
