### PR TITLE
Fixed bug with device_wrapping.DeviceWrappingPlug where the attributes were sometimes not set.

### DIFF
--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -82,8 +82,8 @@ class DeviceWrappingPlug(openhtf.plugs.BasePlug):
                           type(self._device))
 
   def __setattr__(self, name, value):
-    if name == '_device' or not hasattr(
-        super(DeviceWrappingPlug, self), '__getattr__'):
+    if (name == '_device' or '_device' not in self.__dict__ or
+        name in self.__dict__):
       super(DeviceWrappingPlug, self).__setattr__(name, value)
     else:
       setattr(self._device, name, value)


### PR DESCRIPTION
# What I did
Setting the attribute of device_wrapping.DeviceWrappingPlug now has two expected behavior:
First:
-If we are setting the _device, then set the attribute from DeviceWrappingPlug (because we are probably calling this setter from the initializer).
-If _device has not been defined then set the attribute in DeviceWrappingPlug.
-If the attribute has already been defined in DeviceWrappingPlug then set that variable.
Otherwise:
-Set the attribute in the _device object.

# Why I did it
The  device_wrapping.DeviceWrappingPlug didn't set the attributes correctly based on when the super initializer from the children class is being called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/908)
<!-- Reviewable:end -->
