### PR TITLE
Memory-safe phase record attachments

### DIFF
--- a/openhtf/output/callbacks/json_factory.py
+++ b/openhtf/output/callbacks/json_factory.py
@@ -3,13 +3,25 @@
 import base64
 import json
 
+from openhtf.core import test_record
 from openhtf.output import callbacks
 from openhtf.util import data
 import six
 
 
+class TestRecordEncoder(json.JSONEncoder):
+
+  def default(self, obj):
+    if isinstance(obj, test_record.Attachment):
+      dct = obj._asdict()
+      dct['data'] = base64.standard_b64encode(obj.data).decode('utf-8')
+      return dct
+    return super(TestRecordEncoder, self).default(obj)
+
+
 class OutputToJSON(callbacks.OutputToFile):
   """Return an output callback that writes JSON Test Records.
+
   Example filename_patterns might be:
     '/data/test_records/{dut_id}.{metadata[test_name]}.json', indent=4)) or
     '/data/test_records/%(dut_id)s.%(start_time_millis)s'
@@ -35,17 +47,16 @@ class OutputToJSON(callbacks.OutputToFile):
     # Conform strictly to the JSON spec by default.
     kwargs.setdefault('allow_nan', False)
     self.allow_nan = kwargs['allow_nan']
-    self.json_encoder = json.JSONEncoder(**kwargs)
+    self.json_encoder = TestRecordEncoder(**kwargs)
 
   def serialize_test_record(self, test_record):
-    return self.json_encoder.encode(self.convert_to_dict(test_record))
+    return self.json_encoder.iterencode(self.convert_to_dict(test_record))
 
   def convert_to_dict(self, test_record):
     as_dict = data.convert_to_base_types(test_record,
                                          json_safe=(not self.allow_nan))
     if self.inline_attachments:
       for phase, original_phase in zip(as_dict['phases'], test_record.phases):
-        for name, attachment in six.iteritems(phase['attachments']):
-          original_data = original_phase.attachments[name].data
-          attachment['data'] = base64.standard_b64encode(original_data).decode('utf-8')
+        for name, attachment in six.iteritems(original_phase.attachments):
+          phase['attachments'][name] = attachment
     return as_dict

--- a/openhtf/output/proto/mfg_event_converter.py
+++ b/openhtf/output/proto/mfg_event_converter.py
@@ -256,7 +256,6 @@ def phase_uniquizer(all_phases):
     for name, _ in sorted(phase.attachments.items()):
       old_name = name
       name = attachment_name_maker.make_unique(name)
-      phase.attachments[old_name].name = name
       phase.attachments[name] = phase.attachments.pop(old_name)
   return all_phases
 
@@ -397,15 +396,14 @@ class PhaseCopier(object):
 
   def copy_attachments(self, mfg_event):
     for phase in self._phases:
-      for name, (data, mimetype) in sorted(phase.attachments.items()):
-        self._copy_attachment(name, data, mimetype, mfg_event)
+      for name, attachment in sorted(phase.attachments.items()):
+        self._copy_attachment(name, attachment.data, attachment.mimetype,
+                              mfg_event)
 
   def _copy_attachment(self, name, data, mimetype, mfg_event):
     """Copies an attachment to mfg_event."""
     attachment = mfg_event.attachment.add()
     attachment.name = name
-    if isinstance(data, unicode):
-      data = data.encode('utf8')
     attachment.value_binary = data
     if mimetype in test_runs_converter.MIMETYPE_MAP:
       attachment.type = test_runs_converter.MIMETYPE_MAP[mimetype]

--- a/openhtf/output/proto/test_runs_converter.py
+++ b/openhtf/output/proto/test_runs_converter.py
@@ -143,7 +143,7 @@ def _attach_json(record, testrun):
       sort_keys=True, indent=2).serialize_test_record(record)
   testrun_param = testrun.info_parameters.add()
   testrun_param.name = 'OpenHTF_record.json'
-  testrun_param.value_binary = record_json.encode('utf-8')
+  testrun_param.value_binary = b''.join(r.encode('utf-8') for r in record_json)
   # pylint: disable=no-member
   testrun_param.type = test_runs_pb2.TEXT_UTF8
   # pylint: enable=no-member
@@ -152,12 +152,10 @@ def _attach_json(record, testrun):
 def _extract_attachments(phase, testrun, used_parameter_names):
   """Extract attachments, just copy them over."""
   for name, attachment in sorted(six.iteritems(phase.attachments)):
-    attachment_data, mimetype = attachment
+    attachment_data, mimetype = attachment.data, attachment.mimetype
     name = _ensure_unique_parameter_name(name, used_parameter_names)
     testrun_param = testrun.info_parameters.add()
     testrun_param.name = name
-    if isinstance(attachment_data, unicode):
-      attachment_data = attachment_data.encode('utf-8')
     testrun_param.value_binary = attachment_data
     if mimetype in MIMETYPE_MAP:
       testrun_param.type = MIMETYPE_MAP[mimetype]

--- a/openhtf/util/conf.py
+++ b/openhtf/util/conf.py
@@ -459,6 +459,9 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
         retval[key] = value
     return retval
 
+  def __dict__(self):
+    return self._asdict()
+
   @property
   def help_text(self):
     """Return a string with all config keys and their descriptions."""

--- a/openhtf/util/console_output.py
+++ b/openhtf/util/console_output.py
@@ -109,8 +109,8 @@ def banner_print(msg, color='', width=60, file=sys.stdout, logger=_LOG):
   file.flush()
 
 
-def bracket_print(msg, color='', width=8, file=sys.stdout):
-  """Prints the message in brackets in the specified color and end the line.
+def bracket_print(msg, color='', width=8, file=sys.stdout, end_line=True):
+  """Prints message in brackets in the specified color, and maybe end the line.
 
   Args:
     msg: The message to put inside the brackets (a brief status message).
@@ -120,6 +120,8 @@ def bracket_print(msg, color='', width=8, file=sys.stdout):
     width: Total desired width of the bracketed message.
     file: A file object to which the bracketed text will be written. Intended
         for use with CLI output file objects like sys.stdout.
+    end_line: If True, end the line and flush the file object after outputting
+        the bracketed text.
     """
   if CLI_QUIET:
     return
@@ -129,8 +131,9 @@ def bracket_print(msg, color='', width=8, file=sys.stdout):
       lpad=lpad, bright=colorama.Style.BRIGHT, color=color, msg=msg,
       reset=colorama.Style.RESET_ALL, rpad=rpad))
   file.write(colorama.Style.RESET_ALL)
-  file.write(_linesep_for_file(file))
-  file.flush()
+  if end_line:
+    file.write(_linesep_for_file(file))
+    file.flush()
 
 
 def cli_print(msg, color='', end=None, file=sys.stdout, logger=_LOG):

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -84,12 +84,14 @@ _identity = lambda x: x
 
 class ValidatorBase(with_metaclass(abc.ABCMeta, object)):
   @abc.abstractmethod
+
   def __call__(self, value):
     """Should validate value, returning a boolean result."""
 
 
 class RangeValidatorBase(with_metaclass(abc.ABCMeta, ValidatorBase)):
   @abc.abstractproperty
+
   def minimum(self):
     """Should return the minimum, inclusive value of the range."""
 
@@ -99,6 +101,27 @@ class RangeValidatorBase(with_metaclass(abc.ABCMeta, ValidatorBase)):
 
 
 # Built-in validators below this line
+class AllInRangeValidator(ValidatorBase):
+
+  def __init__(self, min_value, max_value):
+    self.min_value = min_value
+    self.max_value = max_value
+
+  def __call__(self, values):
+    return all([self.min_value <= value <= self.max_value for value in values])
+
+
+class AllEqualsValidator(ValidatorBase):
+
+  def __init__(self, spec):
+    self.spec = spec
+
+  def __call__(self, values):
+    return all([value == self.spec for value in values])
+
+register(AllInRangeValidator, name='all_in_range')
+register(AllEqualsValidator, name='all_equals')
+
 
 class InRange(RangeValidatorBase):
   """Validator to verify a numeric value is within a range."""

--- a/test/core/test_record_test.py
+++ b/test/core/test_record_test.py
@@ -1,0 +1,32 @@
+# Lint as: python2, python3
+"""Unit tests for test_record module."""
+
+import sys
+import unittest
+
+from openhtf.core import test_record
+
+
+def _get_obj_size(obj):
+  size = 0
+  for attr in obj.__slots__:
+    size += sys.getsizeof(attr)
+    size += sys.getsizeof(getattr(obj, attr))
+  return size
+
+
+class TestRecordTest(unittest.TestCase):
+
+  def test_attachment_data(self):
+    expected_data = b'test attachment data'
+    attachment = test_record.Attachment(expected_data, 'text')
+    data = attachment.data
+    self.assertEqual(data, expected_data)
+
+  def test_attachment_memory_safety(self):
+    empty_attachment = test_record.Attachment('', 'text')
+    expected_obj_size = _get_obj_size(empty_attachment)
+    large_data = b'test attachment data' * 1000
+    attachment = test_record.Attachment(large_data, 'text')
+    obj_size = _get_obj_size(attachment)
+    self.assertEqual(obj_size, expected_obj_size)

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -19,6 +19,7 @@ actually care for.
 """
 
 import io
+import json
 import sys
 import unittest
 
@@ -28,7 +29,6 @@ from examples import all_the_things
 from openhtf.output.callbacks import console_summary
 from openhtf.output.callbacks import json_factory
 from openhtf.output.proto import mfg_event_converter
-from openhtf.output.proto import mfg_event_pb2
 from openhtf.output.proto import test_runs_converter
 from openhtf.output.proto import test_runs_pb2
 from openhtf.util import test
@@ -60,6 +60,8 @@ class TestOutput(test.TestCase):
       json_output = io.StringIO()
     json_factory.OutputToJSON(
         json_output, sort_keys=True, indent=2)(record)
+    json_output.seek(0)
+    json.loads(json_output.read())
 
   @test.patch_plugs(user_mock='openhtf.plugs.user_input.UserInput')
   def test_test_run_from_test_record(self, user_mock):
@@ -153,7 +155,7 @@ class TestMfgEventOutput(test.TestCase):
 
     # Spot check an attachment (example_attachment.txt)
     for attachment_name in  ['example_attachment_0.txt',
-        'example_attachment_1.txt']:
+                             'example_attachment_1.txt']:
       for attachment in mfg_event.attachment:
         if attachment.name == attachment_name:
           self.assertEqual(

--- a/test/util/conf_test.py
+++ b/test/util/conf_test.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 
 import io
+import os.path
 import sys
+import unittest
+
+from openhtf.util import conf
+import six
+
 
 _old_argv = list(sys.argv)
 sys.argv.extend([
@@ -25,11 +31,6 @@ sys.argv.extend([
     '--config-value=true_value=true',
     '--config-value', 'num_value=100',
 ])
-
-import os.path
-import unittest
-
-from openhtf.util import conf
 
 conf.declare('flag_key')
 conf.declare('other_flag')
@@ -102,23 +103,18 @@ class TestConf(unittest.TestCase):
     self.assertEqual(True, conf.true_value)
 
   def test_as_dict(self):
-    conf.load(station_id='station_id')
-    self.assertEqual({
+    conf_dict = conf._asdict()
+    expected_dict = {
         'flag_key': 'flag_value',
+        'other_flag': 'other_value',
         'true_value': True,
         'num_value': 100,
-        'cancel_timeout_s': 2,
-        'example_plug_increment_size': 1,
-        'allow_unset_measurements': False,
-        'capture_source': False,
-        'station_id': 'station_id',
-        'other_flag': 'other_value',
-        'plug_teardown_timeout_s': 0,
-        'string_default': 'default',
         'none_default': None,
-        'teardown_timeout_s': 30,
-        'stop_on_first_failure': False,
-    }, conf._asdict())
+        'string_default': 'default',
+    }
+    # assert first dict is a subset of second dict
+    self.assertLessEqual(six.viewitems(expected_dict),
+                              six.viewitems(conf_dict))
 
   def test_undeclared(self):
     with self.assertRaises(conf.UndeclaredKeyError):


### PR DESCRIPTION
File attachments created during test runs were stored in memory and caused out of memory errors during some runs. This CL fixes this by storing attachment data in files on disk and retrieves it into memory only when requested. There is also an update to test record serialization code to only serialize one attachment at a time and stream the data directly to file writer.

PiperOrigin-RevId: 279664832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/916)
<!-- Reviewable:end -->
