### PR TITLE
Upgrading mfg-inspector upload errors to WARNING

### DIFF
--- a/openhtf/output/callbacks/mfg_inspector.py
+++ b/openhtf/output/callbacks/mfg_inspector.py
@@ -40,11 +40,11 @@ def _send_mfg_inspector_request(envelope_data, credentials, destination_url):
   try:
     result = json.loads(content)
   except Exception:
-    logging.debug('Upload failed with response %s: %s', resp, content)
+    logging.warning('Upload failed with response %s: %s', resp, content)
     raise UploadFailedError(resp, content)
 
   if resp.status != 200:
-    logging.debug('Upload failed: %s', result)
+    logging.warning('Upload failed: %s', result)
     raise UploadFailedError(result['error'], result)
 
   return result


### PR DESCRIPTION
Upgrading upload errors to WARNING so they have increase visibility (i.e. I believe debug errors are not output).  Now error messages reported by mfg-inspector are visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/917)
<!-- Reviewable:end -->
