### PR TITLE
print new line if console prompt is answered from elsewhere

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -85,6 +85,8 @@ class ConsolePrompt(threading.Thread):
     """Mark this ConsolePrompt as stopped."""
     self._stop_event.set()
     if not self._answered:
+      console_output.cli_print(os.linesep, color=self._color,
+                               end='', logger=None)
       _LOG.debug('Stopping ConsolePrompt--prompt was answered from elsewhere.')
 
   def run(self):


### PR DESCRIPTION
I thought that a new line should be printed if the ConsolePrompt is answered from elsewhere as otherwise it can appear as though the prompt has been answered from the console if text is output to stdout during a test phase.

A new line just moves the console output on so it looks like nothing was input to the prompt. Alternatively, a more descriptive message could be printed, perhaps in a muted colour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/922)
<!-- Reviewable:end -->
