### PR TITLE
Updated Dimension class equality method

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -388,6 +388,8 @@ class Dimension(object):
     })
 
   def __eq__(self, other):
+    if not issubclass(other, self.__class__):
+        return False
     return (self.description == other.description and self.unit == other.unit)
 
   def __ne__(self, other):


### PR DESCRIPTION
This is useful if you have a list of objects that may not be of type `Dimension` and you need to check if a `Dimension` object is in the list. Previously it would throw an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/931)
<!-- Reviewable:end -->
