### PR TITLE
Updated Dimension Class equality method

### DIFF
--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -388,6 +388,8 @@ class Dimension(object):
     })
 
   def __eq__(self, other):
+    if not issubclass(type(other), self.__class__):
+      return False
     return (self.description == other.description and self.unit == other.unit)
 
   def __ne__(self, other):


### PR DESCRIPTION
Added check to see if the object you are testing against is actually a subclass of the current object. This allows for checking if a Dimension object is in a list of objects that may not all be of type Dimension. Previously the program would crash in this situation