### PR TITLE
Only send last message if test still running

### DIFF
--- a/openhtf/output/servers/station_server.py
+++ b/openhtf/output/servers/station_server.py
@@ -280,8 +280,13 @@ class StationPubSub(pub_sub.PubSub):
     cls._last_message = message
 
   def on_subscribe(self, info):
-    """Send the more recent test state to new subscribers when they connect."""
-    if self._last_message is not None:
+    """
+    Send the more recent test state to new subscribers when they connect,
+    unless the test has already completed.
+    """
+    test, _ = _get_executing_test()
+
+    if self._last_message is not None and test is not None:
       self.send(self._last_message)
 
 


### PR DESCRIPTION
Fix the "Unknown test UID" message that appears in the web gui after any
test has completed. This is caused by the last test record containing
information about a test that has completed. Tests that complete are no
longer in the TEST_INSTANCES list, so the web gui can't retrieve any
more information about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/939)
<!-- Reviewable:end -->
