### PR TITLE
Ensure output directory exists

### DIFF
--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -22,6 +22,7 @@ examples.
 
 import collections
 import contextlib
+import os
 import shutil
 import tempfile
 
@@ -82,6 +83,10 @@ class OutputToFile(object):
   @staticmethod
   def open_file(filename):
     """Override method to alter file open behavior or file types."""
+    basepath = os.path.dirname(filename)
+
+    os.makedirs(basepath, exist_ok=True)
+
     return Atomic(filename)
 
   def create_file_name(self, test_record):


### PR DESCRIPTION
If needed, create the directory for the intended output file. This
allows outputs to be grouped into subdirectories instead of only in the
main history directory.