### PR TITLE
Partially modernize build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel>=0.29.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[wheel]
+[bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ setup(
     author_email='madsci@google.com',
     maintainer='Joe Ethier',
     maintainer_email='jethier@google.com',
-    packages=find_packages(exclude='examples'),
+    packages=find_packages(include=['openhtf.*']),
     package_data={'openhtf': ['output/proto/*.proto',
                               'output/web_gui/dist/*.*',
                               'output/web_gui/dist/css/*',

--- a/setup.py
+++ b/setup.py
@@ -216,9 +216,6 @@ setup(
             'pandas>=0.22.0,<0.25.0',
         ],
     },
-    setup_requires=[
-        'wheel>=0.29.0,<1.0',
-    ],
     tests_require=[
         'mock>=2.0.0',
         # Remove max version here after we drop Python 2 support.

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ setup(
             'pyserial>=3.3.0,<4.0',
         ],
         'examples': [
-            'pandas>=0.22.0,<0.25.0',
+            'pandas>=0.22.0',
         ],
     },
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ INSTALL_REQUIRES = [
     'attrs>=19.3.0',
     'colorama>=0.3.9,<1.0',
     'contextlib2>=0.5.1,<1.0',
+    'enum34>=1.1.2,<2.0 ; python_version<"3.4"',
     'future>=0.16.0',
     'mutablerecords>=0.4.1,<2.0',
     'oauth2client>=1.5.2,<2.0',
@@ -138,11 +139,6 @@ INSTALL_REQUIRES = [
     'tornado>=4.3,<5.0',
     'six>=1.12.0',
 ]
-# Not all versions of setuptools support semicolon syntax for specifying
-# platform-specific dependencies, so we do it the old school way.
-if sys.version_info < (3,4):
-  INSTALL_REQUIRES.append('enum34>=1.1.2,<2.0')
-
 
 
 class PyTestCommand(test):

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,7 @@ setup(
                               'output/web_gui/dist/js/*',
                               'output/web_gui/dist/img/*',
                               'output/web_gui/*.*']},
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
     cmdclass={
         'build_proto': BuildProtoCommand,
         'clean': CleanCommand,


### PR DESCRIPTION
This adds a `pyproject.toml`, which allows you to declare the (python) requirements for your build system.

This allows us to drop at least one compatibility anti-feature: the conditional dependency on `enum34` (which won't work properly with wheels).

I also fixed an issue in `find_packages` where you were shipping a top-level package called `pylint_plugins`, which I assume was unintentional. See [the commit message](https://github.com/google/openhtf/commit/082c552b8f8b0ddd0f07cc805e95639969347f64) for more details.

I've dropped the maximum version pin on `pandas` in the `examples` extra, because `python_requires` should handle that, but I didn't drop it in `tests_require`, because you seem to be using the deprecated `setup.py test` mechanism for executing your tests, with a `tests_require` — I believe this may install via the deprecated and long-unmaintained `easy_install` mechanism in `setuptools`, which I think doesn't support `python_requires`.

I think the ideal situation would be to drop all the custom `setup.py` commands and do a direct `pytest` invocation in `tox.ini`. I also strongly recommend dropping all references to `-e .` and `usedevelop=True` and instead [test the package as installed](https://blog.ganssle.io/articles/2019/08/test-as-installed.html) — either by switching to the `src/` layout or using one of the `cd` tricks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/943)
<!-- Reviewable:end -->
