### PR TITLE
Correct type hint for test_start param in Test.execute()

### DIFF
--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -267,7 +267,7 @@ class Test(object):
         self._executor.abort()
 
   def execute(self,
-              test_start: Optional[phase_descriptor.PhaseT] = None,
+              test_start: Optional[Union[phase_descriptor.PhaseT, Callable[[], str]]] = None,
               profile_filename: Optional[Text] = None) -> bool:
     """Starts the framework and executes the given test.
 


### PR DESCRIPTION
The function docstring says `test_start` can be
> Either a trigger phase for starting the test, or a function that returns a DUT ID.

Unfortunately, when you provide the latter, Mypy is unhappy:
```
Argument "test_start" to "execute" of "Test" has incompatible type "Callable[[], str]"; expected "Union[PhaseDescriptor, Callable[..., Optional[PhaseResult]], None]"  [arg-type]
```

This commit updates the type hint of the parameter to be a Union that reflects the docstring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/975)
<!-- Reviewable:end -->
