### PR TITLE
Don't complain about uninitialized plugs in StationServer logs

### DIFF
--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -21,6 +21,7 @@ import copy
 import difflib
 import enum
 import itertools
+import inspect
 import logging
 import math
 import numbers
@@ -168,13 +169,8 @@ def convert_to_base_types(obj,
 
   if hasattr(obj, 'as_base_types'):
     return obj.as_base_types()
-  if hasattr(obj, '_asdict'):
-    try:
-      obj = obj._asdict()
-    except TypeError as e:
-      # This happens if the object is an uninitialized class.
-      logging.warning(
-          'Object %s is not initialized, got error %s', obj, e)
+  if hasattr(obj, '_asdict') and not inspect.isclass(obj):
+    obj = obj._asdict()
   elif isinstance(obj, records.RecordClass):
     new_obj = {}
     for a in type(obj).all_attribute_names:


### PR DESCRIPTION
StationServer seems to be trying to represent (as base type) phase sequences that don't yet have their plugs initialized. This causes a warning to be logged like
```
WARNING:root:Object <class 'my.custom.htf.Plug'> is not initialized, got error _asdict() missing 1 required positional argument: 'self'
```
But has no other effect.

The call stack when that warning is reached is
```
convert_to_base_types (data.py:176)
<dictcomp> (data.py:199)
convert_to_base_types (data.py:201)
<listcomp> (data.py:204)
convert_to_base_types (data.py:206)
<dictcomp> (data.py:199)
convert_to_base_types (data.py:201)
<listcomp> (station_server.py:364)
get (station_server.py:364)
_execute (web.py:1702)
_run (events.py:145)
_run_once (base_events.py:1451)
run_forever (base_events.py:438)
start (asyncio.py:199)
run (web_gui_server.py:157)
run (station_server.py:626)
_bootstrap_inner (threading.py:916)
_bootstrap (threading.py:884)
```

This PR removes that warning, behaviour remains the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/991)
<!-- Reviewable:end -->
