### PR TITLE
Add subtest_previous PhaseFailureCheckpoint

### DIFF
--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -362,7 +362,7 @@ class PhaseExecutor(object):
       subtest_name = None
     evaluated_millis = util.time_millis()
     try:
-      outcome = PhaseExecutionOutcome(checkpoint.get_result(self.test_state))
+      outcome = PhaseExecutionOutcome(checkpoint.get_result(self.test_state, subtest_rec))
       self.logger.debug('Checkpoint %s result: %s', checkpoint.name,
                         outcome.phase_result)
       if outcome.is_fail_subtest and not subtest_rec:

--- a/test/core/phase_branches_test.py
+++ b/test/core/phase_branches_test.py
@@ -434,6 +434,170 @@ class PhaseFailureCheckpointIntegrationTest(htf_test.TestCase):
     ], test_rec.checkpoints)
 
   @htf_test.yields_phases
+  def test_subtest_previous_fail__fail(self):
+    test_rec = yield htf.Test(
+        fail_phase,
+        phase0,
+        phase_branches.PhaseFailureCheckpoint.subtest_previous(
+            'subtest_previous_fail', action=htf.PhaseResult.STOP), error_phase)
+
+    self.assertTestFail(test_rec)
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.PASS, test_rec,
+                                   'phase0')
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.FAIL, test_rec,
+                                   'fail_phase')
+
+    self.assertEqual([
+        test_record.CheckpointRecord(
+            name='subtest_previous_fail',
+            action=htf.PhaseResult.STOP,
+            conditional=phase_branches.PreviousPhases.SUBTEST,
+            subtest_name=None,
+            result=phase_executor.PhaseExecutionOutcome(
+                htf.PhaseResult.STOP),
+            evaluated_millis=htf_test.VALID_TIMESTAMP),
+    ], test_rec.checkpoints)
+
+  @htf_test.yields_phases
+  def test_subtest_previous_fail__pass(self):
+    test_rec = yield htf.Test(
+        phase0,
+        phase1,
+        phase_branches.PhaseFailureCheckpoint.subtest_previous(
+            'subtest_previous_pass', action=htf.PhaseResult.STOP), phase2)
+
+    self.assertTestPass(test_rec)
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.PASS, test_rec,
+                                   'phase0', 'phase1', 'phase2')
+
+    self.assertEqual([
+        test_record.CheckpointRecord(
+            name='subtest_previous_pass',
+            action=htf.PhaseResult.STOP,
+            conditional=phase_branches.PreviousPhases.SUBTEST,
+            subtest_name=None,
+            result=phase_executor.PhaseExecutionOutcome(
+                htf.PhaseResult.CONTINUE),
+            evaluated_millis=htf_test.VALID_TIMESTAMP),
+    ], test_rec.checkpoints)
+
+  @htf_test.yields_phases
+  def test_subtest_previous_fail__fail_in_subtest(self):
+    test_rec = yield htf.Test(
+        phase0,
+        htf.Subtest(
+          'sub', fail_phase, phase1, 
+          phase_branches.PhaseFailureCheckpoint.subtest_previous(
+            'subtest_previous_fail_in_subtest', action=htf.PhaseResult.STOP), 
+        ),
+        error_phase)
+
+    self.assertTestFail(test_rec)
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.PASS, test_rec,
+                                   'phase0', 'phase1')
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.FAIL, test_rec,
+                                   'fail_phase')
+
+    self.assertEqual([
+        test_record.CheckpointRecord(
+            name='subtest_previous_fail_in_subtest',
+            action=htf.PhaseResult.STOP,
+            conditional=phase_branches.PreviousPhases.SUBTEST,
+            subtest_name='sub',
+            result=phase_executor.PhaseExecutionOutcome(
+                htf.PhaseResult.STOP),
+            evaluated_millis=htf_test.VALID_TIMESTAMP),
+    ], test_rec.checkpoints)
+
+  @htf_test.yields_phases
+  def test_subtest_previous_fail__fail_out_of_subtest(self):
+    test_rec = yield htf.Test(
+        fail_phase,
+        htf.Subtest(
+          'sub', phase0, 
+          phase_branches.PhaseFailureCheckpoint.subtest_previous(
+            'subtest_previous_fail_out_of_subtest', action=htf.PhaseResult.STOP), 
+          phase1,
+        ),
+        phase2)
+
+    self.assertTestFail(test_rec)
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.PASS, test_rec,
+                                   'phase0', 'phase1', 'phase2')
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.FAIL, test_rec,
+                                   'fail_phase')
+
+    self.assertEqual([
+        test_record.CheckpointRecord(
+            name='subtest_previous_fail_out_of_subtest',
+            action=htf.PhaseResult.STOP,
+            conditional=phase_branches.PreviousPhases.SUBTEST,
+            subtest_name='sub',
+            result=phase_executor.PhaseExecutionOutcome(
+                htf.PhaseResult.CONTINUE),
+            evaluated_millis=htf_test.VALID_TIMESTAMP),
+    ], test_rec.checkpoints)
+
+  @htf_test.yields_phases
+  def test_subtest_previous_fail__pass_in_subtest(self):
+    test_rec = yield htf.Test(
+        phase0,
+        htf.Subtest(
+          'sub', phase1, 
+          phase_branches.PhaseFailureCheckpoint.subtest_previous(
+            'subtest_previous_pass_in_subtest', action=htf.PhaseResult.STOP),
+          phase2,
+        ), phase3)
+
+    self.assertTestPass(test_rec)
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.PASS, test_rec,
+                                   'phase0', 'phase1', 'phase2', 'phase3')
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.FAIL, test_rec,
+                                   'fail_phase')
+
+    self.assertEqual([
+        test_record.CheckpointRecord(
+            name='subtest_previous_pass_in_subtest',
+            action=htf.PhaseResult.STOP,
+            conditional=phase_branches.PreviousPhases.SUBTEST,
+            subtest_name='sub',
+            result=phase_executor.PhaseExecutionOutcome(
+                htf.PhaseResult.CONTINUE),
+            evaluated_millis=htf_test.VALID_TIMESTAMP),
+    ], test_rec.checkpoints)
+
+  @htf_test.yields_phases
+  def test_subtest_previous_fail_subtest__fail_in_subtest(self):
+    test_rec = yield htf.Test(
+        phase0,
+        htf.Subtest(
+          'sub', fail_phase, phase1, 
+          phase_branches.PhaseFailureCheckpoint.subtest_previous(
+            'subtest_previous_fail_subtest_in_subtest', action=htf.PhaseResult.FAIL_SUBTEST), 
+          skip0,
+        ),
+        phase2)
+
+    self.assertTestFail(test_rec)
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.PASS, test_rec,
+                                   'phase0', 'phase1', 'phase2')
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.FAIL, test_rec,
+                                   'fail_phase')
+    self.assertPhasesOutcomeByName(test_record.PhaseOutcome.SKIP, test_rec, 'skip0')
+
+    self.assertEqual([
+        test_record.CheckpointRecord(
+            name='subtest_previous_fail_subtest_in_subtest',
+            action=htf.PhaseResult.FAIL_SUBTEST,
+            conditional=phase_branches.PreviousPhases.SUBTEST,
+            subtest_name='sub',
+            result=phase_executor.PhaseExecutionOutcome(
+                htf.PhaseResult.FAIL_SUBTEST),
+            evaluated_millis=htf_test.VALID_TIMESTAMP),
+    ], test_rec.checkpoints)
+
+
+  @htf_test.yields_phases
   def test_all__no_previous_phases(self):
     self.test_start_function = None
     test_rec = yield htf.Test(


### PR DESCRIPTION
The `PhaseFailureCheckpoint` currently only supports two modes of failure checking: `last` and `all_previous`. As noted in the docstring for the `PhaseFailureCheckpoint`, the `all_previous` does not play well with subtests:

>   When using `all_previous`, this will take in to account all phases; it will
>   *NOT* limit itself to the subtest when using the FAIL_SUBTEST action.

To remedy this, this PR adds support for a `subtest_previous` mode which checks all phases in the same subtest as the checkpoint, or if the checkpoint is not in any subtest falls back to the behavior of `all_previous`. 

This allows one to use a checkpoint to short-circuit execution of a subtest, without quitting the overall test. A good example of this can be seen in the unittest `test_subtest_previous_fail_subtest__fail_in_subtest`. We construct a phasegroup as follows:
```
htf.Subtest(
         htf.Test(
        phase0,
        htf.Subtest(
          'sub', fail_phase, phase1, 
          phase_branches.PhaseFailureCheckpoint.subtest_previous(
            'subtest_previous_fail_subtest_in_subtest', action=htf.PhaseResult.FAIL_SUBTEST), 
          skip0,
        ),
        phase2)
```
Which results in the following execution:

- phase0: PASS
- fail_phase: FAIL
- phase1: PASS
- checkpoint: FAIL_SUBTEST
- skip0: SKIP
- phase2: PASS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/992)
<!-- Reviewable:end -->
