### PR TITLE
Added support for marginal test results to the protos.

### DIFF
--- a/openhtf/output/proto/mfg_event.proto
+++ b/openhtf/output/proto/mfg_event.proto
@@ -85,6 +85,10 @@ message Measurement {
   optional double numeric_minimum = 12;
   optional double numeric_maximum = 13;
 
+  // Fields to determine numeric marginality which are used in RangeValidators.
+  optional double numeric_marginal_minimum = 25;
+  optional double numeric_marginal_maximum = 26;
+
   // If this parameter is text then fill in these fields
   optional string text_value = 14;
   // This field may be a regular expression describing the expected value
@@ -100,9 +104,11 @@ message Measurement {
   // Created for visualization by UIs that don't support certain fancy
   // parameters. UIs that do support them should hide these parameters.
   optional string associated_attachment = 21;
-  // Next tag = 24
+  // Next tag = 27
 
   extensions 5000 to 5199;
+
+  reserved 24;
 }
 
 // A parameter which is extra information from a test run.  These values are not

--- a/openhtf/output/proto/test_runs.proto
+++ b/openhtf/output/proto/test_runs.proto
@@ -75,6 +75,7 @@ enum Status {
   REWORK = 12;
   SCRAP = 13;
   DEBUG = 14;
+  MARGINAL_PASS = 15;
 }
 
 
@@ -127,6 +128,10 @@ message TestParameter {
   optional double numeric_minimum = 12;
   optional double numeric_maximum = 13;
 
+  // Fields to determine numeric marginality which are used in RangeValidators.
+  optional double numeric_marginal_minimum = 26;
+  optional double numeric_marginal_maximum = 27;
+
   // If this parameter is text then fill in these fields
   optional string text_value = 14;
   // This field may be a regular expression describing the expected value
@@ -139,9 +144,11 @@ message TestParameter {
   // Created for visualization by UIs that don't support certain fancy
   // parameters. UIs that do support them should hide these parameters.
   optional string associated_attachment = 21;
-  // Next tag = 22
+  // Next tag = 28
 
   extensions 5000 to 5199;
+
+  reserved 25;
 }
 
 


### PR DESCRIPTION
# What I did
I added support for marginal test results to `mfg_event.proto` and `test_runs.proto` as  `openhtf/output/proto/mfg_event_converter.py` is already expected to have those protos updated (as of https://github.com/google/openhtf/commit/4646aa6b9ba67532ce7e8743ce16d7bd4369ad3d).

# Why I did it
Our OpenHTF unit tests are not running anymore because travis-ci.org is deprecated. Commits have been submitted without having the CI/CD flow run. In a followup pull request I'm going to add support for GitHub Actions CI/CD flow to prevent such breakage from happening again. This commit should allow unit tests to run successfully again!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1002)
<!-- Reviewable:end -->
