### PR TITLE
Removed support for PY2.

### DIFF
--- a/bin/units_from_xls.py
+++ b/bin/units_from_xls.py
@@ -44,7 +44,6 @@ import shutil
 import sys
 import tempfile
 
-import six
 import xlrd
 
 # Column names for the columns we care about. This list must be populated in
@@ -163,10 +162,10 @@ UNIT_KEY_REPLACEMENTS = {
     '15': 'FIFTEEN',
     '30': 'THIRTY',
     '\\': '_',
-    six.unichr(160): '_',  # NO-BREAK SPACE
-    six.unichr(176): 'DEG_',  # DEGREE SIGN
-    six.unichr(186): 'DEG_',  # MASCULINE ORDINAL INDICATOR
-    six.unichr(8211): '_',  # EN DASH
+    chr(160): '_',  # NO-BREAK SPACE
+    chr(176): 'DEG_',  # DEGREE SIGN
+    chr(186): 'DEG_',  # MASCULINE ORDINAL INDICATOR
+    chr(8211): '_',  # EN DASH
 }
 
 
@@ -222,7 +221,7 @@ def unit_defs_from_sheet(sheet, column_names):
     rows = sheet.get_rows()
 
     # Find the indices for the columns we care about.
-    for idx, cell in enumerate(six.next(rows)):
+    for idx, cell in enumerate(next(rows)):
       if cell.value in column_names:
         col_indices[cell.value] = idx
 
@@ -250,7 +249,7 @@ def unit_key_from_name(name):
   """Return a legal python name for the given name for use as a unit key."""
   result = name
 
-  for old, new in six.iteritems(UNIT_KEY_REPLACEMENTS):
+  for old, new in UNIT_KEY_REPLACEMENTS.items():
     result = result.replace(old, new)
 
   # Collapse redundant underscores and convert to uppercase.

--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -28,8 +28,6 @@ from openhtf.output.callbacks import console_summary
 from openhtf.output.callbacks import json_factory
 from openhtf.plugs import user_input
 from openhtf.util import units
-from six.moves import range
-from six.moves import zip
 
 
 @htf.plug(example=example_plugs.example_plug_configured)

--- a/openhtf/core/diagnoses_lib.py
+++ b/openhtf/core/diagnoses_lib.py
@@ -327,7 +327,7 @@ class _BaseDiagnoser(object):
     pass
 
 
-class BasePhaseDiagnoser(_BaseDiagnoser, metaclass=abc.ABCMeta):
+class BasePhaseDiagnoser(_BaseDiagnoser, abc.ABC):
   """Base class for using an object to define a Phase diagnoser."""
 
   __slots__ = ()
@@ -376,7 +376,7 @@ class PhaseDiagnoser(BasePhaseDiagnoser):
           'PhaseDiagnoser run function not defined for {}'.format(self.name))
 
 
-class BaseTestDiagnoser(_BaseDiagnoser, metaclass=abc.ABCMeta):
+class BaseTestDiagnoser(_BaseDiagnoser, abc.ABC):
   """Base class for using an object to define a Test diagnoser."""
 
   __slots__ = ()

--- a/openhtf/core/diagnoses_lib.py
+++ b/openhtf/core/diagnoses_lib.py
@@ -122,15 +122,14 @@ still run.
 """
 
 import abc
+import collections
+import enum
 import logging
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Text, Type, TYPE_CHECKING, Union
 
 import attr
-import enum  # pylint: disable=g-bad-import-order
 from openhtf.core import test_record
 from openhtf.util import data
-import six
-from six.moves import collections_abc
 
 if TYPE_CHECKING:
   from openhtf.core import test_state  # pylint: disable=g-import-not-at-top
@@ -204,8 +203,8 @@ class DiagnosesManager(object):
       return
     elif isinstance(diagnosis_or_diagnoses, Diagnosis):
       yield self._verify_and_fix_diagnosis(diagnosis_or_diagnoses, diagnoser)
-    elif (isinstance(diagnosis_or_diagnoses, six.string_types) or
-          not isinstance(diagnosis_or_diagnoses, collections_abc.Iterable)):
+    elif (isinstance(diagnosis_or_diagnoses, str) or
+          not isinstance(diagnosis_or_diagnoses, collections.abc.Iterable)):
       raise InvalidDiagnosisError(
           'Diagnoser {} must return a single Diagnosis or an iterable '
           'of them.'.format(diagnoser.name))
@@ -328,7 +327,7 @@ class _BaseDiagnoser(object):
     pass
 
 
-class BasePhaseDiagnoser(six.with_metaclass(abc.ABCMeta, _BaseDiagnoser)):
+class BasePhaseDiagnoser(_BaseDiagnoser, metaclass=abc.ABCMeta):
   """Base class for using an object to define a Phase diagnoser."""
 
   __slots__ = ()
@@ -377,7 +376,7 @@ class PhaseDiagnoser(BasePhaseDiagnoser):
           'PhaseDiagnoser run function not defined for {}'.format(self.name))
 
 
-class BaseTestDiagnoser(six.with_metaclass(abc.ABCMeta, _BaseDiagnoser)):
+class BaseTestDiagnoser(_BaseDiagnoser, metaclass=abc.ABCMeta):
   """Base class for using an object to define a Test diagnoser."""
 
   __slots__ = ()

--- a/openhtf/core/diagnoses_lib.py
+++ b/openhtf/core/diagnoses_lib.py
@@ -122,7 +122,7 @@ still run.
 """
 
 import abc
-import collections
+from collections.abc import Iterable as CollectionsIterable
 import enum
 import logging
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Text, Type, TYPE_CHECKING, Union
@@ -204,7 +204,7 @@ class DiagnosesManager(object):
     elif isinstance(diagnosis_or_diagnoses, Diagnosis):
       yield self._verify_and_fix_diagnosis(diagnosis_or_diagnoses, diagnoser)
     elif (isinstance(diagnosis_or_diagnoses, str) or
-          not isinstance(diagnosis_or_diagnoses, collections.abc.Iterable)):
+          not isinstance(diagnosis_or_diagnoses, CollectionsIterable)):
       raise InvalidDiagnosisError(
           'Diagnoser {} must return a single Diagnosis or an iterable '
           'of them.'.format(diagnoser.name))

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -71,7 +71,6 @@ from openhtf import util
 from openhtf.util import data
 from openhtf.util import units as util_units
 from openhtf.util import validators
-import six
 if typing.TYPE_CHECKING:
   from openhtf.core import diagnoses_lib
 
@@ -147,7 +146,7 @@ def _coordinates_len(coordinates: Any) -> int:
     coordinates: any type, measurement coordinates for multidimensional
       measurements.
   """
-  if isinstance(coordinates, six.string_types):
+  if isinstance(coordinates, str):
     return 1
   if hasattr(coordinates, '__len__'):
     return len(coordinates)
@@ -361,7 +360,7 @@ class Measurement(object):
     Returns:
       This measurement, used for chaining operations.
     """
-    for result, validator in six.iteritems(result_to_validator_mapping):
+    for result, validator in result_to_validator_mapping.items():
       if not callable(validator):
         raise ValueError('Validator must be callable', validator)
       self.conditional_validators.append(
@@ -658,7 +657,7 @@ class DimensionedMeasuredValue(object):
 
   def __iter__(self) -> Iterator[Any]:
     """Iterate over items, allows easy conversion to a dict."""
-    return iter(six.iteritems(self.value_dict))
+    return iter(self.value_dict.items())
 
   def __setitem__(self, coordinates: Any, value: Any) -> None:
     coordinates_len = _coordinates_len(coordinates)
@@ -717,14 +716,14 @@ class DimensionedMeasuredValue(object):
       raise MeasurementNotSetError('Measurement not yet set', self.name)
     return [
         dimensions + (value,)
-        for dimensions, value in six.iteritems(self.value_dict)
+        for dimensions, value in self.value_dict.items()
     ]
 
   def basetype_value(self) -> List[Any]:
     if self._cached_basetype_values is None:
       self._cached_basetype_values = list(
           data.convert_to_base_types(coordinates + (value,))
-          for coordinates, value in six.iteritems(self.value_dict))
+          for coordinates, value in self.value_dict.items())
     return self._cached_basetype_values
 
   def to_dataframe(self, columns: Any = None) -> Any:
@@ -791,7 +790,7 @@ class Collection(object):
   def __iter__(self) -> Iterator[Tuple[Text, Any]]:
     """Extract each MeasurementValue's value."""
     return ((key, meas.measured_value.value)
-            for key, meas in six.iteritems(self._measurements))
+            for key, meas in self._measurements.items())
 
   def _custom_setattr(self, name: Text, value: Any) -> None:
     if name == '_measurements':

--- a/openhtf/core/monitors.py
+++ b/openhtf/core/monitors.py
@@ -76,14 +76,9 @@ class _MonitorThread(threads.KillableThread):
     self.extra_kwargs = extra_kwargs
 
   def get_value(self) -> Any:
-    if six.PY3:
-      argspec = inspect.getfullargspec(self.monitor_desc.func)
-      argspec_args = argspec.args
-      argspec_keywords = argspec.varkw
-    else:
-      argspec = inspect.getargspec(self.monitor_desc.func)  # pylint: disable=deprecated-method
-      argspec_args = argspec.args
-      argspec_keywords = argspec.keywords
+    argspec = inspect.getfullargspec(self.monitor_desc.func)
+    argspec_args = argspec.args
+    argspec_keywords = argspec.varkw
     if argspec_keywords:
       # Monitor phase takes **kwargs, so just pass everything in.
       kwargs = self.extra_kwargs

--- a/openhtf/core/phase_branches.py
+++ b/openhtf/core/phase_branches.py
@@ -141,7 +141,7 @@ class BranchSequence(phase_collections.PhaseSequence):
 
 
 @attr.s(slots=True, frozen=True)
-class Checkpoint(phase_nodes.PhaseNode, metaclass=abc.ABCMeta):
+class Checkpoint(phase_nodes.PhaseNode, abc.ABC):
   """Nodes that check for phase failures or if diagnoses were triggered.
 
   When the condition for a checkpoint is triggered, a STOP or FAIL_SUBTEST

--- a/openhtf/core/phase_branches.py
+++ b/openhtf/core/phase_branches.py
@@ -19,10 +19,10 @@ diagnosis results of the test run.
 """
 
 import abc
+import enum
 from typing import Any, Callable, Dict, Iterator, Text, Tuple, TYPE_CHECKING, Union
 
 import attr
-import enum  # pylint: disable=g-bad-import-order
 from openhtf import util
 from openhtf.core import diagnoses_lib
 from openhtf.core import phase_collections
@@ -30,7 +30,6 @@ from openhtf.core import phase_descriptor
 from openhtf.core import phase_nodes
 from openhtf.core import test_record
 from openhtf.util import data
-import six
 
 if TYPE_CHECKING:
   from openhtf.core import test_state  # pylint: disable=g-import-not-at-top
@@ -142,7 +141,7 @@ class BranchSequence(phase_collections.PhaseSequence):
 
 
 @attr.s(slots=True, frozen=True)
-class Checkpoint(six.with_metaclass(abc.ABCMeta, phase_nodes.PhaseNode)):
+class Checkpoint(phase_nodes.PhaseNode, metaclass=abc.ABCMeta):
   """Nodes that check for phase failures or if diagnoses were triggered.
 
   When the condition for a checkpoint is triggered, a STOP or FAIL_SUBTEST

--- a/openhtf/core/phase_collections.py
+++ b/openhtf/core/phase_collections.py
@@ -61,7 +61,7 @@ def flatten(n: Any) -> List[phase_nodes.PhaseNode]:
   return list(_recursive_flatten(n))
 
 
-class PhaseCollectionNode(phase_nodes.PhaseNode, metaclass=abc.ABCMeta):
+class PhaseCollectionNode(phase_nodes.PhaseNode, abc.ABC):
   """Base class for a node that contains multiple other phase nodes."""
 
   __slots__ = ()

--- a/openhtf/core/phase_collections.py
+++ b/openhtf/core/phase_collections.py
@@ -29,8 +29,6 @@ from openhtf import util
 from openhtf.core import base_plugs
 from openhtf.core import phase_descriptor
 from openhtf.core import phase_nodes
-import six
-from six.moves import collections_abc
 
 NodeType = TypeVar('NodeType', bound=phase_nodes.PhaseNode)
 SequenceClassT = TypeVar('SequenceClassT', bound='PhaseSequence')
@@ -45,7 +43,7 @@ class DuplicateSubtestNamesError(Exception):
 
 def _recursive_flatten(n: Any) -> Iterator[phase_nodes.PhaseNode]:
   """Yields flattened phase nodes."""
-  if isinstance(n, collections_abc.Iterable):
+  if isinstance(n, collections.abc.Iterable):
     for it in n:
       for node in _recursive_flatten(it):
         yield node
@@ -62,8 +60,7 @@ def flatten(n: Any) -> List[phase_nodes.PhaseNode]:
   return list(_recursive_flatten(n))
 
 
-class PhaseCollectionNode(
-    six.with_metaclass(abc.ABCMeta, phase_nodes.PhaseNode)):
+class PhaseCollectionNode(phase_nodes.PhaseNode, metaclass=abc.ABCMeta):
   """Base class for a node that contains multiple other phase nodes."""
 
   __slots__ = ()

--- a/openhtf/core/phase_collections.py
+++ b/openhtf/core/phase_collections.py
@@ -22,6 +22,7 @@ skipped.
 
 import abc
 import collections
+from collections.abc import Iterable as CollectionsIterable
 from typing import Any, Callable, DefaultDict, Dict, Iterable, Iterator, List, Optional, Text, Tuple, Type, TypeVar, Union
 
 import attr
@@ -43,7 +44,7 @@ class DuplicateSubtestNamesError(Exception):
 
 def _recursive_flatten(n: Any) -> Iterator[phase_nodes.PhaseNode]:
   """Yields flattened phase nodes."""
-  if isinstance(n, collections.abc.Iterable):
+  if isinstance(n, CollectionsIterable):
     for it in n:
       for node in _recursive_flatten(it):
         yield node

--- a/openhtf/core/phase_descriptor.py
+++ b/openhtf/core/phase_descriptor.py
@@ -37,8 +37,6 @@ from openhtf.core import test_record
 import openhtf.plugs
 from openhtf.util import data
 
-import six
-
 if TYPE_CHECKING:
   from openhtf.core import test_state  # pylint: disable=g-import-not-at-top
 
@@ -134,7 +132,7 @@ class PhaseOptions(object):
     return data.attr_copy(self, name=util.format_string(self.name, kwargs))
 
   def update(self, **kwargs: Any) -> None:
-    for key, value in six.iteritems(kwargs):
+    for key, value in kwargs.items():
       setattr(self, key, value)
 
   def __call__(self, phase_func: PhaseT) -> 'PhaseDescriptor':
@@ -245,14 +243,10 @@ class PhaseDescriptor(phase_nodes.PhaseNode):
     Returns:
       Updated PhaseDescriptor.
     """
-    if six.PY3:
-      argspec = inspect.getfullargspec(self.func)
-      argspec_keywords = argspec.varkw
-    else:
-      argspec = inspect.getargspec(self.func)  # pylint: disable=deprecated-method
-      argspec_keywords = argspec.keywords
+    argspec = inspect.getfullargspec(self.func)
+    argspec_keywords = argspec.varkw
     known_arguments = {}
-    for key, arg in six.iteritems(kwargs):
+    for key, arg in kwargs.items():
       if key in argspec.args or argspec_keywords:
         known_arguments[key] = arg
 
@@ -283,7 +277,7 @@ class PhaseDescriptor(phase_nodes.PhaseNode):
     plugs_by_name = {plug.name: plug for plug in self.plugs}
     new_plugs = {}
 
-    for name, sub_class in six.iteritems(subplugs):
+    for name, sub_class in subplugs.items():
       original_plug = plugs_by_name.get(name)
       accept_substitute = True
       if original_plug is None:
@@ -341,12 +335,8 @@ class PhaseDescriptor(phase_nodes.PhaseNode):
       The return value from calling the underlying function.
     """
     kwargs = {}
-    if six.PY3:
-      arg_info = inspect.getfullargspec(self.func)
-      keywords = arg_info.varkw
-    else:
-      arg_info = inspect.getargspec(self.func)  # pylint: disable=deprecated-method
-      keywords = arg_info.keywords
+    arg_info = inspect.getfullargspec(self.func)
+    keywords = arg_info.varkw
     if arg_info.defaults is not None:
       for arg_name, arg_value in zip(arg_info.args[-len(arg_info.defaults):],
                                      arg_info.defaults):
@@ -419,7 +409,7 @@ def measures(*measurements: Union[Text, core_measurements.Measurement],
     """Turn strings into Measurement objects if necessary."""
     if isinstance(meas, core_measurements.Measurement):
       return meas
-    elif isinstance(meas, six.string_types):
+    elif isinstance(meas, str):
       return core_measurements.Measurement(meas, **kwargs)
     raise core_measurements.InvalidMeasurementTypeError(
         'Expected Measurement or string', meas)

--- a/openhtf/core/phase_nodes.py
+++ b/openhtf/core/phase_nodes.py
@@ -27,7 +27,7 @@ WithModifierT = TypeVar('WithModifierT', bound='PhaseNode')
 ApplyAllNodesT = TypeVar('ApplyAllNodesT', bound='PhaseNode')
 
 
-class PhaseNode(metaclass=abc.ABCMeta):
+class PhaseNode(abc.ABC):
   """Base class for all executable nodes in OpenHTF."""
 
   __slots__ = ()

--- a/openhtf/core/phase_nodes.py
+++ b/openhtf/core/phase_nodes.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Dict, Optional, Text, Type, TypeVar, TYPE_CHEC
 
 from openhtf.core import base_plugs
 from openhtf.util import data
-import six
 
 if TYPE_CHECKING:
   from openhtf.core import phase_descriptor  # pylint: disable=g-import-not-at-top
@@ -28,7 +27,7 @@ WithModifierT = TypeVar('WithModifierT', bound='PhaseNode')
 ApplyAllNodesT = TypeVar('ApplyAllNodesT', bound='PhaseNode')
 
 
-class PhaseNode(six.with_metaclass(abc.ABCMeta, object)):
+class PhaseNode(metaclass=abc.ABCMeta):
   """Base class for all executable nodes in OpenHTF."""
 
   __slots__ = ()

--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -50,8 +50,6 @@ from openhtf.util import configuration
 from openhtf.util import console_output
 from openhtf.util import logs
 
-import six
-
 CONF = configuration.CONF
 
 _LOG = logging.getLogger(__name__)
@@ -247,7 +245,7 @@ class Test(object):
       sys.stdout.write(CONF.help_text)
       sys.exit(0)
     logs.configure_logging()
-    for key, value in six.iteritems(kwargs):
+    for key, value in kwargs.items():
       setattr(self._test_options, key, value)
 
   @classmethod

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -175,11 +175,12 @@ class TestExecutor(threads.KillableThread):
     """Waits until death."""
     # Must use a timeout here in case this is called from the main thread.
     # Otherwise, the SIGINT abort logic in test_descriptor will not get called.
-    timeout = 31557600  # Seconds in a year.
-    if sys.version_info >= (3, 2):
-      # TIMEOUT_MAX can be too large and cause overflows on 32-bit OSes, so take
-      # whichever timeout is shorter.
-      timeout = min(threading.TIMEOUT_MAX, timeout)  # pytype: disable=module-attr
+    # TIMEOUT_MAX can be too large and cause overflows on 32-bit OSes, so take
+    # whichever timeout is shorter.
+    timeout = min(
+        threading.TIMEOUT_MAX,
+        31557600,  # Seconds in a year.
+    )
     self.join(timeout)
 
   def _thread_proc(self) -> None:

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """OpenHTF module responsible for managing records of tests."""
 
+import enum
 import hashlib
 import inspect
 import logging
@@ -21,14 +22,11 @@ import tempfile
 from typing import Any, Dict, List, Optional, Text, TYPE_CHECKING, Union
 
 import attr
-import enum  # pylint: disable=g-bad-import-order
 
 from openhtf import util
 from openhtf.util import configuration
 from openhtf.util import data
 from openhtf.util import logs
-
-import six
 
 CONF = configuration.CONF
 
@@ -83,7 +81,8 @@ class Attachment(object):
   size = attr.ib(type=int)
 
   def __init__(self, contents: Union[Text, bytes], mimetype: Text):
-    contents = six.ensure_binary(contents)
+    if isinstance(contents, str):
+      contents = contents.encode()
     self.mimetype = mimetype
     self.sha1 = hashlib.sha1(contents).hexdigest()
     self.size = len(contents)

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -48,8 +48,6 @@ from openhtf.util import configuration
 from openhtf.util import data
 from openhtf.util import logs
 from openhtf.util import units
-from past.builtins import long
-import six
 from typing_extensions import Literal
 
 CONF = configuration.CONF
@@ -559,7 +557,7 @@ class PhaseState(object):
   _update_measurements = attr.ib(type=Set[Text], factory=set)
 
   def __attrs_post_init__(self):
-    for m in six.itervalues(self.measurements):
+    for m in self.measurements.values():
       # Using functools.partial to capture the value of the loop variable.
       m.set_notification_callback(functools.partial(self._notify, m.name))
     self._cached = {
@@ -573,11 +571,10 @@ class PhaseState(object):
         'options':
             None,
         'measurements': {
-            k: m.as_base_types() for k, m in six.iteritems(self.measurements)
+            k: m.as_base_types() for k, m in self.measurements.items()
         },
         'attachments': {},
-        'start_time_millis':
-            long(self.phase_record.record_start_time()),
+        'start_time_millis': self.phase_record.record_start_time(),
         'subtest_name':
             None,
     }

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -19,7 +19,9 @@ alternative serialization schemes, see json_factory.py and mfg_inspector.py for
 examples.
 """
 
+import collections
 import contextlib
+import pickle
 import shutil
 import tempfile
 import typing
@@ -28,9 +30,6 @@ from typing import BinaryIO, Callable, Iterator, Optional, Text, Union
 from openhtf import util
 from openhtf.core import test_record
 from openhtf.util import data
-import six
-from six.moves import collections_abc
-from six.moves import cPickle as pickle
 
 SerializedTestRecord = Union[Text, bytes, Iterator[Union[Text, bytes]]]
 
@@ -56,7 +55,7 @@ class CloseAttachments(object):
 
   def __call__(self, test_rec: test_record.TestRecord) -> None:
     for phase_rec in test_rec.phases:
-      for attachment in six.itervalues(phase_rec.attachments):
+      for attachment in phase_rec.attachments.values():
         attachment.close()
 
 
@@ -81,7 +80,7 @@ class OutputToFile(object):
                                                      BinaryIO]):
     self.filename_pattern = None  # type: Optional[Union[Text, Callable[..., Text]]]
     self.output_file = None  # type: Optional[BinaryIO]
-    if (isinstance(filename_pattern_or_file, six.string_types) or
+    if (isinstance(filename_pattern_or_file, str) or
         callable(filename_pattern_or_file)):
       self.filename_pattern = filename_pattern_or_file  # pytype: disable=annotation-type-mismatch
     else:
@@ -130,11 +129,11 @@ class OutputToFile(object):
   def __call__(self, test_rec: test_record.TestRecord) -> None:
     with self.open_output_file(test_rec) as outfile:
       serialized_record = self.serialize_test_record(test_rec)
-      if isinstance(serialized_record, six.string_types):
-        outfile.write(six.ensure_binary(serialized_record))
-      elif isinstance(serialized_record, collections_abc.Iterable):
+      if isinstance(serialized_record, str):
+        outfile.write(serialized_record.encode())
+      elif isinstance(serialized_record, collections.abc.Iterable):
         for chunk in serialized_record:
-          outfile.write(six.ensure_binary(chunk))
+          outfile.write(chunk.encode())
       else:
         raise TypeError('Expected string or iterable but got {}.'.format(
             type(serialized_record)))

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -19,7 +19,7 @@ alternative serialization schemes, see json_factory.py and mfg_inspector.py for
 examples.
 """
 
-import collections
+from collections.abc import Iterable
 import contextlib
 import pickle
 import shutil
@@ -131,7 +131,7 @@ class OutputToFile(object):
       serialized_record = self.serialize_test_record(test_rec)
       if isinstance(serialized_record, str):
         outfile.write(serialized_record.encode())
-      elif isinstance(serialized_record, collections.abc.Iterable):
+      elif isinstance(serialized_record, Iterable):
         for chunk in serialized_record:
           outfile.write(chunk.encode())
       else:

--- a/openhtf/output/callbacks/console_summary.py
+++ b/openhtf/output/callbacks/console_summary.py
@@ -5,7 +5,6 @@ import sys
 
 from openhtf.core import measurements
 from openhtf.core import test_record
-import six
 
 
 class ConsoleSummary():
@@ -48,7 +47,7 @@ class ConsoleSummary():
         new_phase = True
         phase_time_sec = (float(phase.end_time_millis) -
                           float(phase.start_time_millis)) / 1000.0
-        for name, measurement in six.iteritems(phase.measurements):
+        for name, measurement in phase.measurements.items():
           if measurement.outcome != measurements.Outcome.PASS:
             if new_phase:
               output_lines.append('failed phase: %s [ran for %.2f sec]' %

--- a/openhtf/output/callbacks/json_factory.py
+++ b/openhtf/output/callbacks/json_factory.py
@@ -7,7 +7,6 @@ from typing import Any, BinaryIO, Callable, Dict, Iterator, Text, Union
 from openhtf.core import test_record
 from openhtf.output import callbacks
 from openhtf.util import data
-import six
 
 
 class TestRecordEncoder(json.JSONEncoder):
@@ -40,7 +39,7 @@ def convert_test_record_to_json(
   as_dict = data.convert_to_base_types(test_rec, json_safe=(not allow_nan))
   if inline_attachments:
     for phase, original_phase in zip(as_dict['phases'], test_rec.phases):
-      for name, attachment in six.iteritems(original_phase.attachments):
+      for name, attachment in original_phase.attachments.items():
         phase['attachments'][name] = attachment
   return as_dict
 

--- a/openhtf/output/callbacks/mfg_inspector.py
+++ b/openhtf/output/callbacks/mfg_inspector.py
@@ -13,8 +13,6 @@ import oauth2client.client
 from openhtf.output import callbacks
 from openhtf.output.proto import guzzle_pb2
 from openhtf.output.proto import test_runs_converter
-import six
-from six.moves import range
 
 
 class UploadFailedError(Exception):
@@ -150,7 +148,7 @@ class MfgInspector(object):
     if user and keydata:
       self.credentials = oauth2client.client.SignedJwtAssertionCredentials(
           service_account_name=self.user,
-          private_key=six.ensure_binary(self.keydata),
+          private_key=self.keydata.encode(),
           scope=self.SCOPE_CODE_URI,
           user_agent='OpenHTF Guzzle Upload Client',
           token_uri=self.token_uri)

--- a/openhtf/output/proto/mfg_event_converter.py
+++ b/openhtf/output/proto/mfg_event_converter.py
@@ -418,10 +418,6 @@ class PhaseCopier(object):
 
     if isinstance(value, numbers.Number):
       mfg_measurement.numeric_value = float(value)
-    elif isinstance(value, bytes):
-      # text_value expects unicode or ascii-compatible strings, so we must
-      # 'decode' it, even if it's actually just garbage bytestring data.
-      mfg_measurement.text_value = value.decode(errors='replace')  # pytype: disable=wrong-keyword-args
     else:
       # Coercing to string.
       mfg_measurement.text_value = str(value)

--- a/openhtf/output/proto/mfg_event_converter.py
+++ b/openhtf/output/proto/mfg_event_converter.py
@@ -418,6 +418,8 @@ class PhaseCopier(object):
 
     if isinstance(value, numbers.Number):
       mfg_measurement.numeric_value = float(value)
+    elif isinstance(value, bytes):
+      mfg_measurement.text_value = value.decode(errors='replace')
     else:
       # Coercing to string.
       mfg_measurement.text_value = str(value)

--- a/openhtf/output/proto/mfg_event_converter.py
+++ b/openhtf/output/proto/mfg_event_converter.py
@@ -26,8 +26,6 @@ from openhtf.output.proto import test_runs_pb2
 from openhtf.util import data as htf_data
 from openhtf.util import units
 from openhtf.util import validators
-from past.builtins import unicode
-import six
 
 TEST_RECORD_ATTACHMENT_NAME = 'OpenHTF_record.json'
 
@@ -214,8 +212,8 @@ def _convert_object_to_json(obj):  # pylint: disable=missing-function-docstring
 
   def unsupported_type_handler(o):
     # For bytes, JSONEncoder will fallback to this function to convert to str.
-    if six.PY3 and isinstance(o, six.binary_type):
-      return six.ensure_str(o, encoding='utf-8', errors='replace')
+    if isinstance(o, bytes):
+      return o.decode(encoding='utf-8', errors='replace')
     elif isinstance(o, (datetime.date, datetime.datetime)):
       return o.isoformat()
     else:
@@ -319,7 +317,7 @@ def multidim_measurement_to_attachment(name, measurement):
     if d.suffix is None:
       suffix = u''
     else:
-      suffix = six.ensure_text(d.suffix)
+      suffix = d.suffix
     dims.append({
         'uom_suffix': suffix,
         'uom_code': d.code,
@@ -423,10 +421,7 @@ class PhaseCopier(object):
     elif isinstance(value, bytes):
       # text_value expects unicode or ascii-compatible strings, so we must
       # 'decode' it, even if it's actually just garbage bytestring data.
-      mfg_measurement.text_value = unicode(value, errors='replace')  # pytype: disable=wrong-keyword-args
-    elif isinstance(value, unicode):
-      # Don't waste time and potential errors decoding unicode.
-      mfg_measurement.text_value = value
+      mfg_measurement.text_value = value.decode(errors='replace')  # pytype: disable=wrong-keyword-args
     else:
       # Coercing to string.
       mfg_measurement.text_value = str(value)

--- a/openhtf/output/proto/test_runs_converter.py
+++ b/openhtf/output/proto/test_runs_converter.py
@@ -36,7 +36,6 @@ from openhtf.core import test_record
 from openhtf.output.callbacks import json_factory
 from openhtf.output.proto import test_runs_pb2
 from openhtf.util import validators
-import six
 
 # pylint: disable=g-complex-comprehension
 
@@ -60,8 +59,8 @@ OUTCOME_MAP = {
 UOM_CODE_MAP = {
     u.GetOptions().Extensions[
         test_runs_pb2.uom_code]: num
-    for num, u in six.iteritems(
-        test_runs_pb2.Units.UnitCode.DESCRIPTOR.values_by_number)
+    for num, u in 
+        test_runs_pb2.Units.UnitCode.DESCRIPTOR.values_by_number.items()
 }
 # pylint: enable=no-member
 
@@ -147,7 +146,7 @@ def _attach_json(record, testrun):
 
 def _extract_attachments(phase, testrun, used_parameter_names):
   """Extract attachments, just copy them over."""
-  for name, attachment in sorted(six.iteritems(phase.attachments)):
+  for name, attachment in sorted(phase.attachments.items()):
     attachment_data, mimetype = attachment.data, attachment.mimetype
     name = _ensure_unique_parameter_name(name, used_parameter_names)
     testrun_param = testrun.info_parameters.add()
@@ -207,7 +206,7 @@ def _extract_parameters(record, testrun, used_parameter_names):
   mangled_parameters = {}
   for phase in record.phases:
     _extract_attachments(phase, testrun, used_parameter_names)
-    for name, measurement in sorted(six.iteritems(phase.measurements)):
+    for name, measurement in sorted(phase.measurements.items()):
       tr_name = _ensure_unique_parameter_name(name, used_parameter_names)
       testrun_param = testrun.test_parameters.add()
       testrun_param.name = tr_name
@@ -279,7 +278,7 @@ def _extract_parameters(record, testrun, used_parameter_names):
 
 def _add_mangled_parameters(testrun, mangled_parameters, used_parameter_names):
   """Add any mangled parameters we generated from multidim measurements."""
-  for mangled_name, mangled_param in sorted(six.iteritems(mangled_parameters)):
+  for mangled_name, mangled_param in sorted(mangled_parameters.items()):
     if mangled_name != _ensure_unique_parameter_name(mangled_name,
                                                      used_parameter_names):
       logging.warning('Mangled name %s in use by non-mangled parameter',

--- a/openhtf/output/servers/dashboard_server.py
+++ b/openhtf/output/servers/dashboard_server.py
@@ -18,7 +18,6 @@ from openhtf.output.servers import web_gui_server
 from openhtf.output.web_gui import web_launcher
 from openhtf.util import data
 from openhtf.util import multicast
-import six
 import sockjs.tornado
 import tornado.web
 
@@ -90,7 +89,7 @@ class DashboardPubSub(pub_sub.PubSub):
     with cls.station_map_lock:
 
       # By default, assume old stations are unreachable.
-      for host_port, station_info in six.iteritems(cls.station_map):
+      for host_port, station_info in cls.station_map.items():
         cls.station_map[host_port] = station_info._replace(status='UNREACHABLE')
 
       for station_info in station_info_list:

--- a/openhtf/output/servers/station_server.py
+++ b/openhtf/output/servers/station_server.py
@@ -24,7 +24,6 @@ from openhtf.util import data
 from openhtf.util import functions
 from openhtf.util import multicast
 from openhtf.util import timeouts
-import six
 import sockjs.tornado
 
 CONF = configuration.CONF
@@ -72,7 +71,7 @@ def _get_executing_test():
     test: The test that was executing when this function was called, or None.
     test_state: The state of the executing test, or None.
   """
-  tests = list(six.itervalues(openhtf.Test.TEST_INSTANCES))
+  tests = list(openhtf.Test.TEST_INSTANCES.values())
 
   if not tests:
     return None, None

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -30,7 +30,6 @@ from openhtf.core import phase_descriptor
 from openhtf.util import configuration
 from openhtf.util import data
 from openhtf.util import threads
-import six
 
 CONF = configuration.CONF
 
@@ -116,7 +115,7 @@ def plug(
 
     phase.plugs.extend([
         base_plugs.PhasePlug(name, a_plug, update_kwargs=update_kwargs)
-        for name, a_plug in six.iteritems(plugs_map)
+        for name, a_plug in plugs_map.items()
     ])
     return phase
 
@@ -183,11 +182,11 @@ class PlugManager(object):
     return {
         'plug_descriptors': {
             name: attr.asdict(descriptor)
-            for name, descriptor in six.iteritems(self._plug_descriptors)
+            for name, descriptor in self._plug_descriptors.items()
         },
         'plug_states': {
             name: data.convert_to_base_types(plug)
-            for name, plug in six.iteritems(self._plugs_by_name)
+            for name, plug in self._plugs_by_name.items()
         },
     }
 
@@ -333,7 +332,7 @@ class PlugManager(object):
     by this method.
     """
     _LOG.debug('Tearing down all plugs.')
-    for plug_type, plug_instance in six.iteritems(self._plugs_by_type):
+    for plug_type, plug_instance in self._plugs_by_type.items():
       if plug_instance.uses_base_tear_down():
         name = '<PlugTearDownThread: BasePlug No-Op for %s>' % plug_type
       else:
@@ -389,6 +388,6 @@ class PlugManager(object):
   def get_frontend_aware_plug_names(self) -> List[Text]:
     """Returns the names of frontend-aware plugs."""
     return [
-        name for name, plug in six.iteritems(self._plugs_by_name)
+        name for name, plug in self._plugs_by_name.items()
         if isinstance(plug, base_plugs.FrontendAwareBasePlug)
     ]

--- a/openhtf/plugs/device_wrapping.py
+++ b/openhtf/plugs/device_wrapping.py
@@ -22,7 +22,6 @@ import functools
 import types
 
 from openhtf.core import base_plugs
-import six
 
 
 def short_repr(obj, max_len=40):
@@ -117,7 +116,7 @@ class DeviceWrappingPlug(base_plugs.BasePlug):
       """Wraps a callable with a logging statement."""
       args_strings = tuple(short_repr(arg) for arg in args)
       kwargs_strings = tuple(('%s=%s' % (key, short_repr(val))
-                              for key, val in six.iteritems(kwargs)))
+                              for key, val in kwargs.items()))
       log_line = '%s calling "%s" on device.' % (type(self).__name__, attr)
       if args_strings or kwargs_strings:
         log_line += ' Args: \n  %s' % (', '.join(args_strings + kwargs_strings))

--- a/openhtf/plugs/usb/adb_device.py
+++ b/openhtf/plugs/usb/adb_device.py
@@ -30,6 +30,7 @@ class, subclass, and protocol.
 
 # pytype: skip-file
 
+import io
 import logging
 import os.path
 
@@ -38,7 +39,6 @@ from openhtf.plugs.usb import filesync_service
 from openhtf.plugs.usb import shell_service
 from openhtf.plugs.usb import usb_exceptions
 from openhtf.util import timeouts
-import six
 
 try:
   from M2Crypto import RSA  # pylint: disable=g-import-not-at-top
@@ -141,7 +141,7 @@ class AdbDevice(object):
       timeout_ms: Expected timeout for any part of the push.
     """
     mtime = 0
-    if isinstance(source_file, six.string_types):
+    if isinstance(source_file, str):
       mtime = os.path.getmtime(source_file)
       source_file = open(source_file)
 
@@ -163,10 +163,10 @@ class AdbDevice(object):
       The file data if dest_file is not set, None otherwise.
     """
     should_return_data = dest_file is None
-    if isinstance(dest_file, six.string_types):
+    if isinstance(dest_file, str):
       dest_file = open(dest_file, 'w')
     elif dest_file is None:
-      dest_file = six.StringIO()
+      dest_file = io.StringIO()
     self.filesync_service.recv(device_filename, dest_file,
                                timeouts.PolledTimeout.from_millis(timeout_ms))
     if should_return_data:

--- a/openhtf/plugs/usb/adb_message.py
+++ b/openhtf/plugs/usb/adb_message.py
@@ -48,7 +48,6 @@ import threading
 
 from openhtf.plugs.usb import usb_exceptions
 from openhtf.util import timeouts
-import six
 
 _LOG = logging.getLogger(__name__)
 
@@ -58,7 +57,7 @@ def make_wire_commands(*ids):
   cmd_to_wire = {
       cmd: sum(ord(c) << (i * 8) for i, c in enumerate(cmd)) for cmd in ids
   }
-  wire_to_cmd = {wire: cmd for cmd, wire in six.iteritems(cmd_to_wire)}
+  wire_to_cmd = {wire: cmd for cmd, wire in cmd_to_wire.items()}
   return cmd_to_wire, wire_to_cmd
 
 

--- a/openhtf/plugs/usb/adb_protocol.py
+++ b/openhtf/plugs/usb/adb_protocol.py
@@ -78,6 +78,7 @@ import collections
 import enum
 import itertools
 import logging
+import queue
 import sys
 import threading
 
@@ -85,8 +86,6 @@ from openhtf.plugs.usb import adb_message
 from openhtf.plugs.usb import usb_exceptions
 from openhtf.util import argv
 from openhtf.util import timeouts
-import six
-from six.moves import queue
 
 ADB_MESSAGE_LOG = False
 
@@ -913,11 +912,9 @@ class AdbConnection(object):
           ('CNXN',), timeouts.PolledTimeout.from_millis(auth_timeout_ms))
     except usb_exceptions.UsbReadFailedError as exception:
       if exception.is_timeout():
-        six.reraise(
-            usb_exceptions.DeviceAuthError,
-            usb_exceptions.DeviceAuthError(
-                message='Accept auth key on device, then retry.'),
-            sys.exc_info()[2])
+        raise usb_exceptions.DeviceAuthError(
+            message='Accept auth key on device, then retry.').with_traceback(
+                sys.exc_info()[2])
       raise
 
     # The read didn't time-out, so we got a CNXN response.

--- a/openhtf/plugs/usb/fastboot_protocol.py
+++ b/openhtf/plugs/usb/fastboot_protocol.py
@@ -15,13 +15,13 @@
 
 import binascii
 import collections
+import io
 import logging
 import os
 import struct
 
 from . import usb_exceptions
 from openhtf.util import argv
-import six
 
 FASTBOOT_DOWNLOAD_CHUNK_SIZE_KB = 1024
 
@@ -73,7 +73,7 @@ class FastbootProtocol(object):
     """
     if arg is not None:
       command = '%s:%s' % (command, arg)
-    self._write(six.StringIO(command), len(command))
+    self._write(io.StringIO(command), len(command))
 
   def handle_simple_responses(self,
                               timeout_ms=None,
@@ -184,7 +184,7 @@ class FastbootProtocol(object):
     """Sends the data to the device, tracking progress with the callback."""
     if progress_callback:
       progress = self._handle_progress(length, progress_callback)  # pylint: disable=assignment-from-no-return
-      six.next(progress)
+      next(progress)
     while length:
       tmp = data.read(FASTBOOT_DOWNLOAD_CHUNK_SIZE_KB * 1024)
       length -= len(tmp)
@@ -276,14 +276,14 @@ class FastbootCommands(object):
     Returns:
       Response to a download request, normally nothing.
     """
-    if isinstance(source_file, six.string_types):
+    if isinstance(source_file, str):
       source_len = os.stat(source_file).st_size
       source_file = open(source_file)
 
     if source_len == 0:
       # Fall back to storing it all in memory :(
       data = source_file.read()
-      source_file = six.StringIO(data)
+      source_file = io.StringIO(data)
       source_len = len(data)
 
     self._protocol.send_command('download', '%08x' % source_len)

--- a/openhtf/plugs/usb/filesync_service.py
+++ b/openhtf/plugs/usb/filesync_service.py
@@ -111,7 +111,6 @@ import struct
 import sys
 import time
 
-from future.utils import raise_with_traceback
 from openhtf.plugs.usb import adb_message
 from openhtf.plugs.usb import usb_exceptions
 
@@ -231,7 +230,7 @@ class FilesyncService(object):
       if sys.exc_info()[0] is usb_exceptions.AdbRemoteError:
         raise
     # Otherwise reraise the original exception.
-    raise_with_traceback(exc_info[0](exc_info[1]), traceback=exc_info[2])
+    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
 
   # pylint: disable=too-many-arguments
   def send(self,

--- a/openhtf/plugs/usb/local_usb.py
+++ b/openhtf/plugs/usb/local_usb.py
@@ -24,7 +24,6 @@ import logging
 
 from openhtf.plugs.usb import usb_exceptions
 from openhtf.plugs.usb import usb_handle
-import six
 
 try:
   # pylint: disable=g-import-not-at-top
@@ -164,14 +163,14 @@ class LibUsbHandle(usb_handle.UsbHandle):
     handle_iter = cls.iter_open(**kwargs)
 
     try:
-      handle = six.next(handle_iter)
+      handle = next(handle_iter)
     except StopIteration:
       # No matching interface, raise.
       raise usb_exceptions.DeviceNotFoundError('Open failed with args: %s' %
                                                kwargs)
 
     try:
-      multiple_handle = six.next(handle_iter)
+      multiple_handle = next(handle_iter)
     except StopIteration:
       # Exactly one matching device, return it.
       return handle

--- a/openhtf/plugs/usb/shell_service.py
+++ b/openhtf/plugs/usb/shell_service.py
@@ -66,14 +66,13 @@ Some examples of how to use this service:
   # output.getvalue() now contains the output of the arecord command.
 """
 
+import io
 import threading
 import time
 
 from openhtf.plugs.usb import adb_protocol
 from openhtf.plugs.usb import usb_exceptions
-
 from openhtf.util import timeouts
-import six
 
 
 class AsyncCommandHandle(object):
@@ -110,7 +109,7 @@ class AsyncCommandHandle(object):
     """
     self.stream = stream
     self.stdin = stdin
-    self.stdout = stdout or six.StringIO()
+    self.stdout = stdout or io.StringIO()
     self.force_closed_or_timeout = False
 
     self.reader_thread = threading.Thread(

--- a/openhtf/plugs/usb/usb_handle.py
+++ b/openhtf/plugs/usb/usb_handle.py
@@ -59,7 +59,7 @@ def requires_open_handle(method):
   return wrapper_requiring_open_handle
 
 
-class UsbHandle(metaclass=abc.ABCMeta):
+class UsbHandle(abc.ABC):
   """UsbHandle objects provide read/write access to USB Interfaces.
 
   Subclasses must implement this interface to provide actual Read/Write/Close

--- a/openhtf/plugs/usb/usb_handle.py
+++ b/openhtf/plugs/usb/usb_handle.py
@@ -23,7 +23,6 @@ import abc
 import functools
 import logging
 
-from future.utils import with_metaclass
 from openhtf.plugs.usb import usb_exceptions
 
 DEFAULT_TIMEOUT_MS = 5000
@@ -60,7 +59,7 @@ def requires_open_handle(method):
   return wrapper_requiring_open_handle
 
 
-class UsbHandle(with_metaclass(abc.ABCMeta, object)):
+class UsbHandle(metaclass=abc.ABCMeta):
   """UsbHandle objects provide read/write access to USB Interfaces.
 
   Subclasses must implement this interface to provide actual Read/Write/Close

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -32,7 +32,6 @@ import openhtf
 from openhtf import plugs
 from openhtf.core import base_plugs
 from openhtf.util import console_output
-from six.moves import input
 
 if platform.system() != 'Windows':
   import termios  # pylint: disable=g-import-not-at-top

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -23,8 +23,6 @@ import weakref
 
 import attr
 
-import six
-
 
 def _log_every_n_to_logger(n: int, logger: Optional[logging.Logger], level: int,
                            message: Text, *args: Any) -> Callable[[], bool]:
@@ -50,7 +48,7 @@ def _log_every_n_to_logger(n: int, logger: Optional[logging.Logger], level: int,
       yield True
 
   gen = _gen()
-  return lambda: six.next(gen)
+  return lambda: next(gen)
 
 
 def log_every_n(n: int, level: int, message: Text,
@@ -169,7 +167,7 @@ def format_string(target, kwargs):
     return None
   if callable(target):
     return target(**kwargs)
-  if not isinstance(target, six.string_types):
+  if not isinstance(target, str):
     return target
   if '{' in target:
     return partial_format(target, **kwargs)

--- a/openhtf/util/configuration.py
+++ b/openhtf/util/configuration.py
@@ -147,7 +147,6 @@ from typing import Any, Optional, Text, Type, TypeVar
 import attr
 from openhtf.util import argv
 from openhtf.util import threads
-import six
 from typing_extensions import Protocol
 import yaml
 
@@ -549,7 +548,7 @@ class _Configuration(object):
         declarations have been evaluated.
     """
     undeclared_keys = []
-    for key, value in six.iteritems(dictionary):
+    for key, value in dictionary.items():
       # Warn in this case.  We raise if you try to access a config key that
       # hasn't been declared, but we don't raise here so that you can use
       # configuration files that are supersets of required configuration for
@@ -590,7 +589,7 @@ class _Configuration(object):
     retval.update(self._loaded_values)
     # Only update keys that are declared so we don't allow injecting
     # un-declared keys via commandline flags.
-    for key, value in six.iteritems(self._flag_values):
+    for key, value in self._flag_values.items():
       if key in self._declarations:
         retval[key] = value
     return retval
@@ -705,10 +704,7 @@ class _Configuration(object):
       A wrapper that, when invoked, will call the wrapped method, passing in
     configuration values for positional arguments.
     """
-    if six.PY3:
-      argspec = inspect.getfullargspec(method)
-    else:
-      argspec = inspect.getargspec(method)  # pylint: disable=deprecated-method
+    argspec = inspect.getfullargspec(method)
 
     # Index in argspec.args of the first keyword argument.  This index is a
     # negative number if there are any kwargs, or 0 if there are no kwargs.

--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -17,7 +17,7 @@ We use a few special data formats internally, these utility functions make it a
 little easier to work with them.
 """
 
-import collections
+from collections.abc import Iterable
 import copy
 import difflib
 import enum
@@ -243,7 +243,7 @@ def total_size(obj):
       size += sum(
           map(sizeof,
               itertools.chain.from_iterable(current_obj.items())))
-    elif (isinstance(current_obj, collections.abc.Iterable) and
+    elif (isinstance(current_obj, Iterable) and
           not isinstance(current_obj, str)):
       size += sum(sizeof(item) for item in current_obj)
     elif isinstance(current_obj, records.RecordClass):

--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -17,6 +17,7 @@ We use a few special data formats internally, these utility functions make it a
 little easier to work with them.
 """
 
+import collections
 import copy
 import difflib
 import enum
@@ -31,15 +32,9 @@ from typing import Any, TypeVar
 
 import attr
 from mutablerecords import records
-from past.builtins import long
-from past.builtins import unicode
-
-import six
-from six.moves import collections_abc
-from six.moves import zip
 
 # Used by convert_to_base_types().
-PASSTHROUGH_TYPES = {bool, bytes, int, long, type(None), unicode}
+PASSTHROUGH_TYPES = {bool, bytes, int, type(None), str}
 
 
 def pprint_diff(first, second, first_name='first', second_name='second'):
@@ -141,14 +136,14 @@ def convert_to_base_types(obj,
       skipped.
     - Enum instances are converted to strings via their .name attribute.
     - Real and integral numbers are converted to built-in types.
-    - Byte and unicode strings are left alone (instances of six.string_types).
+    - Byte and strings are left alone.
     - Other non-None values are converted to strings via str().
 
   The return value contains only the Python built-in types: dict, list, tuple,
-  str, unicode, int, float, long, bool, and NoneType (unless tuple_type is set
-  to something else).  If tuples should be converted to lists (e.g. for an
-  encoding that does not differentiate between the two), pass 'tuple_type=list'
-  as an argument.
+  str, int, float, bool, and NoneType (unless tuple_type is set to something
+  else).  If tuples should be converted to lists (e.g. for an encoding that
+  does not differentiate between the two), pass 'tuple_type=list' as an
+  argument.
 
   Args:
     obj: object to recursively convert to base types.
@@ -164,7 +159,7 @@ def convert_to_base_types(obj,
     Version of the object composed of base types.
   """
   # Because it's *really* annoying to pass a single string accidentally.
-  assert not isinstance(ignore_keys, six.string_types), 'Pass a real iterable!'
+  assert not isinstance(ignore_keys, str), 'Pass a real iterable!'
 
   if hasattr(obj, 'as_base_types'):
     return obj.as_base_types()
@@ -195,7 +190,7 @@ def convert_to_base_types(obj,
     return {  # pylint: disable=g-complex-comprehension
         convert_to_base_types(k, ignore_keys, tuple_type):
         convert_to_base_types(v, ignore_keys, tuple_type)
-        for k, v in six.iteritems(obj)
+        for k, v in obj.items()
         if k not in ignore_keys
     }
   elif isinstance(obj, list):
@@ -210,7 +205,7 @@ def convert_to_base_types(obj,
 
   # Convert numeric types (e.g. numpy ints and floats) into built-in types.
   elif isinstance(obj, numbers.Integral):
-    return long(obj)
+    return int(obj)
   elif isinstance(obj, numbers.Real):
     as_float = float(obj)
     if json_safe and (math.isinf(as_float) or math.isnan(as_float)):
@@ -247,9 +242,9 @@ def total_size(obj):
     if isinstance(current_obj, dict):
       size += sum(
           map(sizeof,
-              itertools.chain.from_iterable(six.iteritems(current_obj))))
-    elif (isinstance(current_obj, collections_abc.Iterable) and
-          not isinstance(current_obj, six.string_types)):
+              itertools.chain.from_iterable(current_obj.items())))
+    elif (isinstance(current_obj, collections.abc.Iterable) and
+          not isinstance(current_obj, str)):
       size += sum(sizeof(item) for item in current_obj)
     elif isinstance(current_obj, records.RecordClass):
       size += sum(

--- a/openhtf/util/functions.py
+++ b/openhtf/util/functions.py
@@ -18,8 +18,6 @@ import functools
 import inspect
 import time
 
-import six
-
 
 def call_once(func):
   """Decorate a function to only allow it to be called once.
@@ -34,16 +32,10 @@ def call_once(func):
   Returns:
     The decorated function.
   """
-  if six.PY3:
-    argspec = inspect.getfullargspec(func)
-    argspec_args = argspec.args
-    argspec_varargs = argspec.varargs
-    argspec_keywords = argspec.varkw
-  else:
-    argspec = inspect.getargspec(func)  # pylint: disable=deprecated-method
-    argspec_args = argspec.args
-    argspec_varargs = argspec.varargs
-    argspec_keywords = argspec.keywords
+  argspec = inspect.getfullargspec(func)
+  argspec_args = argspec.args
+  argspec_varargs = argspec.varargs
+  argspec_keywords = argspec.varkw
   if argspec_args or argspec_varargs or argspec_keywords:
     raise ValueError('Can only decorate functions with no args', func, argspec)
 

--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -111,7 +111,6 @@ from openhtf.util import argv
 from openhtf.util import console_output
 from openhtf.util import functions
 from openhtf.util import threads
-import six
 
 # The number of v's provided as command line arguments to control verbosity.
 # Will be overridden if the ARG_PARSER below parses the -v argument.
@@ -219,11 +218,11 @@ class MacAddressLogFilter(logging.Filter):
   def filter(self, record):
     if self.MAC_REPLACE_RE.search(record.getMessage()):
       # Update all the things to have no mac address in them
-      if isinstance(record.msg, six.string_types):
+      if isinstance(record.msg, str):
         record.msg = self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, record.msg)
         record.args = tuple([
             self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT, str(arg))
-            if isinstance(arg, six.string_types) else arg for arg in record.args
+            if isinstance(arg, str) else arg for arg in record.args
         ])
       else:
         record.msg = self.MAC_REPLACE_RE.sub(self.MAC_REPLACEMENT,

--- a/openhtf/util/multicast.py
+++ b/openhtf/util/multicast.py
@@ -19,13 +19,12 @@ function that is used to send one-shot messages to a multicast socket.
 """
 
 import logging
+import queue
 import socket
 import struct
 import sys
 import threading
 import time
-
-from six.moves import queue
 
 _LOG = logging.getLogger(__name__)
 

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -127,6 +127,7 @@ List of assertions that can be used with either PhaseRecords or TestRecords:
 """
 
 import collections
+from collections.abc import Callable as CollectionsCallable, Iterator
 import functools
 import inspect
 import logging
@@ -322,7 +323,7 @@ def _merge_stats(stats: pstats.Stats, filepath: pathlib.Path) -> None:
   test_executor.combine_profile_stats(stats_to_combine, str(filepath))
 
 
-class PhaseOrTestIterator(collections.abc.Iterator):
+class PhaseOrTestIterator(Iterator):
 
   def __init__(self, test_case, iterator, mock_plugs, phase_user_defined_state,
                phase_diagnoses):
@@ -466,7 +467,7 @@ class PhaseOrTestIterator(collections.abc.Iterator):
     phase_or_test = self.iterator.send(self.last_result)
     if isinstance(phase_or_test, test_descriptor.Test):
       self.last_result, failure_message = self._handle_test(phase_or_test)
-    elif not isinstance(phase_or_test, collections.abc.Callable):
+    elif not isinstance(phase_or_test, CollectionsCallable):
       raise InvalidTestError(
           'methods decorated with patch_plugs must yield Test instances or '
           'individual test phases', phase_or_test)
@@ -479,7 +480,7 @@ class PhaseOrTestIterator(collections.abc.Iterator):
     phase_or_test = self.iterator.send(self.last_result)
     if isinstance(phase_or_test, test_descriptor.Test):
       self.last_result, failure_message = self._handle_test(phase_or_test)
-    elif not isinstance(phase_or_test, collections.abc.Callable):
+    elif not isinstance(phase_or_test, CollectionsCallable):
       raise InvalidTestError(
           'methods decorated with patch_plugs must yield Test instances or '
           'individual test phases', phase_or_test)

--- a/openhtf/util/threads.py
+++ b/openhtf/util/threads.py
@@ -22,11 +22,10 @@ import pstats
 import sys
 import threading
 
-import six
 try:
-  from six.moves import _thread  # pylint: disable=g-import-not-at-top
+  import _thread  # pylint: disable=g-import-not-at-top
 except ImportError:
-  from six.moves import _dummy_thread as _thread  # pylint: disable=g-import-not-at-top
+  import _dummy_thread as _thread  # pylint: disable=g-import-not-at-top
 
 _LOG = logging.getLogger(__name__)
 
@@ -40,15 +39,13 @@ class InvalidUsageError(Exception):
 
 
 def safe_lock_release_context(rlock):
-  if six.PY2:
-    return _safe_lock_release_py2(rlock)
   # Python3 has a C-implementation of RLock, which doesn't have the thread
   # termination issues.
-  return _placeholder_release_py3()
+  return _placeholder_release()
 
 
 @contextlib.contextmanager
-def _placeholder_release_py3():
+def _placeholder_release():
   yield
 
 

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -82,14 +82,14 @@ def create_validator(name, *args, **kwargs):
 _identity = lambda x: x
 
 
-class ValidatorBase(metaclass=abc.ABCMeta):
+class ValidatorBase(abc.ABC):
 
   @abc.abstractmethod
   def __call__(self, value):
     """Should validate value, returning a boolean result."""
 
 
-class RangeValidatorBase(ValidatorBase, metaclass=abc.ABCMeta):
+class RangeValidatorBase(ValidatorBase, abc.ABC):
 
   @abc.abstractproperty
   def minimum(self):

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -58,9 +58,7 @@ import abc
 import math
 import numbers
 import re
-from future.utils import with_metaclass
 from openhtf import util
-import six
 
 _VALIDATORS = {}
 
@@ -84,14 +82,14 @@ def create_validator(name, *args, **kwargs):
 _identity = lambda x: x
 
 
-class ValidatorBase(with_metaclass(abc.ABCMeta, object)):
+class ValidatorBase(metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def __call__(self, value):
     """Should validate value, returning a boolean result."""
 
 
-class RangeValidatorBase(with_metaclass(abc.ABCMeta, ValidatorBase)):
+class RangeValidatorBase(ValidatorBase, metaclass=abc.ABCMeta):
 
   @abc.abstractproperty
   def minimum(self):
@@ -228,8 +226,8 @@ register(AllInRangeValidator, name='all_in_range')
 def all_equals(value, type=None):  # pylint: disable=redefined-builtin
   if isinstance(value, numbers.Number):
     return AllInRangeValidator(minimum=value, maximum=value)
-  elif isinstance(value, six.string_types):
-    assert type is None or issubclass(type, six.string_types), (
+  elif isinstance(value, str):
+    assert type is None or issubclass(type, str), (
         'Cannot use a non-string type when matching a string')
     return matches_regex('^{}$'.format(re.escape(value)))
   else:
@@ -367,8 +365,8 @@ register(in_range, name='in_range')
 def equals(value, type=None):  # pylint: disable=redefined-builtin
   if isinstance(value, numbers.Number):
     return InRange(minimum=value, maximum=value, type=type)
-  elif isinstance(value, six.string_types):
-    assert type is None or issubclass(type, six.string_types), (
+  elif isinstance(value, str):
+    assert type is None or issubclass(type, str), (
         'Cannot use a non-string type when matching a string')
     return matches_regex('^{}$'.format(re.escape(value)))
   else:

--- a/openhtf/util/xmlrpcutil.py
+++ b/openhtf/util/xmlrpcutil.py
@@ -13,25 +13,16 @@
 # limitations under the License.
 """Utility helpers for xmlrpclib."""
 
+import collections
 import http.client
 import socketserver
 import sys
 import threading
 import xmlrpc.client
 import xmlrpc.server
-
-import six
-from six.moves import collections_abc
+from xmlrpc.server import SimpleXMLRPCServer
 
 DEFAULT_PROXY_TIMEOUT_S = 3
-
-# https://github.com/PythonCharmers/python-future/issues/280
-# pylint: disable=g-import-not-at-top,g-importing-member
-if sys.version_info[0] < 3:
-  from SimpleXMLRPCServer import SimpleXMLRPCServer  # pytype: disable=import-error
-else:
-  from xmlrpc.server import SimpleXMLRPCServer  # pytype: disable=import-error
-# pylint: enable=g-import-not-at-top,g-importing-member
 
 
 class TimeoutHTTPConnection(http.client.HTTPConnection):  # pylint: disable=missing-class-docstring
@@ -81,10 +72,7 @@ class TimeoutProxyMixin(object):
     super(TimeoutProxyMixin, self).__init__(*args, **kwargs)
 
   def __settimeout(self, timeout_s):
-    if six.PY3:
-      self._transport.settimeout(timeout_s)  # pytype: disable=attribute-error
-    else:
-      self.__transport.settimeout(timeout_s)  # pytype: disable=attribute-error
+    self._transport.settimeout(timeout_s)  # pytype: disable=attribute-error
 
 
 class TimeoutProxyServer(TimeoutProxyMixin, BaseServerProxy):
@@ -100,7 +88,7 @@ class LockedProxyMixin(object):
 
   def __getattr__(self, attr):
     method = super(LockedProxyMixin, self).__getattr__(attr)  # pytype: disable=attribute-error
-    if isinstance(method, collections_abc.Callable):
+    if isinstance(method, collections.abc.Callable):
       # xmlrpc doesn't support **kwargs, so only accept *args.
       def _wrapper(*args):
         with self._lock:

--- a/openhtf/util/xmlrpcutil.py
+++ b/openhtf/util/xmlrpcutil.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Utility helpers for xmlrpclib."""
 
-import collections
+from collections.abc import Callable
 import http.client
 import socketserver
 import sys
@@ -88,7 +88,7 @@ class LockedProxyMixin(object):
 
   def __getattr__(self, attr):
     method = super(LockedProxyMixin, self).__getattr__(attr)  # pytype: disable=attribute-error
-    if isinstance(method, collections.abc.Callable):
+    if isinstance(method, Callable):
       # xmlrpc doesn't support **kwargs, so only accept *args.
       def _wrapper(*args):
         with self._lock:

--- a/setup.py
+++ b/setup.py
@@ -133,8 +133,6 @@ INSTALL_REQUIRES = [
     'colorama>=0.3.9,<1.0',
     'contextlib2>=0.5.1,<1.0',
     'dataclasses;python_version<"3.7"',
-    'enum34>=1.1.2,<2.0 ; python_version<"3.4"',
-    'future>=0.16.0',
     'inflection',
     'mutablerecords>=0.4.1,<2.0',
     'oauth2client>=1.5.2,<2.0',
@@ -143,7 +141,6 @@ INSTALL_REQUIRES = [
     'pyOpenSSL>=17.1.0,<18.0',
     'sockjs-tornado>=1.0.3,<2.0',
     'tornado>=4.3,<5.0',
-    'six>=1.13.0',
     'typing-extensions',
 ]
 
@@ -217,7 +214,6 @@ setup(
     },
     tests_require=[
         'absl-py>=0.10.0',
-        'mock>=2.0.0',
         'pandas>=0.22.0',
         'numpy',
         'pytest>=2.9.2',

--- a/test/core/diagnoses_test.py
+++ b/test/core/diagnoses_test.py
@@ -1,17 +1,16 @@
 """Tests for Diagnoses in OpenHTF."""
 
+import enum
 import time
 import unittest
+from unittest import mock
 
-import enum  # pylint: disable=g-bad-import-order
-import mock
 import openhtf as htf
 from openhtf.core import diagnoses_lib
 from openhtf.core import measurements
 from openhtf.core import test_record
 from openhtf.util import data
 from openhtf.util import test as htf_test
-import six
 
 
 class DiagPhaseError(Exception):
@@ -1078,14 +1077,14 @@ class DiagnosesTest(htf_test.TestCase):
   def test_phase_diagnoser_serialization(self):
     converted = data.convert_to_base_types(basic_wrapper_phase_diagnoser)
     self.assertEqual('basic_wrapper_phase_diagnoser', converted['name'])
-    six.assertCountEqual(self, ['okay', 'fine', 'great', 'test_ok'],
-                         converted['possible_results'])
+    self.assertCountEqual(['okay', 'fine', 'great', 'test_ok'],
+                          converted['possible_results'])
 
   def test_test_diagnoser_serialization(self):
     converted = data.convert_to_base_types(basic_wrapper_test_diagnoser)
     self.assertEqual('basic_wrapper_test_diagnoser', converted['name'])
-    six.assertCountEqual(self, ['okay', 'fine', 'great', 'test_ok'],
-                         converted['possible_results'])
+    self.assertCountEqual(['okay', 'fine', 'great', 'test_ok'],
+                          converted['possible_results'])
 
   @htf_test.yields_phases
   def test_test_record_diagnosis_serialization(self):

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -17,9 +17,9 @@ import logging
 import threading
 import time
 import unittest
+from unittest import mock
 
 from absl.testing import parameterized
-import mock
 
 import openhtf
 from openhtf import plugs

--- a/test/core/measurements_test.py
+++ b/test/core/measurements_test.py
@@ -20,8 +20,8 @@ actually care about.
 
 import collections
 import unittest
+from unittest import mock
 
-import mock
 import openhtf as htf
 from openhtf.core import measurements
 from examples import all_the_things

--- a/test/core/monitors_test.py
+++ b/test/core/monitors_test.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import queue
 import time
 import unittest
+from unittest import mock
 
-import mock
 from openhtf import plugs
 from openhtf.core import base_plugs
 from openhtf.core import monitors
-from six.moves import queue
 
 
 class EmptyPlug(base_plugs.BasePlug):

--- a/test/core/phase_branches_test.py
+++ b/test/core/phase_branches_test.py
@@ -1,8 +1,7 @@
 """Tests for google3.third_party.py.openhtf.test.core.phase_branches."""
 
 import unittest
-
-import mock
+from unittest import mock
 
 import openhtf as htf
 from openhtf.core import phase_branches

--- a/test/core/phase_collections_test.py
+++ b/test/core/phase_collections_test.py
@@ -1,8 +1,8 @@
 """Unit tests for the phase collections library."""
 
 import unittest
+from unittest import mock
 
-import mock
 import openhtf as htf
 from openhtf import plugs
 from openhtf.core import base_plugs

--- a/test/core/phase_group_test.py
+++ b/test/core/phase_group_test.py
@@ -2,8 +2,8 @@
 
 import threading
 import unittest
+from unittest import mock
 
-import mock
 import openhtf as htf
 from openhtf import plugs
 from openhtf.core import base_plugs

--- a/test/core/test_descriptor_test.py
+++ b/test/core/test_descriptor_test.py
@@ -2,8 +2,8 @@
 
 import re
 import unittest
+from unittest import mock
 
-import mock
 from openhtf.core import test_descriptor
 
 

--- a/test/test_state_test.py
+++ b/test/test_state_test.py
@@ -17,9 +17,9 @@ import logging
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 from absl.testing import parameterized
-import mock
 import openhtf
 from openhtf.core import phase_collections
 from openhtf.core import phase_descriptor

--- a/test/util/conf_test.py
+++ b/test/util/conf_test.py
@@ -17,7 +17,6 @@ import os.path
 import unittest
 
 from openhtf.util import configuration
-import six
 
 CONF = configuration.CONF
 
@@ -116,7 +115,7 @@ class TestConf(TestConfBase):
         'string_default': 'default',
     }
     # assert first dict is a subset of second dict
-    self.assertLessEqual(six.viewitems(expected_dict), six.viewitems(conf_dict))
+    self.assertLessEqual(expected_dict.items(), conf_dict.items())
 
   def test_undeclared(self):
     with self.assertRaises(configuration.UndeclaredKeyError):

--- a/test/util/data_test.py
+++ b/test/util/data_test.py
@@ -17,7 +17,6 @@ import unittest
 
 import attr
 from openhtf.util import data
-import past.builtins
 
 
 class TestData(unittest.TestCase):
@@ -60,10 +59,8 @@ class TestData(unittest.TestCase):
         'list': [10],
         'tuple': (10,),
         'str': '10',
-        'unicode': '10',
         'int': 2**40,
         'float': 10.0,
-        'long': 2**80,
         'bool': True,
         'none': None,
         'complex': 10j,
@@ -82,10 +79,8 @@ class TestData(unittest.TestCase):
     self.assertIsInstance(converted['list'], list)
     self.assertIsInstance(converted['tuple'], tuple)
     self.assertIsInstance(converted['str'], str)
-    self.assertIsInstance(converted['unicode'], str)
     self.assertIsInstance(converted['int'], int)
     self.assertIsInstance(converted['float'], float)
-    self.assertIsInstance(converted['long'], past.builtins.long)
     self.assertIsInstance(converted['bool'], bool)
     self.assertIsNone(converted['none'])
     self.assertIsInstance(converted['complex'], str)

--- a/test/util/functions_test.py
+++ b/test/util/functions_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-import mock
+from unittest import mock
 
 from openhtf.util import functions
 

--- a/test/util/logs_test.py
+++ b/test/util/logs_test.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import unittest
-import mock
+from unittest import mock
 
 from openhtf.util import logs
 

--- a/test/util/util_test.py
+++ b/test/util/util_test.py
@@ -15,8 +15,8 @@
 import copy
 import time
 import unittest
+from unittest import mock
 
-import mock
 from openhtf import util
 from openhtf.util import timeouts
 

--- a/test/util/validators_test.py
+++ b/test/util/validators_test.py
@@ -7,15 +7,14 @@ import unittest
 import openhtf as htf
 from openhtf.util import test as htf_test
 from openhtf.util import validators
-import six
 
 
 class TestInRange(unittest.TestCase):
 
   def test_raises_if_invalid_arguments(self):
-    with six.assertRaisesRegex(self, ValueError, 'Must specify minimum'):
+    with self.assertRaisesRegex(ValueError, 'Must specify minimum'):
       validators.InRange()
-    with six.assertRaisesRegex(self, ValueError, 'Minimum cannot be greater'):
+    with self.assertRaisesRegex(ValueError, 'Minimum cannot be greater'):
       validators.InRange(minimum=10, maximum=0)
 
   def test_invalidates_non_numbers(self):
@@ -250,7 +249,7 @@ class TestEqualsFactory(unittest.TestCase):
 class TestWithinPercent(unittest.TestCase):
 
   def test_raises_for_negative_percentage(self):
-    with six.assertRaisesRegex(self, ValueError, 'percent argument is'):
+    with self.assertRaisesRegex(ValueError, 'percent argument is'):
       validators.WithinPercent(expected=100, percent=-1)
 
   def test_within_percent_less_than_one_hundred(self):

--- a/test_reqs.txt
+++ b/test_reqs.txt
@@ -1,6 +1,5 @@
 pytest
 pytest-cov
-mock
 
 # We also want everything as specified by setup.py
 -e .


### PR DESCRIPTION
# What I did
I'm removing all the third party libraries used to add compatibility for PY2.

# Why I did it
To reduce tech debt as PY2 is deprecated (https://www.python.org/doc/sunset-python-2/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1009)
<!-- Reviewable:end -->
