### PR TITLE
Fix regressions occuring during PY2 deprecation.

### DIFF
--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -43,7 +43,9 @@ class Atomic(object):
     self.temp = tempfile.NamedTemporaryFile(delete=False)
 
   def write(self, write_data: Union[Text, bytes]) -> int:
-    return self.temp.write(six.ensure_binary(write_data))
+    if isinstance(write_data, str):
+      write_data = write_data.encode()
+    return self.temp.write(write_data)
 
   def close(self) -> None:
     self.temp.close()
@@ -133,7 +135,7 @@ class OutputToFile(object):
         outfile.write(serialized_record.encode())
       elif isinstance(serialized_record, Iterable):
         for chunk in serialized_record:
-          outfile.write(chunk.encode())
+          outfile.write(chunk.encode() if isinstance(chunk, str) else chunk)
       else:
         raise TypeError('Expected string or iterable but got {}.'.format(
             type(serialized_record)))

--- a/openhtf/output/callbacks/mfg_inspector.py
+++ b/openhtf/output/callbacks/mfg_inspector.py
@@ -148,8 +148,8 @@ class MfgInspector(object):
     if user and keydata:
       self.credentials = oauth2client.client.SignedJwtAssertionCredentials(
           service_account_name=self.user,
-          private_key=self.keydata.encode()
-          if isinstance(self.keydata, str) else self.keydata,
+          private_key=(self.keydata.encode()
+                       if isinstance(self.keydata, str) else self.keydata),
           scope=self.SCOPE_CODE_URI,
           user_agent='OpenHTF Guzzle Upload Client',
           token_uri=self.token_uri)

--- a/openhtf/output/callbacks/mfg_inspector.py
+++ b/openhtf/output/callbacks/mfg_inspector.py
@@ -148,7 +148,8 @@ class MfgInspector(object):
     if user and keydata:
       self.credentials = oauth2client.client.SignedJwtAssertionCredentials(
           service_account_name=self.user,
-          private_key=self.keydata.encode(),
+          private_key=self.keydata.encode()
+          if isinstance(self.keydata, str) else self.keydata,
           scope=self.SCOPE_CODE_URI,
           user_agent='OpenHTF Guzzle Upload Client',
           token_uri=self.token_uri)

--- a/openhtf/util/threads.py
+++ b/openhtf/util/threads.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Thread library defining a few helpers."""
 
+import _thread
 import contextlib
 import cProfile
 import ctypes
@@ -21,11 +22,6 @@ import logging
 import pstats
 import sys
 import threading
-
-try:
-  import _thread  # pylint: disable=g-import-not-at-top
-except ImportError:
-  import _dummy_thread as _thread  # pylint: disable=g-import-not-at-top
 
 _LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
# What I did
I fixed a few regressions that occurred because of #1009.

# Why I did it
* `encode()` cannot be called on a set of bytes so we check the type before converting to bytes.
* `dummy_thread` is removed in PY3.9: https://bugs.python.org/issue37312.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1011)
<!-- Reviewable:end -->
