### PR TITLE
pyOpenSSL version update to unbreak build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ INSTALL_REQUIRES = [
     'oauth2client>=1.5.2,<2.0',
     'protobuf>=3.6.0,<4.0',
     'PyYAML>=3.13',
-    'pyOpenSSL>=17.1.0,<18.0',
+    'pyOpenSSL>=17.1.0,<22.1',
     'sockjs-tornado>=1.0.3,<2.0',
     'tornado>=4.3,<5.0',
     'typing-extensions',


### PR DESCRIPTION
The build is currently broken due to some incompatibilities in pyOpenSSL versions. This attempts to bump the version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1022)
<!-- Reviewable:end -->
