### PR TITLE
Fix and add CI checks for `autoflake`, `isort`

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -49,6 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: |
-        pip install -U autoflake
-        autoflake .
+    - run: pip install -U autoflake isort
+    - run: autoflake .
+    - run: isort --check --diff --color .

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -44,3 +44,11 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_PUBLISH_PASSWORD }}
         skip_existing: true
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+        pip install -U autoflake
+        autoflake .

--- a/examples/all_the_things.py
+++ b/examples/all_the_things.py
@@ -20,9 +20,9 @@ python all_the_things.py
 import os.path
 import time
 
-import openhtf as htf
-from openhtf import util
 from examples import example_plugs
+from openhtf import util
+import openhtf as htf
 from openhtf.output import callbacks
 from openhtf.output.callbacks import console_summary
 from openhtf.output.callbacks import json_factory

--- a/examples/checkpoints.py
+++ b/examples/checkpoints.py
@@ -15,8 +15,8 @@
 
 import time
 
-import openhtf as htf
 from examples import measurements as measurements_example
+import openhtf as htf
 from openhtf.output.callbacks import console_summary
 from openhtf.output.callbacks import json_factory
 from openhtf.util import checkpoints

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -30,10 +30,8 @@ For more information on output, see the output.py example.
 # from it throughout our test scripts. See __all__ at the top of
 # openhtf/__init__.py for details on what's in top-of-module namespace.
 import openhtf as htf
-
 # Import this output mechanism as it's the specific one we want to use.
 from openhtf.output.callbacks import json_factory
-
 from openhtf.plugs import user_input
 
 

--- a/examples/measurements.py
+++ b/examples/measurements.py
@@ -49,10 +49,8 @@ Some constraints on measurements:
 import random
 
 import openhtf as htf
-
 # Import this output mechanism as it's the specific one we want to use.
 from openhtf.output.callbacks import json_factory
-
 # You won't normally need to import this, see validators.py example for
 # more details.  It's used for the inline measurement declaration example
 # below, but normally you'll only import it when you want to define custom

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -15,6 +15,8 @@
 
 import signal
 
+import pkg_resources
+
 from openhtf import plugs
 from openhtf.core import phase_executor
 from openhtf.core import test_record
@@ -26,7 +28,6 @@ from openhtf.core.diagnoses_lib import DiagPriority
 from openhtf.core.diagnoses_lib import DiagResultEnum
 from openhtf.core.diagnoses_lib import PhaseDiagnoser
 from openhtf.core.diagnoses_lib import TestDiagnoser
-
 from openhtf.core.measurements import Dimension
 from openhtf.core.measurements import Measurement
 from openhtf.core.monitors import monitors
@@ -56,7 +57,6 @@ from openhtf.util import data
 from openhtf.util import functions
 from openhtf.util import logs
 from openhtf.util import units
-import pkg_resources
 
 conf = configuration.CONF
 

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -14,7 +14,6 @@
 """The main OpenHTF entry point."""
 
 import signal
-import typing
 
 from openhtf import plugs
 from openhtf.core import phase_executor

--- a/openhtf/core/diagnoses_lib.py
+++ b/openhtf/core/diagnoses_lib.py
@@ -125,9 +125,11 @@ import abc
 from collections.abc import Iterable as CollectionsIterable
 import enum
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Text, Type, TYPE_CHECKING, Union
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Sequence,
+                    Text, Type, TYPE_CHECKING, Union)
 
 import attr
+
 from openhtf.core import test_record
 from openhtf.util import data
 

--- a/openhtf/core/diagnoses_lib.py
+++ b/openhtf/core/diagnoses_lib.py
@@ -324,7 +324,6 @@ class _BaseDiagnoser(object):
 
   def _check_definition(self) -> None:
     """Internal function to verify that the diagnoser is completely defined."""
-    pass
 
 
 class BasePhaseDiagnoser(_BaseDiagnoser, abc.ABC):

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -63,7 +63,8 @@ import enum
 import functools
 import logging
 import typing
-from typing import Any, Callable, Dict, Iterator, List, Optional, Text, Tuple, Union
+from typing import (Any, Callable, Dict, Iterator, List, Optional, Text, Tuple,
+                    Union)
 
 import attr
 
@@ -71,12 +72,14 @@ from openhtf import util
 from openhtf.util import data
 from openhtf.util import units as util_units
 from openhtf.util import validators
+
 if typing.TYPE_CHECKING:
   from openhtf.core import diagnoses_lib
 
 try:
   # pylint: disable=g-import-not-at-top
   import pandas  # pytype: disable=import-error
+
   # pylint: enable=g-import-not-at-top
 except ImportError:
   pandas = None

--- a/openhtf/core/monitors.py
+++ b/openhtf/core/monitors.py
@@ -48,6 +48,8 @@ import inspect
 import time
 from typing import Any, Callable, Dict, Optional, Text
 
+import six
+
 import openhtf
 from openhtf import plugs
 from openhtf.core import measurements
@@ -55,7 +57,6 @@ from openhtf.core import phase_descriptor
 from openhtf.core import test_state as core_test_state
 from openhtf.util import threads
 from openhtf.util import units as uom
-import six
 
 
 class _MonitorThread(threads.KillableThread):

--- a/openhtf/core/phase_branches.py
+++ b/openhtf/core/phase_branches.py
@@ -20,10 +20,11 @@ diagnosis results of the test run.
 
 import abc
 import enum
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterator, Optional,
-                    Text, Tuple, Union)
+from typing import (Any, Callable, Dict, Iterator, Optional, Text, Tuple,
+                    TYPE_CHECKING, Union)
 
 import attr
+
 from openhtf import util
 from openhtf.core import diagnoses_lib
 from openhtf.core import phase_collections

--- a/openhtf/core/phase_collections.py
+++ b/openhtf/core/phase_collections.py
@@ -23,9 +23,11 @@ skipped.
 import abc
 import collections
 from collections.abc import Iterable as CollectionsIterable
-from typing import Any, Callable, DefaultDict, Dict, Iterable, Iterator, List, Optional, Text, Tuple, Type, TypeVar, Union
+from typing import (Any, Callable, DefaultDict, Dict, Iterable, Iterator, List,
+                    Optional, Text, Tuple, Type, TypeVar, Union)
 
 import attr
+
 from openhtf import util
 from openhtf.core import base_plugs
 from openhtf.core import phase_descriptor

--- a/openhtf/core/phase_descriptor.py
+++ b/openhtf/core/phase_descriptor.py
@@ -22,7 +22,8 @@ import collections
 import enum
 import inspect
 import pdb
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Set, Text, TYPE_CHECKING, Type, Union
+from typing import (Any, Callable, Dict, Iterator, List, Optional, Sequence,
+                    Set, Text, Type, TYPE_CHECKING, Union)
 
 import attr
 import inflection

--- a/openhtf/core/phase_executor.py
+++ b/openhtf/core/phase_executor.py
@@ -39,6 +39,7 @@ import types
 from typing import Any, Dict, Optional, Text, Tuple, Type, TYPE_CHECKING, Union
 
 import attr
+
 from openhtf import util
 from openhtf.core import phase_branches
 from openhtf.core import phase_descriptor

--- a/openhtf/core/phase_nodes.py
+++ b/openhtf/core/phase_nodes.py
@@ -15,13 +15,15 @@
 """Contains the abstract interfaces for phase nodes."""
 
 import abc
-from typing import Any, Callable, Dict, Optional, Text, Type, TypeVar, TYPE_CHECKING
+from typing import (Any, Callable, Dict, Optional, Text, Type, TYPE_CHECKING,
+                    TypeVar)
 
 from openhtf.core import base_plugs
 from openhtf.util import data
 
 if TYPE_CHECKING:
-  from openhtf.core import phase_descriptor  # pylint: disable=g-import-not-at-top
+  from openhtf.core import \
+      phase_descriptor  # pylint: disable=g-import-not-at-top
 
 WithModifierT = TypeVar('WithModifierT', bound='PhaseNode')
 ApplyAllNodesT = TypeVar('ApplyAllNodesT', bound='PhaseNode')

--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -45,7 +45,6 @@ from openhtf.core import phase_executor
 from openhtf.core import test_executor
 from openhtf.core import test_record as htf_test_record
 from openhtf.core import test_state
-
 from openhtf.util import configuration
 from openhtf.util import console_output
 from openhtf.util import logs

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -40,7 +40,8 @@ from openhtf.util import threads
 CONF = configuration.CONF
 
 if TYPE_CHECKING:
-  from openhtf.core import test_descriptor  # pylint: disable=g-import-not-at-top
+  from openhtf.core import \
+      test_descriptor  # pylint: disable=g-import-not-at-top
 
 _LOG = logging.getLogger(__name__)
 

--- a/openhtf/core/test_record.py
+++ b/openhtf/core/test_record.py
@@ -33,9 +33,10 @@ CONF = configuration.CONF
 if TYPE_CHECKING:
   from openhtf.core import diagnoses_lib  # pylint: disable=g-import-not-at-top
   from openhtf.core import measurements as htf_measurements  # pylint: disable=g-import-not-at-top
-  from openhtf.core import phase_descriptor  # pylint: disable=g-import-not-at-top
-  from openhtf.core import phase_executor  # pylint: disable=g-import-not-at-top
   from openhtf.core import phase_branches  # pylint: disable=g-import-not-at-top
+  from openhtf.core import \
+      phase_descriptor  # pylint: disable=g-import-not-at-top
+  from openhtf.core import phase_executor  # pylint: disable=g-import-not-at-top
 
 CONF.declare(
     'attachments_directory',

--- a/openhtf/core/test_state.py
+++ b/openhtf/core/test_state.py
@@ -32,9 +32,11 @@ import mimetypes
 import os
 import socket
 import sys
-from typing import Any, Dict, Iterator, List, Optional, Set, Text, TYPE_CHECKING, Union
+from typing import (Any, Dict, Iterator, List, Optional, Set, Text,
+                    TYPE_CHECKING, Union)
 
 import attr
+from typing_extensions import Literal
 
 import openhtf
 from openhtf import plugs
@@ -48,12 +50,12 @@ from openhtf.util import configuration
 from openhtf.util import data
 from openhtf.util import logs
 from openhtf.util import units
-from typing_extensions import Literal
 
 CONF = configuration.CONF
 
 if TYPE_CHECKING:
-  from openhtf.core import test_descriptor  # pylint: disable=g-import-not-at-top
+  from openhtf.core import \
+      test_descriptor  # pylint: disable=g-import-not-at-top
 
 CONF.declare(
     'allow_unset_measurements',

--- a/openhtf/output/servers/dashboard_server.py
+++ b/openhtf/output/servers/dashboard_server.py
@@ -12,14 +12,15 @@ import socket
 import threading
 import time
 
+import sockjs.tornado
+import tornado.web
+
 from openhtf.output.servers import pub_sub
 from openhtf.output.servers import station_server
 from openhtf.output.servers import web_gui_server
 from openhtf.output.web_gui import web_launcher
 from openhtf.util import data
 from openhtf.util import multicast
-import sockjs.tornado
-import tornado.web
 
 _LOG = logging.getLogger(__name__)
 

--- a/openhtf/output/servers/pub_sub.py
+++ b/openhtf/output/servers/pub_sub.py
@@ -67,8 +67,6 @@ class PubSub(sockjs.tornado.SockJSConnection):
 
   def on_subscribe(self, info):
     """Called when new clients subscribe. Subclasses can override."""
-    pass
 
   def on_unsubscribe(self):
     """Called when clients unsubscribe. Subclasses can override."""
-    pass

--- a/openhtf/output/servers/pub_sub.py
+++ b/openhtf/output/servers/pub_sub.py
@@ -15,8 +15,9 @@
 
 import logging
 
-from openhtf import util as htf_util
 import sockjs.tornado
+
+from openhtf import util as htf_util
 
 _LOG = logging.getLogger(__name__)
 

--- a/openhtf/output/servers/station_server.py
+++ b/openhtf/output/servers/station_server.py
@@ -17,6 +17,8 @@ import time
 import types
 from typing import Optional, Union
 
+import sockjs.tornado
+
 import openhtf
 from openhtf.output.servers import pub_sub
 from openhtf.output.servers import web_gui_server
@@ -25,7 +27,6 @@ from openhtf.util import data
 from openhtf.util import functions
 from openhtf.util import multicast
 from openhtf.util import timeouts
-import sockjs.tornado
 
 CONF = configuration.CONF
 

--- a/openhtf/plugs/__init__.py
+++ b/openhtf/plugs/__init__.py
@@ -21,7 +21,8 @@ is-ready check.
 """
 
 import logging
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Text, Tuple, Type, TypeVar, Union
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Set, Text,
+                    Tuple, Type, TypeVar, Union)
 
 import attr
 

--- a/openhtf/plugs/cambrionix/__init__.py
+++ b/openhtf/plugs/cambrionix/__init__.py
@@ -15,6 +15,7 @@
 
 import subprocess
 import time
+
 from openhtf.plugs.usb import local_usb
 
 

--- a/openhtf/plugs/generic/serial_collection.py
+++ b/openhtf/plugs/generic/serial_collection.py
@@ -28,6 +28,7 @@ CONF = configuration.CONF
 try:
   # pylint: disable=g-import-not-at-top
   import serial  # pytype: disable=import-error
+
   # pylint: enable=g-import-not-at-top
 except ImportError:
   logging.error(

--- a/openhtf/plugs/usb/fastboot_protocol.py
+++ b/openhtf/plugs/usb/fastboot_protocol.py
@@ -20,8 +20,9 @@ import logging
 import os
 import struct
 
-from . import usb_exceptions
 from openhtf.util import argv
+
+from . import usb_exceptions
 
 FASTBOOT_DOWNLOAD_CHUNK_SIZE_KB = 1024
 

--- a/openhtf/plugs/usb/local_usb.py
+++ b/openhtf/plugs/usb/local_usb.py
@@ -29,6 +29,7 @@ try:
   # pylint: disable=g-import-not-at-top
   import libusb1  # pytype: disable=import-error
   import usb1  # pytype: disable=import-error
+
   # pylint: enable=g-import-not-at-top
 except ImportError:
   logging.error('Failed to import libusb, did you pip install '

--- a/openhtf/plugs/usb/usb_exceptions.py
+++ b/openhtf/plugs/usb/usb_exceptions.py
@@ -18,6 +18,7 @@ import logging
 try:
   # pylint: disable=g-import-not-at-top
   import libusb1  # pytype: disable=import-error
+
   # pylint: enable=g-import-not-at-top
 except ImportError:
   logging.error('Failed to import libusb, did you pip install '

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, Optional, Text, Tuple, Union
 import uuid
 
 import attr
+
 import openhtf
 from openhtf import plugs
 from openhtf.core import base_plugs

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -18,7 +18,7 @@ import re
 import threading
 import time
 import typing
-from typing import Any, Callable, Dict, Iterator, Optional, Text, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Text, Tuple, TypeVar
 import weakref
 
 import attr

--- a/openhtf/util/configuration.py
+++ b/openhtf/util/configuration.py
@@ -145,10 +145,11 @@ import threading
 from typing import Any, Optional, Text, Type, TypeVar
 
 import attr
-from openhtf.util import argv
-from openhtf.util import threads
 from typing_extensions import Protocol
 import yaml
+
+from openhtf.util import argv
+from openhtf.util import threads
 
 T = TypeVar('T')
 

--- a/openhtf/util/data.py
+++ b/openhtf/util/data.py
@@ -21,8 +21,8 @@ from collections.abc import Iterable
 import copy
 import difflib
 import enum
-import itertools
 import inspect
+import itertools
 import logging
 import math
 import numbers

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -126,7 +126,8 @@ List of assertions that can be used with either PhaseRecords or TestRecords:
   assertMeasurementFail(phase_or_test_rec, measurement)
 """
 
-from collections.abc import Callable as CollectionsCallable, Iterator
+from collections.abc import Callable as CollectionsCallable
+from collections.abc import Iterator
 import functools
 import inspect
 import logging
@@ -137,23 +138,13 @@ import sys
 import tempfile
 import types
 import typing
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Text,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Sequence,
+                    Text, Tuple, Type, Union)
 import unittest
 from unittest import mock
 
 import attr
+
 from openhtf import plugs
 from openhtf import util
 from openhtf.core import base_plugs

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -126,7 +126,6 @@ List of assertions that can be used with either PhaseRecords or TestRecords:
   assertMeasurementFail(phase_or_test_rec, measurement)
 """
 
-import collections
 from collections.abc import Callable as CollectionsCallable, Iterator
 import functools
 import inspect

--- a/openhtf/util/text.py
+++ b/openhtf/util/text.py
@@ -36,6 +36,7 @@ import sys
 from typing import List, Optional
 
 import colorama
+
 import openhtf
 from openhtf.core import measurements
 from openhtf.core import phase_descriptor

--- a/openhtf/util/threads.py
+++ b/openhtf/util/threads.py
@@ -14,7 +14,6 @@
 """Thread library defining a few helpers."""
 
 import _thread
-import contextlib
 import cProfile
 import ctypes
 import functools

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -58,7 +58,7 @@ import abc
 import math
 import numbers
 import re
-from typing import Callable, Dict, Optional, Type, TypeVar, Union
+from typing import Callable, Dict, Optional, Union
 
 from openhtf import util
 

--- a/openhtf/util/xmlrpcutil.py
+++ b/openhtf/util/xmlrpcutil.py
@@ -16,7 +16,6 @@
 from collections.abc import Callable
 import http.client
 import socketserver
-import sys
 import threading
 import xmlrpc.client
 import xmlrpc.server

--- a/pylint_plugins/conf_plugin.py
+++ b/pylint_plugins/conf_plugin.py
@@ -14,7 +14,6 @@
 
 
 import astroid
-
 from astroid import MANAGER
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools>=40.8.0", "wheel>=0.29.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.autoflake]
+recursive = true
+check_diff = true
+exclude = "*_pb2.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,8 @@ build-backend = "setuptools.build_meta"
 recursive = true
 check_diff = true
 exclude = "*_pb2.py"
+
+[tool.isort]
+line_length = 80
+profile = "google"
+skip_glob = ["*_pb2.py"]

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 """Setup script for OpenHTF."""
 
+from distutils.cmd import Command
+# pylint: disable=g-importing-member,g-bad-import-order
+from distutils.command.build import build
+from distutils.command.clean import clean
 import errno
 import glob
 import os
@@ -20,10 +24,6 @@ import platform
 import subprocess
 import sys
 
-# pylint: disable=g-importing-member,g-bad-import-order
-from distutils.command.build import build
-from distutils.command.clean import clean
-from distutils.cmd import Command
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.test import test

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -35,7 +35,6 @@ from openhtf.core import test_descriptor
 from openhtf.core import test_executor
 from openhtf.core import test_record
 from openhtf.core import test_state
-
 from openhtf.util import configuration
 from openhtf.util import logs
 from openhtf.util import timeouts

--- a/test/core/measurements_test.py
+++ b/test/core/measurements_test.py
@@ -19,7 +19,6 @@ actually care about.
 """
 
 import collections
-import unittest
 from unittest import mock
 
 import openhtf as htf

--- a/test/core/measurements_test.py
+++ b/test/core/measurements_test.py
@@ -21,9 +21,9 @@ actually care about.
 import collections
 from unittest import mock
 
+from examples import all_the_things
 import openhtf as htf
 from openhtf.core import measurements
-from examples import all_the_things
 from openhtf.util import test as htf_test
 
 # Fields that are considered 'volatile' for record comparison.

--- a/test/core/phase_collections_test.py
+++ b/test/core/phase_collections_test.py
@@ -3,8 +3,8 @@
 import unittest
 from unittest import mock
 
-import openhtf as htf
 from openhtf import plugs
+import openhtf as htf
 from openhtf.core import base_plugs
 from openhtf.core import phase_collections
 from openhtf.core import phase_descriptor

--- a/test/core/phase_group_test.py
+++ b/test/core/phase_group_test.py
@@ -4,8 +4,8 @@ import threading
 import unittest
 from unittest import mock
 
-import openhtf as htf
 from openhtf import plugs
+import openhtf as htf
 from openhtf.core import base_plugs
 from openhtf.core import phase_collections
 from openhtf.core import test_record

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -21,10 +21,13 @@ actually care for.
 import io
 import json
 
-import openhtf as htf
-from openhtf import util
 from examples import all_the_things
-from openhtf.core import phase_branches, phase_descriptor, phase_collections, phase_group
+from openhtf import util
+import openhtf as htf
+from openhtf.core import phase_branches
+from openhtf.core import phase_collections
+from openhtf.core import phase_descriptor
+from openhtf.core import phase_group
 from openhtf.output.callbacks import console_summary
 from openhtf.output.callbacks import json_factory
 from openhtf.output.proto import mfg_event_converter

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -20,7 +20,6 @@ actually care for.
 
 import io
 import json
-import unittest
 
 import openhtf as htf
 from openhtf import util

--- a/test/output/callbacks/mfg_inspector_test.py
+++ b/test/output/callbacks/mfg_inspector_test.py
@@ -19,7 +19,6 @@ actually care for.
 """
 import collections
 import io
-import unittest
 from unittest import mock
 
 import openhtf as htf

--- a/test/output/callbacks/mfg_inspector_test.py
+++ b/test/output/callbacks/mfg_inspector_test.py
@@ -21,9 +21,9 @@ import collections
 import io
 from unittest import mock
 
-import openhtf as htf
-from openhtf import util
 from examples import all_the_things
+from openhtf import util
+import openhtf as htf
 from openhtf.output.callbacks import mfg_inspector
 from openhtf.output.proto import guzzle_pb2
 from openhtf.output.proto import test_runs_converter

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -30,7 +30,6 @@ from openhtf.util import test as htf_test
 
 def plain_func():
   """Plain Docstring."""
-  pass
 
 
 def normal_test_phase():

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -15,8 +15,8 @@
 import unittest
 
 from absl import logging
-
 import attr
+
 import openhtf
 from openhtf import plugs
 from openhtf.core import base_plugs

--- a/test/plugs/plugs_test.py
+++ b/test/plugs/plugs_test.py
@@ -14,7 +14,6 @@
 
 import threading
 import time
-import unittest
 
 from openhtf import plugs
 from openhtf.core import base_plugs

--- a/test/test_state_test.py
+++ b/test/test_state_test.py
@@ -16,7 +16,6 @@ import copy
 import logging
 import sys
 import tempfile
-import unittest
 from unittest import mock
 
 from absl.testing import parameterized
@@ -37,7 +36,6 @@ CONF = configuration.CONF
 @openhtf.PhaseOptions(name='test_phase')
 def test_phase():
   """Test docstring."""
-  pass
 
 
 PHASE_STATE_BASE_TYPE_INITIAL = {

--- a/test/test_state_test.py
+++ b/test/test_state_test.py
@@ -19,6 +19,7 @@ import tempfile
 from unittest import mock
 
 from absl.testing import parameterized
+
 import openhtf
 from openhtf.core import phase_collections
 from openhtf.core import phase_descriptor

--- a/test/util/data_test.py
+++ b/test/util/data_test.py
@@ -16,6 +16,7 @@ import collections
 import unittest
 
 import attr
+
 from openhtf.util import data
 
 

--- a/test/util/test_test.py
+++ b/test/util/test_test.py
@@ -22,7 +22,6 @@ import unittest
 from unittest import mock
 
 import openhtf
-
 from openhtf import plugs
 from openhtf.core import base_plugs
 from openhtf.util import test

--- a/test/util/text_test.py
+++ b/test/util/text_test.py
@@ -17,7 +17,6 @@ import io
 import sys
 import types
 import typing
-import unittest
 from unittest import mock
 
 from absl.testing import parameterized

--- a/test/util/text_test.py
+++ b/test/util/text_test.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 from absl.testing import parameterized
 import colorama
+
 import openhtf
 from openhtf.core import measurements
 from openhtf.core import phase_descriptor


### PR DESCRIPTION
[autoflake](https://github.com/PyCQA/autoflake) cleans up unused imports and useless pass statements.
[isort](https://github.com/PyCQA/isort) manages import sorting.

I configured the profiles that would have the smallest diff and seemed most reasonable.

The really interesting part (IMO) is the addition of these as a GitHub Actions CI job that should prevent non-conforming code from being added and hence keep a more consistent code style in the repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1049)
<!-- Reviewable:end -->
