### PR TITLE
Replace Issuestats, which is very dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The open-source hardware testing framework.
 
 [![Build Status](https://github.com/google/openhtf/actions/workflows/build_and_deploy.yml/badge.svg?branch=master)](https://github.com/google/openhtf/actions?branch=master)
 [![Coverage Status](https://coveralls.io/repos/google/openhtf/badge.svg?branch=master&service=github)](https://coveralls.io/github/google/openhtf?branch=master)
-
-[Issue Stats](http://issuestats.com/github/google/openhtf)
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/google/openhtf.svg)](http://isitmaintained.com/project/google/openhtf "Percentage of issues still open")
+[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/google/openhtf.svg)](http://isitmaintained.com/project/google/openhtf "Average time to resolve an issue")
 
 ## Overview
 OpenHTF is a Python library that provides a set of convenient abstractions


### PR DESCRIPTION
I lol'ed when I clicked that link in the readme

<img width=500 src=https://user-images.githubusercontent.com/11611719/195193193-7bb5bae7-4c70-45c1-a733-a57e4c3f601e.png />

Patched Readme looks like
![image](https://user-images.githubusercontent.com/11611719/195193441-e797ffe1-c5bd-4d04-b696-b04f36c9f285.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1054)
<!-- Reviewable:end -->
