### PR TITLE
Don't try to set Content-Type if no mimetype is available

### DIFF
--- a/openhtf/output/servers/station_server.py
+++ b/openhtf/output/servers/station_server.py
@@ -360,7 +360,8 @@ class AttachmentsHandler(BaseTestHandler):
       self.set_status(404)
       return
 
-    self.set_header('Content-Type', attachment.mimetype)
+    if attachment.mimetype:
+      self.set_header('Content-Type', attachment.mimetype)
     self.write(attachment.data)
 
 


### PR DESCRIPTION
This phase:
```py
def attach(test_api: htf.TestApi) -> None:
    test_api.attach("file.unknown", b"I'm data")
```
will work, but when you try to download an attachment that has an extension that https://github.com/google/openhtf/blob/c669a9cc64fd2c4e86cd3cc6431c08545156d483/openhtf/core/test_state.py#L669-L670 does not recognize, the mimetype is set to None (null in json). This makes Tornado fail on attachment download when it sets the Content-Type of the response:
```py
Traceback (most recent call last):
  File "path/to/tornado/web.py", line 1702, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "path/to/openhtf/output/servers/station_server.py", line 369, in get
    self.set_header('Content-Type', attachment.mimetype)
  File "path/to/tornado/web.py", line 374, in set_header
    self._headers[name] = self._convert_header_value(value)
  File "path/to/tornado/web.py", line 416, in _convert_header_value
    raise TypeError("Unsupported header value %r" % value)
TypeError: Unsupported header value None
```

The simple fix is to only send the `Content-Type` header when we actually know it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1069)
<!-- Reviewable:end -->
