### PR TITLE
Python3.10 compatibility

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -14,6 +14,7 @@
 """The main OpenHTF entry point."""
 
 import signal
+import sys
 import typing
 
 from openhtf import plugs
@@ -146,3 +147,7 @@ __version__ = get_version()
 
 # Register signal handler to stop all tests on SIGINT.
 Test.DEFAULT_SIGINT_HANDLER = signal.signal(signal.SIGINT, Test.handle_sig_int)
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)


### PR DESCRIPTION
When trying to run WebUI in Python3.10, I get an error `AttributeError: module 'collections' has no attribute 'MutableMapping'`. It happens because `collections.MutableMapping` got moved to `collections.abc.MutableMapping` in Python3.10. 

Ideally, I'd have to bump tornado package, but I haven't had any success doing so because of the new async policies, that tornado>=5 started following. I could not make async loop to run correctly and even if I did, I'd not be sure that something else has not broken, hence this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1093)
<!-- Reviewable:end -->
