### PR TITLE
Fix broken `plug` relative import in global `__init__.py`

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -16,7 +16,6 @@
 import signal
 import typing
 
-from openhtf import plugs
 from openhtf.core import phase_executor
 from openhtf.core import test_record
 import openhtf.core.base_plugs
@@ -29,6 +28,7 @@ import openhtf.core.phase_descriptor
 import openhtf.core.phase_group
 import openhtf.core.phase_nodes
 import openhtf.core.test_descriptor
+import openhtf.plugs
 import openhtf.util
 from openhtf.util import configuration
 from openhtf.util import console_output
@@ -86,6 +86,7 @@ __all__ = (  # Expliclty export certain API components.
     'conf',
 )
 
+plugs = openhtf.plugs
 plug = openhtf.plugs.plug
 BasePlug = openhtf.core.base_plugs.BasePlug
 

--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -86,7 +86,7 @@ __all__ = (  # Expliclty export certain API components.
     'conf',
 )
 
-plug = plugs.plug
+plug = openhtf.plugs.plug
 BasePlug = openhtf.core.base_plugs.BasePlug
 
 DiagnosesStore = openhtf.core.diagnoses_lib.DiagnosesStore


### PR DESCRIPTION
The imported `plug` module was broken, plugs did not work with multiple monitors as they should have been.

This was probably due to the black magic class->name->object shenanigans going on in the plug initialization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1099)
<!-- Reviewable:end -->
