### PR TITLE
Remove unused `six` import in monitor code

### DIFF
--- a/openhtf/core/monitors.py
+++ b/openhtf/core/monitors.py
@@ -55,7 +55,6 @@ from openhtf.core import phase_descriptor
 from openhtf.core import test_state as core_test_state
 from openhtf.util import threads
 from openhtf.util import units as uom
-import six
 
 
 class _MonitorThread(threads.KillableThread):


### PR DESCRIPTION
This removes the seemingly unused `six` import from `openhtf/core/monitors.py`.

Fixes #1111.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1112)
<!-- Reviewable:end -->
