### PR TITLE
Use coveralls github action instead of manual coveralls

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -48,6 +48,8 @@ jobs:
       run: tox
     - name: Publish to Coveralls with GitHub Action
       uses: coverallsapp/github-action@v2.2.3
+      with:
+        parallel: true
 
   web_ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -50,6 +50,7 @@ jobs:
       uses: coverallsapp/github-action@v2.2.3
       with:
         parallel: true
+        flag-name: python-${{ matrix.python-version }}
 
   web_ui:
     runs-on: ubuntu-latest
@@ -61,3 +62,13 @@ jobs:
       - uses: actions/setup-node@v3
       - run: npm install
       - run: npm run build
+
+  finish:
+    needs: build_and_test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -38,7 +38,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions
-        pip install coveralls
         wget https://github.com/protocolbuffers/protobuf/releases/download/v21.6/protoc-21.6-linux-x86_64.zip
         unzip protoc-21.6-linux-x86_64.zip
         sudo cp bin/protoc /usr/bin/protoc && sudo chmod 777 /usr/bin/protoc
@@ -47,10 +46,8 @@ jobs:
         sudo apt-get install -y libusb-1.0-0-dev libprotobuf-dev swig
     - name: Test with tox
       run: tox
-    - name: Publish to coveralls.io
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      run: coveralls --service=github
+    - name: Publish to Coveralls with GitHub Action
+      uses: coverallsapp/github-action@v2.2.3
 
   web_ui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Coveralls is failing on recent runs so lets migrate to the current latest way to use it.

Example failure: https://github.com/google/openhtf/actions/runs/7403069556/job/20142167751

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1131)
<!-- Reviewable:end -->
