### PR TITLE
Fix multicast binding on Windows.

### DIFF
--- a/openhtf/util/multicast.py
+++ b/openhtf/util/multicast.py
@@ -140,7 +140,10 @@ class MulticastListener(threading.Thread):
     else:
       self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR,
                             1)  # Allow multiple listeners to bind.
-    self._sock.bind((self.address, self.port))
+    if sys.platform == 'win32':
+      self._sock.bind(('', self.port))
+    else:
+      self._sock.bind((self.address, self.port))
 
     while self._live:
       try:


### PR DESCRIPTION
Windows does not appear to support binding to `239.1.1.1` instead it needs to be bound to the local ip.

This fixes https://github.com/google/openhtf/issues/971

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1134)
<!-- Reviewable:end -->
