### PR TITLE
Add brackets to ImageURL in user-input-plug.component.html

### DIFF
--- a/openhtf/output/web_gui/src/app/plugs/user-input-plug.component.html
+++ b/openhtf/output/web_gui/src/app/plugs/user-input-plug.component.html
@@ -27,7 +27,7 @@
 
     <div class="htf-layout-widget-body">
 
-      <img *ngIf="hasImage()" [src]="Image_URL" alt="user-input-image">
+      <img *ngIf="hasImage()" [src]="Image_URL()" alt="user-input-image">
 
       <div [innerHTML]="prompt"></div>
 


### PR DESCRIPTION
The paramenter `image_url` in `openhtf.plugs.user_input.UserInput.promt()` doesn't seem to have any effect. After adding these brackets, the given image shows up just fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1157)
<!-- Reviewable:end -->
