### PR TITLE
fix typo in event_sequence.md

### DIFF
--- a/docs/event_sequence.md
+++ b/docs/event_sequence.md
@@ -123,7 +123,7 @@ When you hit Ctrl-C to the process the following occurs:
   `PhaseGroup` main phase, the phase's thread is attempted to be killed. No
   other phases of these kinds are run.
 * `PhaseGroup` teardown phases are still run unless a second Ctrl-C is sent.
-* We then follow the same steps as in [Test error shirt-circuiting](
-    #test-error-shirt-circuiting)
+* We then follow the same steps as in [Test error short-circuiting](
+    #test-error-short-circuiting)
 * All plugs are deleted.
 * Test outcome is ABORTED for output callbacks.


### PR DESCRIPTION
Fix typo in link

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1168)
<!-- Reviewable:end -->
