### PR TITLE
pyproject: Package web gui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,16 @@ dependencies = [
 ]
 license = {file = "LICENSE"}
 
+[tool.setuptools.package-data]
+"openhtf" = [
+    "output/proto/*.proto",
+    "output/web_gui/dist/*.*",
+    "output/web_gui/dist/css/*",
+    "output/web_gui/dist/js/*",
+    "output/web_gui/dist/img/*",
+    "output/web_gui/*.*",
+]
+
 [project.optional-dependencies]
 usb_plugs = [
     "libusb1>=3.1.0",


### PR DESCRIPTION
https://github.com/google/openhtf/commit/16b0c052daca07a26e1956ff77f2d4d731a67650 modernized the build system. This introduced an issue where the web gui Angular application isn't packaged.

This is rectified by adding it to the package data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1192)
<!-- Reviewable:end -->
