### PR TITLE
Update profiling to work with python3.12

### DIFF
--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -329,7 +329,7 @@ class Test(object):
           self.make_uid(),
           trigger,
           self._test_options,
-          run_with_profiling=profile_filename is not None)
+          run_phases_with_profiling=profile_filename is not None)
 
       _LOG.info('Executing test: %s', self.descriptor.code_info.name)
       self.TEST_INSTANCES[self.uid] = self

--- a/openhtf/core/test_executor.py
+++ b/openhtf/core/test_executor.py
@@ -96,11 +96,10 @@ class TestExecutor(threads.KillableThread):
                execution_uid: Text,
                test_start: Optional[phase_descriptor.PhaseDescriptor],
                test_options: 'test_descriptor.TestOptions',
-               run_with_profiling: bool):
-    super(TestExecutor, self).__init__(
-        name='TestExecutorThread', run_with_profiling=run_with_profiling)
+               run_phases_with_profiling: bool):
+    super(TestExecutor, self).__init__(name='TestExecutorThread')
     self.test_state = None  # type: Optional[test_state.TestState]
-
+    self._run_phases_with_profiling = run_phases_with_profiling
     self._test_descriptor = test_descriptor
     self._test_start = test_start
     self._test_options = test_options
@@ -276,7 +275,7 @@ class TestExecutor(threads.KillableThread):
       return True
 
     outcome, profile_stats = self.phase_executor.execute_phase(
-        self._test_start, self._run_with_profiling
+        self._test_start, self._run_phases_with_profiling
     )
 
     if profile_stats is not None:
@@ -339,7 +338,7 @@ class TestExecutor(threads.KillableThread):
 
     outcome, profile_stats = self.phase_executor.execute_phase(
         phase,
-        run_with_profiling=self._run_with_profiling,
+        run_with_profiling=self._run_phases_with_profiling,
         subtest_rec=subtest_rec,
     )
     if profile_stats is not None:

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -439,7 +439,7 @@ class PhaseOrTestIterator(Iterator):
     if profile_filepath is None:
       profile_tempfile = None
     else:
-      profile_tempfile = tempfile.NamedTemporaryFile()
+      profile_tempfile = tempfile.NamedTemporaryFile(delete=False)
     # Mock the PlugManager to use ours instead, and execute the test.
     with mock.patch.object(
         plugs, 'PlugManager', new=lambda _, __: self.plug_manager):

--- a/test/core/exe_test.py
+++ b/test/core/exe_test.py
@@ -258,7 +258,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
 
     executor.start()
     executor.wait()
@@ -273,7 +273,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     executor.start()
     executor.wait()
     record = executor.running_test_state.test_record
@@ -331,7 +331,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         cancel_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
 
     executor.start()
     executor.wait()
@@ -366,7 +366,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
 
     executor.start()
     executor.wait()
@@ -408,7 +408,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
 
     executor.start()
     executor.wait()
@@ -459,7 +459,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
 
     executor.start()
     executor.wait()
@@ -488,7 +488,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         None,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     executor.start()
     executor.wait()
     record = executor.running_test_state.test_record
@@ -522,7 +522,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         fail_plug_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     executor.start()
     executor.wait()
     record = executor.running_test_state.test_record
@@ -544,7 +544,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     executor.start()
     executor.wait()
     record = executor.running_test_state.test_record
@@ -568,7 +568,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     executor.start()
     executor.wait()
     record = executor.running_test_state.test_record
@@ -596,7 +596,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
 
     executor.start()
     executor.wait()
@@ -628,7 +628,7 @@ class TestExecutorTest(unittest.TestCase):
         'uid',
         start_phase,
         test._test_options,
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
 
     executor.start()
     executor.wait()
@@ -665,7 +665,7 @@ class TestExecutorExecutePhaseTest(unittest.TestCase):
         td.uid,
         None,
         test_descriptor.TestOptions(),
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     self.test_exec.test_state = self.test_state
     self.test_exec._phase_exec = self.phase_exec
 
@@ -742,7 +742,7 @@ class TestExecutorExecuteSequencesTest(unittest.TestCase):
         td.uid,
         None,
         test_descriptor.TestOptions(),
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     self.test_exec.test_state = self.test_state
     patcher = mock.patch.object(self.test_exec, '_execute_node')
     self.mock_execute_node = patcher.start()
@@ -897,7 +897,7 @@ class TestExecutorExecutePhaseGroupTest(unittest.TestCase):
         td.uid,
         None,
         test_descriptor.TestOptions(),
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     self.test_exec.test_state = self.test_state
     patcher = mock.patch.object(self.test_exec, '_execute_sequence')
     self.mock_execute_sequence = patcher.start()
@@ -1086,7 +1086,7 @@ class TestExecutorExecuteBranchTest(parameterized.TestCase):
         td.uid,
         None,
         test_descriptor.TestOptions(),
-        run_with_profiling=False)
+        run_phases_with_profiling=False)
     self.test_exec.test_state = self.test_state
     patcher = mock.patch.object(self.test_exec, '_execute_sequence')
     self.mock_execute_sequence = patcher.start()


### PR DESCRIPTION
We are affected by two changes in Python 3.12:

1. Tempfiles have a new argument, [`delete_on_close`](https://docs.python.org/3/whatsnew/3.12.html#tempfile), which defaults to `True`. As fix, we set the existing `delete` argument to `False` which makes the new argument a no-op.
2. Nested profiling now raises. This behavior change isn't captured in the release notes and caused various bug reports in Python, [for example](https://github.com/python/cpython/issues/110770). Previously we were enabling profiling in the Test Executor thread, but we didn't actually use that profile. This patch stops enabling profiling in that thread, since we only care about profiling of the actual phases.

Tested by running one of the example tests with profiling and checking the generated file using `pstats`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1194)
<!-- Reviewable:end -->
