### PR TITLE
Add Python 3.12 and 3.13 to tox (local run) environments.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311
+env_list = py39,py310,py311,py312,py313
 
 [gh-actions]
 python =


### PR DESCRIPTION
This only affects tox runs from the command line; the GitHub actions are already up to date.

Tested on my dev machine where I have python3.11 and python3.12 available, tox ran both (skipping the others as they are not installed on my machine).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1196)
<!-- Reviewable:end -->
