### PR TITLE
Remove unused imports using autoflake

### DIFF
--- a/openhtf/__init__.py
+++ b/openhtf/__init__.py
@@ -15,7 +15,6 @@
 
 import importlib.metadata
 import signal
-import typing
 
 from openhtf.core import phase_executor
 from openhtf.core import test_record

--- a/openhtf/core/base_plugs.py
+++ b/openhtf/core/base_plugs.py
@@ -128,17 +128,17 @@ class BasePlug(object):
       via TestApi.
   """
   # Override this to True in subclasses to support remote Plug access.
-  enable_remote = False  # type: bool
+  enable_remote: bool = False
   # Allow explicitly disabling remote access to specific attributes.
-  disable_remote_attrs = set()  # type: Set[Text]
+  disable_remote_attrs = set()
   # Override this to True in subclasses to support using with_plugs with this
   # plug without needing to use placeholder.  This will only affect the classes
   # that explicitly define this; subclasses do not share the declaration.
-  auto_placeholder = False  # type: bool
+  auto_placeholder: bool = False
   # Default logger to be used only in __init__ of subclasses.
   # This is overwritten both on the class and the instance so don't store
   # a copy of it anywhere.
-  logger = _LOG  # type: logging.Logger
+  logger: logging.Logger = _LOG
 
   @util.classproperty
   def placeholder(cls) -> 'PlugPlaceholder':  # pylint: disable=no-self-argument
@@ -185,7 +185,7 @@ class FrontendAwareBasePlug(BasePlug, util.SubscribableStateMixin):
   Since the Station API runs in a separate thread, the _asdict() method of
   frontend-aware plugs should be written with thread safety in mind.
   """
-  enable_remote = True  # type: bool
+  enable_remote: bool = True
 
 
 @attr.s(slots=True, frozen=True)

--- a/openhtf/core/base_plugs.py
+++ b/openhtf/core/base_plugs.py
@@ -94,7 +94,7 @@ framework won't pass any, so you'll get a TypeError.
 """
 
 import logging
-from typing import Any, Dict, Set, Text, Type, Union
+from typing import Any, Dict, Text, Type, Union
 
 import attr
 

--- a/openhtf/core/diagnoses_lib.py
+++ b/openhtf/core/diagnoses_lib.py
@@ -324,7 +324,6 @@ class _BaseDiagnoser(object):
 
   def _check_definition(self) -> None:
     """Internal function to verify that the diagnoser is completely defined."""
-    pass
 
 
 class BasePhaseDiagnoser(_BaseDiagnoser, abc.ABC):

--- a/openhtf/core/measurements.py
+++ b/openhtf/core/measurements.py
@@ -63,7 +63,6 @@ import copy
 import enum
 import functools
 import logging
-import time
 import typing
 from typing import Any, Callable, Dict, Iterator, List, Optional, Text, Tuple, Union
 

--- a/openhtf/core/phase_collections.py
+++ b/openhtf/core/phase_collections.py
@@ -221,16 +221,18 @@ def check_for_duplicate_subtest_names(sequence: PhaseSequence):
   Raises:
     DuplicateSubtestNamesError: when duplicate subtest names are found.
   """
-  names_to_subtests = collections.defaultdict(
-      list)  # type: DefaultDict[Text, List[Subtest]]
+  names_to_subtests: collections.defaultdict[str, list[Subtest]] = (
+      collections.defaultdict(list)
+  )
   for subtest in sequence.filter_by_type(Subtest):
     names_to_subtests[subtest.name].append(subtest)
 
-  duplicates = []  # type: List[Text]
+  duplicates: list[str] = []
   for name, subtests in names_to_subtests.items():
     if len(subtests) > 1:
-      duplicates.append('Name "{}" used by multiple subtests: {}'.format(
-          name, subtests))
+      duplicates.append(
+          'Name "{}" used by multiple subtests: {}'.format(name, subtests)
+      )
   if not duplicates:
     return
   duplicates.sort()

--- a/openhtf/core/phase_collections.py
+++ b/openhtf/core/phase_collections.py
@@ -23,7 +23,7 @@ skipped.
 import abc
 import collections
 from collections.abc import Iterable as CollectionsIterable
-from typing import Any, Callable, DefaultDict, Dict, Iterable, Iterator, List, Optional, Text, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Text, Tuple, Type, TypeVar, Union
 
 import attr
 from openhtf import util

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -25,7 +25,7 @@ import pickle
 import shutil
 import tempfile
 import typing
-from typing import BinaryIO, Callable, Iterator, Optional, Text, Union
+from typing import BinaryIO, Callable, Iterator, Text, Union
 
 from openhtf import util
 from openhtf.core import test_record

--- a/openhtf/output/callbacks/__init__.py
+++ b/openhtf/output/callbacks/__init__.py
@@ -25,7 +25,7 @@ import pickle
 import shutil
 import tempfile
 import typing
-from typing import BinaryIO, Callable, Iterator, Text, Union
+from typing import BinaryIO, Callable, Iterator, Optional, Text, Union
 
 from openhtf import util
 from openhtf.core import test_record
@@ -80,8 +80,8 @@ class OutputToFile(object):
 
   def __init__(self, filename_pattern_or_file: Union[Text, Callable[..., Text],
                                                      BinaryIO]):
-    self.filename_pattern = None  # type: Optional[Union[Text, Callable[..., Text]]]
-    self.output_file = None  # type: Optional[BinaryIO]
+    self.filename_pattern: Optional[Union[Text, Callable[..., Text]]] = None
+    self.output_file: Optional[BinaryIO] = None
     if (isinstance(filename_pattern_or_file, str) or
         callable(filename_pattern_or_file)):
       self.filename_pattern = filename_pattern_or_file  # pytype: disable=annotation-type-mismatch

--- a/openhtf/output/servers/pub_sub.py
+++ b/openhtf/output/servers/pub_sub.py
@@ -67,8 +67,6 @@ class PubSub(sockjs.tornado.SockJSConnection):
 
   def on_subscribe(self, info):
     """Called when new clients subscribe. Subclasses can override."""
-    pass
 
   def on_unsubscribe(self):
     """Called when clients unsubscribe. Subclasses can override."""
-    pass

--- a/openhtf/plugs/generic/serial_collection.py
+++ b/openhtf/plugs/generic/serial_collection.py
@@ -18,7 +18,6 @@ Allows for writing out to a serial port.
 
 import logging
 import threading
-from typing import Optional
 
 from openhtf.core import base_plugs
 from openhtf.util import configuration

--- a/openhtf/plugs/generic/serial_collection.py
+++ b/openhtf/plugs/generic/serial_collection.py
@@ -18,6 +18,7 @@ Allows for writing out to a serial port.
 
 import logging
 import threading
+from typing import Optional
 
 from openhtf.core import base_plugs
 from openhtf.util import configuration
@@ -57,10 +58,10 @@ class SerialCollectionPlug(base_plugs.BasePlug):
   # Serial library can raise these exceptions
   SERIAL_EXCEPTIONS = (serial.SerialException, ValueError)
 
-  _serial = None  # type: serial.Serial
-  _serial_port = None  # type: int
-  _collect = None  # type: bool
-  _collection_thread = None  # type: Optional[threading.Thread]
+  _serial: Optional[serial.Serial] = None
+  _serial_port: Optional[int] = None
+  _collect: Optional[bool] = None
+  _collection_thread: Optional[threading.Thread] = None
 
   @CONF.inject_positional_args
   def __init__(self, serial_collection_port, serial_collection_baud):

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -142,10 +142,10 @@ class UserInput(base_plugs.FrontendAwareBasePlug):
 
   def __init__(self):
     super(UserInput, self).__init__()
-    self.last_response = None  # type: Optional[Tuple[Text, Text]]
-    self._prompt = None  # type: Optional[Prompt]
-    self._console_prompt = None  # type: Optional[ConsolePrompt]
-    self._response = None  # type: Optional[Text]
+    self.last_response: Optional[tuple[str, str]] = None
+    self._prompt: Optional[Prompt] = None
+    self._console_prompt: Optional[ConsolePrompt] = None
+    self._response: Optional[Text] = None
     self._cond = threading.Condition(threading.RLock())
 
   def _asdict(self) -> Optional[Dict[Text, Any]]:

--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -24,7 +24,7 @@ import platform
 import select
 import sys
 import threading
-from typing import Any, Callable, Dict, Optional, Text, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Text, Union
 import uuid
 
 import attr

--- a/openhtf/util/__init__.py
+++ b/openhtf/util/__init__.py
@@ -18,7 +18,7 @@ import re
 import threading
 import time
 import typing
-from typing import Any, Callable, Dict, Iterator, Optional, Text, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Text, Tuple, TypeVar
 import weakref
 
 import attr

--- a/openhtf/util/logs.py
+++ b/openhtf/util/logs.py
@@ -110,7 +110,6 @@ import textwrap
 from openhtf.util import argv
 from openhtf.util import console_output
 from openhtf.util import functions
-from openhtf.util import threads
 
 # The number of v's provided as command line arguments to control verbosity.
 # Will be overridden if the ARG_PARSER below parses the -v argument.

--- a/openhtf/util/test.py
+++ b/openhtf/util/test.py
@@ -126,7 +126,6 @@ List of assertions that can be used with either PhaseRecords or TestRecords:
   assertMeasurementFail(phase_or_test_rec, measurement)
 """
 
-import collections
 from collections.abc import Callable as CollectionsCallable, Iterator
 import functools
 import inspect

--- a/openhtf/util/threads.py
+++ b/openhtf/util/threads.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Thread library defining a few helpers."""
 
-import _thread
-import contextlib
 import cProfile
 import ctypes
 import functools

--- a/openhtf/util/validators.py
+++ b/openhtf/util/validators.py
@@ -71,7 +71,7 @@ import abc
 import math
 import numbers
 import re
-from typing import Callable, Dict, Optional, Type, TypeVar, Union
+from typing import Callable, Dict, Optional, Union
 
 from openhtf import util
 

--- a/openhtf/util/xmlrpcutil.py
+++ b/openhtf/util/xmlrpcutil.py
@@ -16,7 +16,6 @@
 from collections.abc import Callable
 import http.client
 import socketserver
-import sys
 import threading
 import xmlrpc.client
 import xmlrpc.server

--- a/test/core/measurements_test.py
+++ b/test/core/measurements_test.py
@@ -19,7 +19,6 @@ actually care about.
 """
 
 import collections
-import unittest
 from unittest import mock
 
 import openhtf as htf

--- a/test/output/callbacks/callbacks_test.py
+++ b/test/output/callbacks/callbacks_test.py
@@ -20,7 +20,6 @@ actually care for.
 
 import io
 import json
-import unittest
 
 import openhtf as htf
 from openhtf import util

--- a/test/output/callbacks/mfg_inspector_test.py
+++ b/test/output/callbacks/mfg_inspector_test.py
@@ -19,7 +19,6 @@ actually care for.
 """
 import collections
 import io
-import unittest
 from unittest import mock
 
 import openhtf as htf

--- a/test/phase_descriptor_test.py
+++ b/test/phase_descriptor_test.py
@@ -30,7 +30,6 @@ from openhtf.util import test as htf_test
 
 def plain_func():
   """Plain Docstring."""
-  pass
 
 
 def normal_test_phase():

--- a/test/plugs/plugs_test.py
+++ b/test/plugs/plugs_test.py
@@ -14,7 +14,6 @@
 
 import threading
 import time
-import unittest
 
 from openhtf import plugs
 from openhtf.core import base_plugs

--- a/test/test_state_test.py
+++ b/test/test_state_test.py
@@ -16,7 +16,6 @@ import copy
 import logging
 import sys
 import tempfile
-import unittest
 from unittest import mock
 
 from absl.testing import parameterized
@@ -37,7 +36,6 @@ CONF = configuration.CONF
 @openhtf.PhaseOptions(name='test_phase')
 def test_phase():
   """Test docstring."""
-  pass
 
 
 PHASE_STATE_BASE_TYPE_INITIAL = {

--- a/test/util/text_test.py
+++ b/test/util/text_test.py
@@ -17,7 +17,6 @@ import io
 import sys
 import types
 import typing
-import unittest
 from unittest import mock
 
 from absl.testing import parameterized


### PR DESCRIPTION
Autoflake command `autoflake --in-place --recursive --remove-all-unused-imports .`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1198)
<!-- Reviewable:end -->
