### PR TITLE
Use default access token to avoid rate limiting

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,6 +40,8 @@ jobs:
         sudo apt-get install -y libusb-1.0-0-dev libprotobuf-dev swig libevent-dev
     - name: Setup protoc
       uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Create OpenHTF package
       run: |
         python -m build


### PR DESCRIPTION
Taken from usage notes at https://github.com/arduino/setup-protoc: https://github.com/arduino/setup-protoc/blob/3ea1d70ac22caff0b66ed6cb37d5b7aadebd4623/README.md

Fixes issues like: https://github.com/google/openhtf/actions/runs/13686172353/job/38269973965#step:5:13

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1218)
<!-- Reviewable:end -->
