### PR TITLE
Resolve warnings for threading methods

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -277,7 +277,7 @@ class UserInput(base_plugs.FrontendAwareBasePlug):
       self._response = response
       self.last_response = (prompt_id, response)
       self.remove_prompt()
-      self._cond.notifyAll()
+      self._cond.notify_all()
 
 
 def prompt_for_test_start(


### PR DESCRIPTION
# PR Summary
Small PR - resolves the deprecation warnings coming from `threading` package which you can find in the [CI logs](https://github.com/google/openhtf/actions/runs/14541531483/job/40800328564#step:7:350):
```python
  test/plugs/user_input_test.py::PlugsTest::test_respond_to_non_blocking_prompt
    /home/runner/work/openhtf/openhtf/openhtf/plugs/user_input.py:280: DeprecationWarning: notifyAll() is deprecated, use notify_all() instead
      self._cond.notifyAll()
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/openhtf/1225)
<!-- Reviewable:end -->
