### PR TITLE
Remove legacy pylint settings and migrate bad-functions configuration

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 init-hook='import sys; sys.path.append("./")'
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
@@ -20,7 +17,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=pylint_plugins.conf_plugin,pylint_plugins.mutablerecords_plugin
+load-plugins=pylint_plugins.conf_plugin,pylint.extensions.bad_builtin
 
 [MESSAGES CONTROL]
 
@@ -52,11 +49,6 @@ disable=import-error,I0011,too-few-public-methods
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=yes
 
@@ -66,10 +58,6 @@ reports=yes
 # number of statements analyzed. This is used by the global evaluation report
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
@@ -98,12 +86,6 @@ ignore-imports=no
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input
 
 # Regular expression which should only match correct module names
 module-rgx=[a-z_][a-z_][a-z0-9][a-z0-9_]{1,30}$
@@ -165,9 +147,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # else.
 single-line-if-stmt=no
 
-# List of optional constructs for which whitespace checking is disabled
-no-space-check=trailing-comma,dict-separator
-
 # Maximum number of lines in a module
 max-module-lines=1000
 
@@ -186,10 +165,6 @@ ignore-mixin-members=yes
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
-
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
@@ -212,6 +187,9 @@ additional-builtins=
 
 
 [DESIGN]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input
 
 # Maximum number of arguments for function / method
 max-args=5
@@ -265,10 +243,6 @@ int-import-graph=
 
 [CLASSES]
 
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
-
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp
 
@@ -283,4 +257,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
### Description

According to `CONTRIBUTING.md`, new contributions must pass pylint checks.  
The `.pylintrc` file, however, has not been updated in about eight years and still contains  
options that are no longer supported or used in recent pylint releases.

This PR refreshes the pylint configuration to align with current pylint behavior  
and remove legacy settings that no longer have any effect.

---

### Changes
- Removed deprecated or unsupported options:
  - `profile`, `files-output`, `comment`, `required-attributes`,  
    `no-space-check`, `zope`, and `ignore-iface-methods`.
- Removed reference to `pylint_plugins.mutablerecords_plugin`, which was deleted in commit **#960**.
- Migrated `bad-functions` handling to the `pylint.extensions.bad_builtin` plugin.
- Updated `overgeneral-exceptions` to use fully-qualified `builtins.Exception`.