### PR TITLE
Use the max timeout for unlimited timeout

### DIFF
--- a/openhtf/plugs/user_input.py
+++ b/openhtf/plugs/user_input.py
@@ -253,7 +253,7 @@ class UserInput(base_plugs.FrontendAwareBasePlug):
     with self._cond:
       if self._prompt:
         if timeout_s is None:
-          self._cond.wait(3600 * 24 * 365)
+          self._cond.wait(threading.TIMEOUT_MAX)
         else:
           self._cond.wait(timeout_s)
       if self._response is None:


### PR DESCRIPTION
On Windows, `threading.TIMEOUT_MAX` is around 24 days (signed 32-bit int of milliseconds), while on Linux it's around 292 years (signed 64-bit int of nanoseconds).

This also fixes https://github.com/google/openhtf/issues/884 and the discord post https://discord.com/channels/1077920440569299074/1418256119658184795