### PR TITLE
security: fix path traversal in StaticFileHandler

### DIFF
--- a/openhtf/output/servers/web_gui_server.py
+++ b/openhtf/output/servers/web_gui_server.py
@@ -95,9 +95,14 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
 
   @classmethod
   def get_absolute_path(cls, root, path):
-    return os.path.join(root, path)
+    return os.path.abspath(os.path.join(root, path))
 
   def validate_absolute_path(self, root, abspath):
+    root = os.path.abspath(root)
+    if not abspath.startswith(root + os.sep) and abspath != root:
+      raise tornado.web.HTTPError(403)
+    if not os.path.isfile(abspath):
+      raise tornado.web.HTTPError(404)
     return abspath
 
 


### PR DESCRIPTION
## Summary

The custom `StaticFileHandler` in `openhtf/output/servers/web_gui_server.py` overrides Tornado's `validate_absolute_path()` to return the path without any validation, completely removing the built-in path traversal protection.

This allows requests such as `GET /img/../../../../etc/passwd` to read arbitrary files on the host filesystem.

## Fix

- Use `os.path.abspath()` in `get_absolute_path()` to resolve `../` sequences
- Check the resolved path starts with the static root directory in `validate_absolute_path()`
- Return 403 if the path escapes the root, 404 if the file doesn't exist

## Reproduction

```bash
# With the current code, the following returns /etc/passwd contents:
curl --path-as-is "http://HOST:PORT/img/../../../../../../../../etc/passwd"

# Tornado's default StaticFileHandler correctly returns 403
```