### PR TITLE
Fix error when capture_source is enabled and test_start is None

### DIFF
--- a/openhtf/core/test_descriptor.py
+++ b/openhtf/core/test_descriptor.py
@@ -323,7 +323,7 @@ class Test(object):
       else:
         trigger = test_start
 
-      if CONF.capture_source:
+      if CONF.capture_source and trigger:
         trigger.code_info = htf_test_record.CodeInfo.for_function(trigger.func)
 
       self._executor = test_executor.TestExecutor(


### PR DESCRIPTION
What does this PR do?
This PR fixes an AttributeError that occurs when the capture_source configuration is enabled but no test_start trigger is provided.

Why is this change needed?
In openhtf/core/test_descriptor.py, if test_start is passed as None, the trigger variable also evaluates to None. When CONF.capture_source is enabled, the code previously attempted to unconditionally access trigger.func, resulting in an error because it tried to get the func attribute on a None value.

How does this PR fix the problem?
I added a simple safety check (if CONF.capture_source and trigger:) so that it only attempts to capture the source code info if a valid trigger function actually exists.

Fixes #1279