### PR TITLE
Add SKIPPED for measurements and test run status

### DIFF
--- a/openhtf/output/proto/test_runs.proto
+++ b/openhtf/output/proto/test_runs.proto
@@ -76,6 +76,7 @@ enum Status {
   SCRAP = 13;
   DEBUG = 14;
   MARGINAL_PASS = 15;
+  SKIPPED = 16;
 }
 
 


### PR DESCRIPTION
Adds `SKIPPED = 16` to `enum Status` in `test_runs.proto`.
This enum value supports flagging measurements in skipped phases as `SKIPPED` in OpenHTF and MfgEvent outputs without mapping them to `ERROR`.